### PR TITLE
feat: rich seed data for development

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,8 +23,56 @@
         "vitest": "^2.1.8"
       }
     },
+    "../../../../drizzle-graphql": {
+      "version": "0.8.5",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "pluralize": "^8.0.0"
+      },
+      "devDependencies": {
+        "@arethetypeswrong/cli": "^0.15.2",
+        "@babel/parser": "^7.24.1",
+        "@electric-sql/pglite": "^0.3.16",
+        "@libsql/client": "^0.10.0",
+        "@originjs/vite-plugin-commonjs": "^1.0.3",
+        "@types/dockerode": "^3.3.26",
+        "@types/pg": "^8.11.6",
+        "@types/uuid": "^9.0.8",
+        "axios": "^1.6.8",
+        "cpy": "^11.0.1",
+        "dockerode": "^4.0.2",
+        "dprint": "^0.45.1",
+        "drizzle-kit": "^0.24.0",
+        "drizzle-orm": "^1.0.0-beta.1",
+        "get-port": "^7.0.0",
+        "glob": "^10.3.10",
+        "graphql-yoga": "^5.1.1",
+        "mysql2": "^3.9.2",
+        "node-pg": "^1.0.1",
+        "pg": "^8.12.0",
+        "postgres": "^3.4.3",
+        "recast": "^0.23.6",
+        "resolve-tspaths": "^0.8.18",
+        "rimraf": "^5.0.5",
+        "tsup": "^8.5.1",
+        "tsx": "^4.7.1",
+        "typescript": "^5.4.2",
+        "uuid": "^9.0.1",
+        "vite-tsconfig-paths": "^4.3.2",
+        "vitest": "^1.4.0",
+        "zod": "^3.22.4",
+        "zx": "^7.2.3"
+      },
+      "peerDependencies": {
+        "drizzle-orm": "^1.0.0-beta.1",
+        "graphql": ">=16.3.0",
+        "graphql-parse-resolve-info": "^4.13.0",
+        "graphql-scalars": "^1.25.0"
+      }
+    },
     "../drizzle-graphql": {
       "version": "0.8.5",
+      "extraneous": true,
       "license": "Apache-2.0",
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.15.2",
@@ -6691,7 +6739,7 @@
       }
     },
     "node_modules/drizzle-graphql": {
-      "resolved": "../drizzle-graphql",
+      "resolved": "../../../../drizzle-graphql",
       "link": true
     },
     "node_modules/drizzle-kit": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "lint:fix": "biome check --apply .",
     "db:generate": "npm run db:generate -w @auto-cal/db",
     "db:migrate": "npm run migrate -w @auto-cal/db",
+    "db:seed": "npm run seed -w @auto-cal/db",
     "db:studio": "npm run db:studio -w @auto-cal/db",
     "codegen": "graphql-codegen --config codegen.ts",
     "codegen:server": "graphql-codegen-esm --config codegen.server.ts",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -11,7 +11,8 @@
     "migrate": "env-cmd -f ../../.env node --experimental-strip-types src/migrator.ts",
     "db:generate": "env-cmd -f ../../.env drizzle-kit generate",
     "db:migrate": "npm run migrate",
-    "db:studio": "env-cmd -f ../../.env drizzle-kit studio"
+    "db:studio": "env-cmd -f ../../.env drizzle-kit studio",
+    "seed": "env-cmd -f ../../.env node --experimental-strip-types src/seed.ts"
   },
   "dependencies": {
     "@electric-sql/pglite": "^0.2.15"

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -1,5 +1,6 @@
 import { eq } from 'drizzle-orm';
 import { db, users } from './index.ts';
+import { activityTypes, habits, timeBlocks, todos } from './schema.ts';
 
 export const DEMO_USER_ID = '00000000-0000-0000-0000-000000000001';
 export const DEMO_USER_EMAIL = 'demo@auto-cal.app';
@@ -18,4 +19,153 @@ export async function seedDemoUser(): Promise<void> {
     });
     console.log('Demo user created:', DEMO_USER_ID);
   }
+}
+
+export async function seedDemoData(): Promise<void> {
+  const existing = await db
+    .select()
+    .from(activityTypes)
+    .where(eq(activityTypes.userId, DEMO_USER_ID))
+    .limit(1);
+
+  if (existing.length > 0) {
+    console.log('Demo data already exists, skipping seed.');
+    return;
+  }
+
+  // Insert activity types
+  const insertedActivityTypes = await db
+    .insert(activityTypes)
+    .values([
+      { userId: DEMO_USER_ID, name: 'Work', color: '#6366f1' },
+      { userId: DEMO_USER_ID, name: 'Exercise', color: '#22c55e' },
+      { userId: DEMO_USER_ID, name: 'Learning', color: '#f59e0b' },
+    ])
+    .returning();
+
+  const workType = insertedActivityTypes.find((t) => t.name === 'Work');
+  const exerciseType = insertedActivityTypes.find((t) => t.name === 'Exercise');
+  const learningType = insertedActivityTypes.find((t) => t.name === 'Learning');
+
+  if (!workType || !exerciseType || !learningType) {
+    throw new Error('Failed to insert activity types');
+  }
+
+  // Insert time blocks
+  await db.insert(timeBlocks).values([
+    {
+      userId: DEMO_USER_ID,
+      activityTypeId: workType.id,
+      daysOfWeek: [1, 2, 3, 4, 5],
+      startTime: '09:00',
+      endTime: '12:00',
+    },
+    {
+      userId: DEMO_USER_ID,
+      activityTypeId: workType.id,
+      daysOfWeek: [1, 2, 3, 4, 5],
+      startTime: '14:00',
+      endTime: '17:00',
+    },
+    {
+      userId: DEMO_USER_ID,
+      activityTypeId: exerciseType.id,
+      daysOfWeek: [1, 3, 5],
+      startTime: '07:00',
+      endTime: '08:00',
+    },
+    {
+      userId: DEMO_USER_ID,
+      activityTypeId: exerciseType.id,
+      daysOfWeek: [6],
+      startTime: '08:00',
+      endTime: '09:00',
+    },
+    {
+      userId: DEMO_USER_ID,
+      activityTypeId: learningType.id,
+      daysOfWeek: [2, 4],
+      startTime: '18:00',
+      endTime: '20:00',
+    },
+    {
+      userId: DEMO_USER_ID,
+      activityTypeId: learningType.id,
+      daysOfWeek: [6],
+      startTime: '10:00',
+      endTime: '12:00',
+    },
+  ]);
+
+  // Insert habits
+  await db.insert(habits).values([
+    {
+      userId: DEMO_USER_ID,
+      title: 'Daily standup',
+      activityTypeId: workType.id,
+      priority: 90,
+      estimatedLength: 15,
+      frequencyCount: 5,
+      frequencyUnit: 'week',
+    },
+    {
+      userId: DEMO_USER_ID,
+      title: 'Evening walk',
+      activityTypeId: exerciseType.id,
+      priority: 75,
+      estimatedLength: 30,
+      frequencyCount: 3,
+      frequencyUnit: 'week',
+    },
+    {
+      userId: DEMO_USER_ID,
+      title: 'Read technical articles',
+      activityTypeId: learningType.id,
+      priority: 65,
+      estimatedLength: 45,
+      frequencyCount: 3,
+      frequencyUnit: 'week',
+    },
+  ]);
+
+  // Insert todos
+  await db.insert(todos).values([
+    {
+      userId: DEMO_USER_ID,
+      title: 'Write project proposal',
+      activityTypeId: workType.id,
+      priority: 80,
+      estimatedLength: 90,
+    },
+    {
+      userId: DEMO_USER_ID,
+      title: 'Review pull requests',
+      activityTypeId: workType.id,
+      priority: 60,
+      estimatedLength: 30,
+    },
+    {
+      userId: DEMO_USER_ID,
+      title: 'Morning run',
+      activityTypeId: exerciseType.id,
+      priority: 70,
+      estimatedLength: 45,
+    },
+    {
+      userId: DEMO_USER_ID,
+      title: 'Read TypeScript docs',
+      activityTypeId: learningType.id,
+      priority: 50,
+      estimatedLength: 60,
+    },
+    {
+      userId: DEMO_USER_ID,
+      title: 'Set up CI pipeline',
+      activityTypeId: workType.id,
+      priority: 40,
+      estimatedLength: 120,
+    },
+  ]);
+
+  console.log('Demo data seeded successfully.');
 }

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 import { ApolloServer } from '@apollo/server';
 import { expressMiddleware } from '@apollo/server/express4';
 import { db } from '@auto-cal/db';
-import { seedDemoUser } from '@auto-cal/db/seed';
+import { seedDemoData, seedDemoUser } from '@auto-cal/db/seed';
 import cors from 'cors';
 import express from 'express';
 import type { Context } from './context.ts';
@@ -15,6 +15,9 @@ const server = new ApolloServer<Context>({ schema });
 
 await server.start();
 await seedDemoUser();
+if (process.env.NODE_ENV !== 'production') {
+  await seedDemoData();
+}
 
 const clientDist = path.resolve(process.cwd(), 'packages/client/dist');
 const clientDistExists = fs.existsSync(clientDist);


### PR DESCRIPTION
## Summary
- Extends seed.ts with realistic demo data (3 activity types, 6 time blocks, 3 habits, 5 todos)
- Seeding is idempotent — skips if data already exists
- Disabled in production via NODE_ENV check
- Adds db:seed npm script

## Test plan
- [ ] Run npm run dev:server — server starts without errors
- [ ] Verify dashboard shows scheduled items on first load
- [ ] Restart server — verify no duplicate data

🤖 Generated with [Claude Code](https://claude.com/claude-code)