### PR TITLE
feat: error boundaries and empty state polish

### DIFF
--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -232,10 +232,14 @@ function App() {
                     Error loading todos: {todosError.message}
                   </p>
                 )}
-                {todosData?.myTodos.length === 0 && (
-                  <p className="text-muted-foreground">
-                    No todos yet. Create your first one!
-                  </p>
+                {!todosLoading && todosData?.myTodos.length === 0 && (
+                  <div className="flex flex-col items-center gap-3 py-8 text-center">
+                    <p className="text-muted-foreground">No todos yet.</p>
+                    <Button size="sm" onClick={openCreateTodo}>
+                      <Plus className="mr-2 h-4 w-4" />
+                      Create your first todo
+                    </Button>
+                  </div>
                 )}
                 <div className="space-y-2">
                   {todosData?.myTodos.map((todo) => {
@@ -314,10 +318,14 @@ function App() {
                     Error loading habits: {habitsError.message}
                   </p>
                 )}
-                {habitsData?.myHabits.length === 0 && (
-                  <p className="text-muted-foreground">
-                    No habits yet. Create your first one!
-                  </p>
+                {!habitsLoading && habitsData?.myHabits.length === 0 && (
+                  <div className="flex flex-col items-center gap-3 py-8 text-center">
+                    <p className="text-muted-foreground">No habits yet.</p>
+                    <Button size="sm" onClick={() => setHabitFormOpen(true)}>
+                      <Plus className="mr-2 h-4 w-4" />
+                      Create your first habit
+                    </Button>
+                  </div>
                 )}
                 <div className="space-y-2">
                   {habitsData?.myHabits.map((habit) => {
@@ -385,11 +393,21 @@ function App() {
                     Error loading time blocks: {timeBlocksError.message}
                   </p>
                 )}
-                {timeBlocksData?.myTimeBlocks.length === 0 && (
-                  <p className="text-muted-foreground">
-                    No time blocks yet. Create your first one!
-                  </p>
-                )}
+                {!timeBlocksLoading &&
+                  timeBlocksData?.myTimeBlocks.length === 0 && (
+                    <div className="flex flex-col items-center gap-3 py-8 text-center">
+                      <p className="text-muted-foreground">
+                        No time blocks yet.
+                      </p>
+                      <Button
+                        size="sm"
+                        onClick={() => setTimeBlockFormOpen(true)}
+                      >
+                        <Plus className="mr-2 h-4 w-4" />
+                        Create your first time block
+                      </Button>
+                    </div>
+                  )}
                 <div className="space-y-2">
                   {timeBlocksData?.myTimeBlocks.map((block) => {
                     const actType = block.activityTypeId

--- a/packages/client/src/components/ErrorBoundary.tsx
+++ b/packages/client/src/components/ErrorBoundary.tsx
@@ -1,0 +1,61 @@
+import { Button } from '@/components/ui/button';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { Component } from 'react';
+import type { ReactNode } from 'react';
+
+interface Props {
+  children: ReactNode;
+}
+
+interface State {
+  error: Error | null;
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { error: null };
+  }
+
+  static getDerivedStateFromError(error: Error): State {
+    return { error };
+  }
+
+  componentDidCatch(error: Error) {
+    console.error('[ErrorBoundary] Uncaught error:', error);
+  }
+
+  render() {
+    const { error } = this.state;
+    if (error) {
+      return (
+        <div className="flex min-h-screen items-center justify-center bg-gray-50 p-4">
+          <Card className="w-full max-w-md">
+            <CardHeader>
+              <CardTitle>Something went wrong</CardTitle>
+              <CardDescription>
+                An unexpected error occurred. You can try reloading the page.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <code className="block rounded-md bg-muted px-3 py-2 text-sm text-muted-foreground break-all">
+                {error.message}
+              </code>
+              <Button onClick={() => window.location.reload()}>
+                Try again
+              </Button>
+            </CardContent>
+          </Card>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/packages/client/src/main.tsx
+++ b/packages/client/src/main.tsx
@@ -1,17 +1,44 @@
-import { ApolloClient, ApolloProvider, InMemoryCache } from '@apollo/client';
+import {
+  ApolloClient,
+  ApolloProvider,
+  HttpLink,
+  InMemoryCache,
+  from,
+} from '@apollo/client';
+import { onError } from '@apollo/client/link/error';
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
+import { ErrorBoundary } from './components/ErrorBoundary';
 import './index.css';
 
-const client = new ApolloClient({
+const errorLink = onError(({ graphQLErrors, networkError, operation }) => {
+  if (graphQLErrors) {
+    for (const err of graphQLErrors) {
+      console.error(
+        `[GraphQL error] Operation: ${operation.operationName} | Message: ${err.message} | Path: ${err.path?.join('.')}`,
+      );
+    }
+  }
+  if (networkError) {
+    console.error(
+      `[Network error] Operation: ${operation.operationName} | ${networkError.message}`,
+    );
+  }
+});
+
+const httpLink = new HttpLink({
   uri: '/graphql',
-  cache: new InMemoryCache(),
-  // For demo purposes, we'll add a fixed user ID
-  // In production, this would come from authentication
   headers: {
+    // For demo purposes, we'll add a fixed user ID
+    // In production, this would come from authentication
     authorization: 'Bearer 00000000-0000-0000-0000-000000000001',
   },
+});
+
+const client = new ApolloClient({
+  link: from([errorLink, httpLink]),
+  cache: new InMemoryCache(),
 });
 
 const rootElement = document.getElementById('root');
@@ -19,8 +46,10 @@ if (!rootElement) throw new Error('Root element not found');
 
 createRoot(rootElement).render(
   <StrictMode>
-    <ApolloProvider client={client}>
-      <App />
-    </ApolloProvider>
+    <ErrorBoundary>
+      <ApolloProvider client={client}>
+        <App />
+      </ApolloProvider>
+    </ErrorBoundary>
   </StrictMode>,
 );


### PR DESCRIPTION
## Summary
- Added a React `ErrorBoundary` class component with a styled ShadCN Card UI, displaying a friendly "Something went wrong" message, the error in a code block, and a "Try again" button that calls `window.location.reload()`
- Wrapped the root `<App>` in `ErrorBoundary` inside `main.tsx` for root-level error handling
- Added Apollo `onError` link to `main.tsx` to log GraphQL errors (with operation name + path) and network errors clearly to the console
- Upgraded empty states in Todos, Habits, and Time Blocks tabs from plain text to centered empty-state UI with CTA buttons that open the creation dialog directly

## Test plan
- [ ] Empty todos tab shows "No todos yet." + "Create your first todo" button that opens TodoForm
- [ ] Empty habits tab shows "No habits yet." + "Create your first habit" button that opens HabitForm
- [ ] Empty time blocks tab shows "No time blocks yet." + "Create your first time block" button that opens TimeBlockForm
- [ ] Triggering a JS error inside the app renders the styled error card with retry button
- [ ] GraphQL/network errors are logged to the browser console with operation context

🤖 Generated with [Claude Code](https://claude.com/claude-code)