### PR TITLE
feat: timezone handling and user profile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,8 +23,56 @@
         "vitest": "^2.1.8"
       }
     },
+    "../../../../drizzle-graphql": {
+      "version": "0.8.5",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "pluralize": "^8.0.0"
+      },
+      "devDependencies": {
+        "@arethetypeswrong/cli": "^0.15.2",
+        "@babel/parser": "^7.24.1",
+        "@electric-sql/pglite": "^0.3.16",
+        "@libsql/client": "^0.10.0",
+        "@originjs/vite-plugin-commonjs": "^1.0.3",
+        "@types/dockerode": "^3.3.26",
+        "@types/pg": "^8.11.6",
+        "@types/uuid": "^9.0.8",
+        "axios": "^1.6.8",
+        "cpy": "^11.0.1",
+        "dockerode": "^4.0.2",
+        "dprint": "^0.45.1",
+        "drizzle-kit": "^0.24.0",
+        "drizzle-orm": "^1.0.0-beta.1",
+        "get-port": "^7.0.0",
+        "glob": "^10.3.10",
+        "graphql-yoga": "^5.1.1",
+        "mysql2": "^3.9.2",
+        "node-pg": "^1.0.1",
+        "pg": "^8.12.0",
+        "postgres": "^3.4.3",
+        "recast": "^0.23.6",
+        "resolve-tspaths": "^0.8.18",
+        "rimraf": "^5.0.5",
+        "tsup": "^8.5.1",
+        "tsx": "^4.7.1",
+        "typescript": "^5.4.2",
+        "uuid": "^9.0.1",
+        "vite-tsconfig-paths": "^4.3.2",
+        "vitest": "^1.4.0",
+        "zod": "^3.22.4",
+        "zx": "^7.2.3"
+      },
+      "peerDependencies": {
+        "drizzle-orm": "^1.0.0-beta.1",
+        "graphql": ">=16.3.0",
+        "graphql-parse-resolve-info": "^4.13.0",
+        "graphql-scalars": "^1.25.0"
+      }
+    },
     "../drizzle-graphql": {
       "version": "0.8.5",
+      "extraneous": true,
       "license": "Apache-2.0",
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.15.2",
@@ -6691,7 +6739,7 @@
       }
     },
     "node_modules/drizzle-graphql": {
-      "resolved": "../drizzle-graphql",
+      "resolved": "../../../../drizzle-graphql",
       "link": true
     },
     "node_modules/drizzle-kit": {

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -7,9 +7,9 @@ import {
   CardTitle,
 } from '@/components/ui/card';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { gql, useQuery } from '@apollo/client';
+import { gql, useMutation, useQuery } from '@apollo/client';
 import { Pencil, Plus } from 'lucide-react';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { ActivityTypeForm } from './components/ActivityTypeForm';
 import { HabitForm } from './components/HabitForm';
 import { TimeBlockForm } from './components/TimeBlockForm';
@@ -113,6 +113,14 @@ const GET_MY_TIME_BLOCKS = gql`
   }
 `;
 
+const UPDATE_TIMEZONE = gql`
+  mutation UpdateTimezone($timezone: String!) {
+    myUpdateProfile(timezone: $timezone) {
+      timezone
+    }
+  }
+`;
+
 // ─── Constants ──────────────────────────────────────────────────────────────
 
 const DAY_NAMES = [
@@ -129,6 +137,12 @@ const DAY_NAMES = [
 
 function App() {
   const [activeTab, setActiveTab] = useState('todos');
+
+  const [updateTimezone] = useMutation(UPDATE_TIMEZONE);
+  useEffect(() => {
+    const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    updateTimezone({ variables: { timezone: tz } }).catch(() => {});
+  }, [updateTimezone]);
 
   const [todoFormOpen, setTodoFormOpen] = useState(false);
   const [editingTodo, setEditingTodo] = useState<Todo | null>(null);

--- a/packages/db/drizzle/20260427000000_add_user_timezone/migration.sql
+++ b/packages/db/drizzle/20260427000000_add_user_timezone/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "users" ADD COLUMN "timezone" text NOT NULL DEFAULT 'UTC';

--- a/packages/db/src/models/users.ts
+++ b/packages/db/src/models/users.ts
@@ -3,6 +3,7 @@ import { pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-core';
 export const users = pgTable('users', {
   id: uuid('id').primaryKey().defaultRandom(),
   email: text('email').notNull().unique(),
+  timezone: text('timezone').notNull().default('UTC'),
   createdAt: timestamp('created_at').notNull().defaultNow(),
   updatedAt: timestamp('updated_at').notNull().defaultNow(),
 });

--- a/packages/server/src/schema/resolvers.ts
+++ b/packages/server/src/schema/resolvers.ts
@@ -4,6 +4,7 @@ import {
   habits,
   timeBlocks,
   todos,
+  users,
 } from '@auto-cal/db/schema';
 import { and, desc, eq, gte, isNotNull, isNull, lte, sql } from 'drizzle-orm';
 import {
@@ -87,6 +88,12 @@ const CompleteHabitInput = z.object({
 
 // SDL extension
 const extensionSDL = `
+  type UserProfile {
+    id: ID!
+    email: String!
+    timezone: String!
+  }
+
   type ActivityTypeStats {
     activityTypeId: String!
     activityTypeName: String!
@@ -155,6 +162,7 @@ const extensionSDL = `
   }
 
   extend type Query {
+    myProfile: UserProfile
     myActivityTypes: [ActivityType!]!
     myTodos(activityTypeId: ID, completed: Boolean): [Todo!]!
     myHabits(activityTypeId: ID): [Habit!]!
@@ -164,6 +172,7 @@ const extensionSDL = `
   }
 
   extend type Mutation {
+    myUpdateProfile(timezone: String!): UserProfile!
     myCreateActivityType(input: CreateActivityTypeArgs!): ActivityType!
     myUpdateActivityType(input: UpdateActivityTypeArgs!): ActivityType!
     myDeleteActivityType(id: ID!): Boolean!
@@ -186,6 +195,16 @@ export function applyCustomResolvers(schema: GraphQLSchema): GraphQLSchema {
   const mutationType = extended.getType('Mutation') as GraphQLObjectType;
   const queryFields = queryType.getFields();
   const mutationFields = mutationType.getFields();
+
+  // --- Profile Query ---
+
+  // biome-ignore lint/style/noNonNullAssertion: field is defined in SDL above
+  queryFields.myProfile!.resolve = async (_parent, _args, context: Context) => {
+    if (!context.userId) throw new Error('Not authenticated');
+    return context.db._query.users.findFirst({
+      where: eq(users.id, context.userId),
+    });
+  };
 
   // --- ActivityType Queries ---
 
@@ -344,6 +363,24 @@ export function applyCustomResolvers(schema: GraphQLSchema): GraphQLSchema {
       });
     }
     return results;
+  };
+
+  // --- Profile Mutations ---
+
+  // biome-ignore lint/style/noNonNullAssertion: field is defined in SDL above
+  mutationFields.myUpdateProfile!.resolve = async (
+    _parent,
+    args: { timezone: string },
+    context: Context,
+  ) => {
+    if (!context.userId) throw new Error('Not authenticated');
+    const [updated] = await context.db
+      .update(users)
+      .set({ timezone: args.timezone, updatedAt: new Date() })
+      .where(eq(users.id, context.userId))
+      .returning();
+    if (!updated) throw new Error('Failed to update profile');
+    return updated;
   };
 
   // --- ActivityType Mutations ---


### PR DESCRIPTION
## Summary
- Adds `timezone` column to users table with a migration (`20260427000000_add_user_timezone`)
- Adds `myProfile` query (returns `UserProfile { id, email, timezone }`) to GraphQL schema
- Adds `myUpdateProfile(timezone: String!)` mutation to GraphQL schema
- Client auto-detects browser timezone via `Intl.DateTimeFormat().resolvedOptions().timeZone` on startup and persists it via the mutation

## Test plan
- [ ] `npm run db:generate` produces a clean migration (or apply the hand-written migration)
- [ ] `npm run typecheck` passes
- [ ] Server starts with new schema
- [ ] `myProfile` query returns user with timezone field
- [ ] `myUpdateProfile` saves timezone correctly
- [ ] Browser console shows no errors on startup; timezone is silently saved

🤖 Generated with [Claude Code](https://claude.com/claude-code)