### PR TITLE
feat(ci): semantic-release + Docker publish to ghcr.io

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,60 @@
+name: Release
+
+on:
+  workflow_run:
+    workflows: [CI]
+    branches: [main]
+    types: [completed]
+
+jobs:
+  release:
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+      issues: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - run: npm ci
+
+      - name: Semantic Release
+        id: semantic
+        uses: cycjimmy/semantic-release-action@v4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log in to GitHub Container Registry
+        if: steps.semantic.outputs.new_release_published == 'true'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        if: steps.semantic.outputs.new_release_published == 'true'
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push Docker image
+        if: steps.semantic.outputs.new_release_published == 'true'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}:latest
+            ghcr.io/${{ github.repository }}:${{ steps.semantic.outputs.new_release_version }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,9 @@
+{
+  "branches": ["main"],
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    ["@semantic-release/npm", { "npmPublish": false }],
+    "@semantic-release/github"
+  ]
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,35 +1,17 @@
 # Multi-stage build for Auto Cal
 # Build context: the auto-cal/ directory (default)
 #   docker build -t auto-cal .
-#
-# drizzle-graphql is a local sibling dependency referenced by an absolute host
-# path in packages/server/package.json.  We vendor its pre-built dist into
-# vendor/drizzle-graphql, place it at /app/drizzle-graphql inside the image,
-# and patch the absolute path to file:///app/drizzle-graphql so npm can
-# resolve it.  The /app placement lets Node.js walk up to /app/node_modules
-# to resolve drizzle-graphql's peer dependencies.
 
 # ── Stage 1: Build the React client ──────────────────────────────────────────
 FROM node:22-alpine AS client-builder
 
 WORKDIR /app
 
-# Vendor drizzle-graphql under /app so peer dep resolution works
-COPY vendor/drizzle-graphql ./drizzle-graphql
-
-# Copy workspace manifests
 COPY package*.json ./
 COPY packages/client/package*.json ./packages/client/
 
-# Patch absolute host path → in-image path
-RUN sed -i \
-      's|file://home/vantreeseba/code/vantreeseba/apps/drizzle-graphql|file:///app/drizzle-graphql|g' \
-      package.json packages/*/package.json 2>/dev/null || true
-
-# Install all workspace deps (devDeps needed for Vite client build)
 RUN npm install
 
-# Copy client source and build
 COPY biome.json ./
 COPY codegen.ts ./
 COPY packages/client ./packages/client
@@ -41,21 +23,12 @@ FROM node:22-alpine AS server-builder
 
 WORKDIR /app
 
-# Vendor drizzle-graphql under /app for peer dep resolution
-COPY vendor/drizzle-graphql ./drizzle-graphql
-
-# Copy workspace manifests
 COPY package*.json ./
 COPY packages/db/package*.json ./packages/db/
 COPY packages/server/package*.json ./packages/server/
 
-# Patch absolute host path → in-image path, then install prod deps only
-RUN sed -i \
-      's|file://home/vantreeseba/code/vantreeseba/apps/drizzle-graphql|file:///app/drizzle-graphql|g' \
-      package.json packages/*/package.json && \
-    npm install --omit=dev
+RUN npm install --omit=dev
 
-# Copy server and db source + drizzle config
 COPY packages/db ./packages/db
 COPY packages/server ./packages/server
 COPY drizzle.config.ts ./
@@ -65,22 +38,15 @@ FROM node:22-alpine
 
 WORKDIR /app
 
-# drizzle-graphql inside /app so peer deps resolve from /app/node_modules
-COPY --from=server-builder /app/drizzle-graphql ./drizzle-graphql
-
-# Production node_modules, source packages, and root manifest
 COPY --from=server-builder /app/node_modules ./node_modules
 COPY --from=server-builder /app/packages ./packages
 COPY --from=server-builder /app/package.json ./
 
-# Pre-built client static assets
 COPY --from=client-builder /app/packages/client/dist ./packages/client/dist
 
-# Config files required at runtime
 COPY drizzle.config.ts ./
 COPY biome.json ./
 
-# Persistent PGLite data directory — mount a named volume here
 RUN mkdir -p /app/pgdata
 
 EXPOSE 4000
@@ -89,6 +55,4 @@ ENV NODE_ENV=production
 ENV PORT=4000
 ENV PGLITE_DATA_DIR=/app/pgdata
 
-# Run DB migrations (cd into packages/db so ./drizzle/ resolves correctly),
-# then start the GraphQL server from /app
 CMD ["sh", "-c", "cd packages/db && node --experimental-strip-types src/migrator.ts && cd /app && node --experimental-strip-types packages/server/src/index.ts"]


### PR DESCRIPTION
## Summary

- Adds `.releaserc.json` to configure semantic-release: analyzes conventional commits, generates GitHub releases, skips npm publish (package is private)
- Adds `.github/workflows/release.yml`: triggers after CI passes on `main`, runs semantic-release, then builds and pushes the Docker image to `ghcr.io/vantreeseba/auto-cal` tagged with `latest` and the semver version
- Cleans up `Dockerfile`: removes legacy `vendor/drizzle-graphql` copy and `sed` path-patching now that `@vantreeseba/drizzle-graphql` is resolved directly from npm

## Test plan

- [ ] Merge a `fix:` or `feat:` commit to `main` and verify the Release workflow triggers after CI
- [ ] Confirm a GitHub release is created with the correct version and changelog
- [ ] Confirm the Docker image appears in the GitHub Container Registry (`ghcr.io/vantreeseba/auto-cal`)
- [ ] Verify the image runs correctly (`docker pull ghcr.io/vantreeseba/auto-cal:latest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)