### PR TITLE
feat(ci): add semantic-release workflow and minimal Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,20 +2,24 @@
 # Build context: the auto-cal/ directory (default)
 #   docker build -t auto-cal .
 
-# ── Stage 1: Build the React client ──────────────────────────────────────────
+# ── Stage 1: Build the React client (codegen + vite) ─────────────────────────
 FROM node:22-alpine AS client-builder
 
 WORKDIR /app
 
 COPY package*.json ./
 COPY packages/client/package*.json ./packages/client/
+COPY packages/server/package*.json ./packages/server/
+COPY packages/db/package*.json ./packages/db/
 
 RUN npm install
 
 COPY biome.json ./
 COPY codegen.ts ./
-COPY packages/client ./packages/client
-WORKDIR /app/packages/client
+COPY codegen.server.ts ./
+COPY drizzle.config.ts ./
+COPY packages ./packages
+
 RUN npm run build
 
 # ── Stage 2: Install server production dependencies ───────────────────────────
@@ -39,13 +43,11 @@ FROM node:22-alpine
 WORKDIR /app
 
 COPY --from=server-builder /app/node_modules ./node_modules
-COPY --from=server-builder /app/packages ./packages
 COPY --from=server-builder /app/package.json ./
+COPY --from=server-builder /app/packages/server ./packages/server
+COPY --from=server-builder /app/packages/db ./packages/db
 
 COPY --from=client-builder /app/packages/client/dist ./packages/client/dist
-
-COPY drizzle.config.ts ./
-COPY biome.json ./
 
 RUN mkdir -p /app/pgdata
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "dev": "concurrently \"npm:dev:server\" \"npm:dev:client\"",
     "dev:server": "npm run dev -w @auto-cal/server",
     "dev:client": "npm run dev -w @auto-cal/client",
-    "build": "npm run build -w @auto-cal/client && npm run build -w @auto-cal/server",
+    "build": "npm run codegen:server && npm run codegen && (cd packages/client && npx @tanstack/router-cli generate) && npm run build -w @auto-cal/client && npm run build -w @auto-cal/server",
     "build:docker": "docker build -t auto-cal .",
     "typecheck": "npm run typecheck --workspaces --if-present",
     "lint": "biome check .",


### PR DESCRIPTION
## Summary
- Adds semantic-release CI workflow to automate versioning and publish Docker image to ghcr.io
- Streamlines the final Docker stage to only copy `packages/client/dist`, `packages/server`, and `packages/db` — removing `biome.json` and `drizzle.config.ts` which are not needed at runtime
- Fixes the root `build` script to include codegen and route generation steps before building client and server

## Test plan
- [ ] Verify Docker image builds successfully with `docker build -t auto-cal .`
- [ ] Confirm the container starts and migrations run correctly
- [ ] Check that the client is served and the GraphQL API responds

🤖 Generated with [Claude Code](https://claude.com/claude-code)