### PR TITLE
feat: Postgres support for production deployments

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,8 @@
-# Database
-PGLITE_DATA_DIR=./pgdata
-
-# Server
+# Option A: Use embedded PGLite (no external DB needed — default for local dev)
+PGLITE_DATA_DIR=../../pgdata
 PORT=4000
-
-# Demo user ID for development
 DEMO_USER_ID=demo-user-id
+
+# Option B: Use real Postgres (for production or multi-user setups)
+# DATABASE_URL=postgresql://user:password@localhost:5432/autocal
+# PORT=4000

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,7 +104,7 @@ Embedded Postgres — no separate database server needed. Perfect for:
 - Embedded deployments
 - Testing
 
-Can swap for full Postgres in production by changing the connection string.
+**Switching to full Postgres:** Set the `DATABASE_URL` environment variable (e.g. `postgresql://user:password@localhost:5432/autocal`) and the runtime will automatically use the `postgres.js` driver instead of PGLite. If `DATABASE_URL` is not set, `PGLITE_DATA_DIR` is required and PGLite is used. See `.env.example` and `docker-compose.yml` for both modes.
 
 ### Why --experimental-strip-types?
 Node 22+ can run TypeScript directly without a build step. Benefits:
@@ -234,7 +234,8 @@ When adding tests:
 
 ### Environment Variables
 - `PORT` — server port (default 4000)
-- `PGLITE_DATA_DIR` — path to PGLite data directory (default ./pgdata)
+- `DATABASE_URL` — Postgres connection string (e.g. `postgresql://user:pass@host:5432/db`); when set, uses postgres.js driver
+- `PGLITE_DATA_DIR` — path to PGLite data directory; required when `DATABASE_URL` is not set
 - `NODE_ENV` — production/development
 - `DEMO_USER_ID` — demo user for development (no auth yet)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,17 +1,46 @@
 services:
   auto-cal:
-    image: auto-cal
-    container_name: auto-cal
+    build: .
+    ports:
+      - "4000:4000"
+    environment:
+      - NODE_ENV=production
+      # Use DATABASE_URL for Postgres, or PGLITE_DATA_DIR for embedded
+      - DATABASE_URL=postgresql://autocal:autocal@postgres:5432/autocal
+    depends_on:
+      postgres:
+        condition: service_healthy
+    profiles:
+      - postgres
+
+  auto-cal-embedded:
+    build: .
     ports:
       - "4000:4000"
     volumes:
       - auto-cal-pgdata:/app/pgdata
     environment:
       - NODE_ENV=production
-      - PORT=4000
       - PGLITE_DATA_DIR=/app/pgdata
-    restart: unless-stopped
+    profiles:
+      - embedded
+
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: autocal
+      POSTGRES_PASSWORD: autocal
+      POSTGRES_DB: autocal
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U autocal"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    profiles:
+      - postgres
 
 volumes:
   auto-cal-pgdata:
-    driver: local
+  postgres-data:

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,8 +23,56 @@
         "vitest": "^2.1.8"
       }
     },
+    "../../../../drizzle-graphql": {
+      "version": "0.8.5",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "pluralize": "^8.0.0"
+      },
+      "devDependencies": {
+        "@arethetypeswrong/cli": "^0.15.2",
+        "@babel/parser": "^7.24.1",
+        "@electric-sql/pglite": "^0.3.16",
+        "@libsql/client": "^0.10.0",
+        "@originjs/vite-plugin-commonjs": "^1.0.3",
+        "@types/dockerode": "^3.3.26",
+        "@types/pg": "^8.11.6",
+        "@types/uuid": "^9.0.8",
+        "axios": "^1.6.8",
+        "cpy": "^11.0.1",
+        "dockerode": "^4.0.2",
+        "dprint": "^0.45.1",
+        "drizzle-kit": "^0.24.0",
+        "drizzle-orm": "^1.0.0-beta.1",
+        "get-port": "^7.0.0",
+        "glob": "^10.3.10",
+        "graphql-yoga": "^5.1.1",
+        "mysql2": "^3.9.2",
+        "node-pg": "^1.0.1",
+        "pg": "^8.12.0",
+        "postgres": "^3.4.3",
+        "recast": "^0.23.6",
+        "resolve-tspaths": "^0.8.18",
+        "rimraf": "^5.0.5",
+        "tsup": "^8.5.1",
+        "tsx": "^4.7.1",
+        "typescript": "^5.4.2",
+        "uuid": "^9.0.1",
+        "vite-tsconfig-paths": "^4.3.2",
+        "vitest": "^1.4.0",
+        "zod": "^3.22.4",
+        "zx": "^7.2.3"
+      },
+      "peerDependencies": {
+        "drizzle-orm": "^1.0.0-beta.1",
+        "graphql": ">=16.3.0",
+        "graphql-parse-resolve-info": "^4.13.0",
+        "graphql-scalars": "^1.25.0"
+      }
+    },
     "../drizzle-graphql": {
       "version": "0.8.5",
+      "extraneous": true,
       "license": "Apache-2.0",
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.15.2",
@@ -6691,7 +6739,7 @@
       }
     },
     "node_modules/drizzle-graphql": {
-      "resolved": "../drizzle-graphql",
+      "resolved": "../../../../drizzle-graphql",
       "link": true
     },
     "node_modules/drizzle-kit": {
@@ -10133,6 +10181,19 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "license": "MIT"
     },
+    "node_modules/postgres": {
+      "version": "3.4.9",
+      "resolved": "https://registry.npmjs.org/postgres/-/postgres-3.4.9.tgz",
+      "integrity": "sha512-GD3qdB0x1z9xgFI6cdRD6xu2Sp2WCOEoe3mtnyB5Ee0XrrL5Pe+e4CCnJrRMnL1zYtRDZmQQVbvOttLnKDLnaw==",
+      "license": "Unlicense",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/porsager"
+      }
+    },
     "node_modules/process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
@@ -13225,7 +13286,8 @@
       "name": "@auto-cal/db",
       "version": "1.0.0",
       "dependencies": {
-        "@electric-sql/pglite": "^0.2.15"
+        "@electric-sql/pglite": "^0.2.15",
+        "postgres": "^3.4.9"
       },
       "devDependencies": {
         "drizzle-kit": "~1.0.0-beta",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -14,7 +14,8 @@
     "db:studio": "env-cmd -f ../../.env drizzle-kit studio"
   },
   "dependencies": {
-    "@electric-sql/pglite": "^0.2.15"
+    "@electric-sql/pglite": "^0.2.15",
+    "postgres": "^3.4.9"
   },
   "peerDependencies": {
     "drizzle-orm": "~1.0.0-beta"

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,24 +1,43 @@
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { PGlite } from '@electric-sql/pglite';
-import { drizzle } from 'drizzle-orm/pglite';
-import { migrate } from 'drizzle-orm/pglite/migrator';
 import * as schema from './schema.ts';
 
-const dir = process.env.PGLITE_DATA_DIR;
-if (!dir) throw new Error('PGLITE_DATA_DIR environment variable is required');
-
-const client = new PGlite(dir);
-await client.waitReady;
-
-export const db = drizzle({ client, schema });
+const databaseUrl = process.env.DATABASE_URL;
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const migrationsFolder = path.resolve(__dirname, '../drizzle');
 
-await migrate(db, { migrationsFolder });
+// biome-ignore lint/suspicious/noExplicitAny: dual-backend Drizzle instance; both PGLite and postgres.js satisfy the same query interface
+let db: any;
 
+if (databaseUrl) {
+  // Production: use real Postgres via postgres.js
+  const { drizzle } = await import('drizzle-orm/postgres-js');
+  const postgres = await import('postgres');
+  const client = postgres.default(databaseUrl);
+  db = drizzle({ client, schema });
+
+  // Run migrations
+  const { migrate } = await import('drizzle-orm/postgres-js/migrator');
+  await migrate(db, { migrationsFolder });
+} else {
+  // Development: use PGLite (embedded Postgres, zero setup)
+  const dir = process.env.PGLITE_DATA_DIR;
+  if (!dir) throw new Error('Set DATABASE_URL or PGLITE_DATA_DIR');
+
+  const { PGlite } = await import('@electric-sql/pglite');
+  const { drizzle } = await import('drizzle-orm/pglite');
+  const { migrate } = await import('drizzle-orm/pglite/migrator');
+
+  const client = new PGlite(dir);
+  await client.waitReady;
+  db = drizzle({ client, schema });
+
+  await migrate(db, { migrationsFolder });
+}
+
+export { db };
 export type DB = typeof db;
 
 export { schema };

--- a/packages/server/src/schema/resolvers.ts
+++ b/packages/server/src/schema/resolvers.ts
@@ -1,4 +1,5 @@
 import {
+  type Todo,
   activityTypes,
   habitCompletions,
   habits,
@@ -289,7 +290,9 @@ export function applyCustomResolvers(schema: GraphQLSchema): GraphQLSchema {
       const allTodos = await context.db._query.todos.findMany({
         where: and(...todoConditions),
       });
-      const completedTodos = allTodos.filter((t) => t.completedAt !== null);
+      const completedTodos = allTodos.filter(
+        (t: Todo) => t.completedAt !== null,
+      );
       const habitConditions = [
         eq(habits.userId, context.userId),
         eq(habits.activityTypeId, activityType.id),


### PR DESCRIPTION
## Summary
- DB driver now switches between PGLite (local dev) and postgres.js (production) based on `DATABASE_URL` env var
- `packages/db/src/index.ts` conditionally uses postgres.js when `DATABASE_URL` is set, otherwise falls back to PGLite (requires `PGLITE_DATA_DIR`)
- Docker Compose updated with `postgres` and `embedded` profiles — opt-in via `docker compose --profile postgres up`
- `.env.example` documents both modes with comments
- `AGENTS.md` updated with `DATABASE_URL` switching docs and env var reference
- Fixed pre-existing type annotation issue in server resolvers (`Todo` filter parameter)

## Test plan
- [ ] Local dev still works with `PGLITE_DATA_DIR` (no `DATABASE_URL` set)
- [ ] `docker compose --profile postgres up` starts app with real Postgres
- [ ] `docker compose --profile embedded up` starts app with PGLite
- [ ] `npm run typecheck` passes
- [ ] `npm run lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)