### PR TITLE
docs(agents): reconcile .agents/ and todo.md against current code

### DIFF
--- a/.agents/client-patterns.md
+++ b/.agents/client-patterns.md
@@ -4,11 +4,13 @@ React + Vite + Apollo Client + TanStack Router + TanStack Form + ShadCN/Radix + 
 
 ## Installed ShadCN Components
 
-Only use components that are already installed — do not add new ones without checking first:
+Only use components that are already installed — do not add new ones without checking first. Files live in `packages/client/src/components/ui/`.
 
-`button` `card` `dialog` `field` `form` `input` `label` `select` `tabs` `textarea` `tooltip`
+ShadCN primitives (11): `button` `card` `dialog` `field` `form` `input` `label` `select` `tabs` `textarea` `tooltip`
 
-Also present: `inline-length-edit` (custom), `route-error` (custom error boundary component).
+Custom (2, not from ShadCN — keep tagged as such):
+- `inline-length-edit` — quick-edit duration chip used on list items
+- `route-error` — error boundary used in `__root.tsx` and route components
 
 ## Error Handling Conventions
 
@@ -63,20 +65,22 @@ Completion sets `localStorage.onboarding_done = '1'`. Re-runnable from Settings 
 
 ## Routes
 
-File-based routes under `packages/client/src/routes/`. Key routes:
+File-based routes under `packages/client/src/routes/`:
 
 | File | Path | Notes |
 |------|------|-------|
 | `__root.tsx` | `/` | Layout + auth guard — redirects to `/login` if no token, `/onboarding` if not set up |
+| `index.tsx` | `/` | Landing/redirect |
 | `login.tsx` | `/login` | Magic-link request form |
 | `auth.verify.tsx` | `/auth/verify` | Consumes magic-link token, stores JWT, redirects |
 | `onboarding.tsx` | `/onboarding?step=1` | 4-step setup wizard |
 | `dashboard.tsx` | `/dashboard` | Main schedule view |
 | `todos.tsx` | `/todos` | Todo list |
-| `habits.tsx` | `/habits` | Habit list; nested `$habitId` route for detail |
+| `habits.tsx` + `habits.index.tsx` | `/habits` | Habit list (parent + index) |
+| `habits.$habitId.tsx` | `/habits/$habitId` | Habit detail (rates, periods) |
 | `time-blocks.tsx` | `/time-blocks` | Time block management |
 | `activity-types.tsx` | `/activity-types` | Activity type management |
-| `stats.tsx` | `/stats` | Stats overview with date range selector |
+| `stats.tsx` | `/stats` | Analytics surface (composite score, charts — see todo.md #9 for build-out) |
 | `settings.tsx` | `/settings` | iCal feed URL + re-run onboarding wizard |
 
 Auth flow: `requestMagicLink` → magic link logged to server console (and returned in dev) → user visits `/auth/verify?token=…` → `verifyMagicLink` returns `{ token, userId }` → store `token` as `auth_token` in `localStorage` → redirect to `/dashboard`.

--- a/.agents/db-patterns.md
+++ b/.agents/db-patterns.md
@@ -92,6 +92,13 @@ await db.delete(todos).where(and(eq(todos.id, id), eq(todos.userId, userId)));
 
 ## Seed Pattern
 
+`packages/db/src/seed.ts` exports two entry points used by the server on startup (`packages/server/src/index.ts`):
+
+- `seedDemoUser()` — runs in all environments; idempotent insert of the demo user row (`DEMO_USER_ID = '00000000-0000-0000-0000-000000000001'`).
+- `seedDemoData()` — guarded with `NODE_ENV !== 'production'`; idempotent (skips if the demo user already has activity types). Creates 3 activity types (Work / Exercise / Learning), 6 time blocks, 5 todos, 3 habits.
+
+`packages/db/src/seed-runner.ts` is a CLI scaffold for running the seed standalone (no `npm run db:seed` script is currently wired in `package.json`).
+
 ```typescript
 // packages/db/src/seed.ts
 export const DEMO_USER_ID = '00000000-0000-0000-0000-000000000001';

--- a/.agents/deployment.md
+++ b/.agents/deployment.md
@@ -14,7 +14,14 @@ The Dockerfile installs only production deps, then copies:
 - `packages/db` — TypeScript source + migration files
 - `packages/client/dist` — built static assets
 
-Migrations run on container start before the server process.
+Migrations run on container start before the server process — the Dockerfile `CMD` is:
+
+```sh
+cd packages/db && node --experimental-strip-types src/migrator.ts \
+  && cd /app && node --experimental-strip-types packages/server/src/index.ts
+```
+
+`packages/db/src/migrator.ts` runs `drizzle-kit migrate` programmatically before the server boots.
 
 ## Environment Variables
 

--- a/.agents/graphql-patterns.md
+++ b/.agents/graphql-patterns.md
@@ -22,8 +22,10 @@ npm run codegen
 |---------|---------------|---------|
 | User-scoped queries | `my<Resource>` | `myTodos`, `myProfile` |
 | User-scoped mutations | `my<Action><Resource>` | `myCreateTodo`, `myUpdateHabit` |
-| Public mutations | Literal name | `requestMagicLink`, `verifyMagicLink` |
+| Public mutations | Literal name (no `my` prefix); must also be added to `PUBLIC_MUTATIONS` set in `schema/index.ts` | `requestMagicLink`, `verifyMagicLink` |
 | Input types | `<Action><Resource>Args` | `CreateTodoArgs`, `UpdateHabitArgs` |
+
+The full SDL (drizzle-generated + extensions) is emitted to `packages/server/src/__generated__/schema.graphql` by `npm run codegen:server`.
 
 ## Extending the Schema
 
@@ -256,7 +258,9 @@ mutation CreateTodo($input: CreateTodoArgs!) {
 }
 
 mutation UpdateTodo($input: UpdateTodoArgs!) {
-  myUpdateTodo(input: $input) { id title priority scheduledAt completedAt }
+  # UpdateTodoArgs accepts: id (required), title, description, priority,
+  # estimatedLength, activityTypeId, scheduledAt, manuallyScheduled, completedAt
+  myUpdateTodo(input: $input) { id title priority scheduledAt completedAt manuallyScheduled }
 }
 
 mutation CompleteTodo($id: ID!) {

--- a/.agents/project-structure.md
+++ b/.agents/project-structure.md
@@ -1,552 +1,326 @@
 # Project Structure — Auto Cal
 
-## 1. Project Overview
+> Index/overview. For deeper dives see the sibling `.agents/` files: `db-patterns.md`, `server-patterns.md`, `graphql-patterns.md`, `client-patterns.md`, `scheduling.md`, `deployment.md`.
 
-Auto Cal is a smart todo and habit scheduling application. Users create **todos** (single-time tasks) and **habits** (repeated tasks) that are automatically scheduled within user-defined **time blocks** based on priority and activity type. The system tracks completion rates and provides insights by activity type.
+## 1. Overview
 
-The app is built as a **monorepo** with three packages:
+Auto Cal is a smart todo + habit scheduling app. Users create **todos** (one-shot tasks) and **habits** (repeated targets) which the scheduler places into user-defined **time blocks** by priority and activity type. Stats track habit consistency and todo throughput per activity type.
+
+The repo is a **npm workspace** monorepo (`workspaces: ["packages/*"]` in the root `package.json`). There is no `pnpm-workspace.yaml` and no `sst.config.ts`.
 
 | Package | Role |
 |---------|------|
-| `packages/db/` | Drizzle ORM schema, PGLite database layer |
-| `packages/server/` | Node.js GraphQL API (Express + Apollo Server) |
-| `packages/client/` | React + Vite + Apollo Client + ShadCN UI |
+| `packages/db/` | Drizzle ORM schema, PGLite/Postgres connection, seed + migration runners |
+| `packages/server/` | Node 22 GraphQL API (Express + Apollo) — runs `.ts` directly via `--experimental-strip-types` |
+| `packages/client/` | React + Vite + Apollo Client + TanStack Router + ShadCN/Tailwind |
 
-Key technology decisions: **Biome** for linting/formatting, **drizzle-graphql** for zero-duplication schema generation, **PGLite** for embedded Postgres (zero local setup), **experimental-strip-types** for zero-build-step Node server, and **--experimental-strip-types** for the server.
+Key tech choices: **Biome** (lint+format), `@vantreeseba/drizzle-graphql` (auto-generates GraphQL schema from Drizzle tables — feature-fork of upstream), **PGLite** (embedded Postgres default; swap to real Postgres via `DATABASE_URL`), **vitest** for tests.
 
 ---
 
-## 2. Package Structure
+## 2. Package Layout
 
-### `packages/db/` — Database Schema
-
-```
-packages/db/
-├── src/
-│   ├── index.ts          # PGLite singleton + Drizzle instance
-│   └── models/
-│       ├── enums.ts      # Enum constants (ACTIVITY_TYPES, FREQUENCY_UNITS)
-│       ├── index.ts      # Re-exports all models
-│       ├── users.ts      # Users table
-│       ├── todos.ts      # Todos table
-│       ├── activity_types.ts  # Activity types table
-│       ├── habits.ts     # Habits table
-│       ├── time_blocks.ts      # Time blocks table
-│       └── habit_completions.ts  # Habit completions table
-└── drizzle/              # Generated migrations (never edit manually)
-```
-
-### `packages/server/` — GraphQL Server
+### `packages/db/`
 
 ```
-packages/server/
-└── src/
-    ├── index.ts           # Express + Apollo Server setup
-    ├── context.ts         # GraphQL context (db, userId)
-    └── schema/
-        ├── index.ts       # buildSchema pipeline (drizzle-graphql auto-generated)
-        └── resolvers.ts   # Custom queries, mutations, type extensions
+packages/db/src/
+├── index.ts            # PGLite/Postgres dual-backend, exports `db` instance
+├── schema.ts           # Aggregates all model exports
+├── relations.ts        # Drizzle relations
+├── seed.ts             # seedDemoUser(), seedDemoData() — non-prod only
+├── seed-runner.ts      # CLI entry for the seed script
+├── migrator.ts         # Programmatic drizzle-kit migrate (used by Dockerfile)
+└── models/
+    ├── enums.ts            # ACTIVITY_TYPES, FREQUENCY_UNITS, etc.
+    ├── index.ts            # Re-exports all models
+    ├── users.ts
+    ├── activity_types.ts
+    ├── todos.ts
+    ├── habits.ts
+    ├── time_blocks.ts
+    └── habit_completions.ts
+
+packages/db/drizzle/         # Generated migrations — never edit manually
 ```
 
-Important conventions:
-- Imports **must** include `.ts` extension
-- Built for Node 22+ with `--experimental-strip-types` (zero build step)
-
-### `packages/client/` — React Frontend
+### `packages/server/`
 
 ```
-packages/client/
-├── src/
-│   ├── main.tsx           # App entry point, Apollo Provider setup
-│   ├── App.tsx            # Main application component with tabs
-│   ├── lib/utils.ts       # cn() utility for className merging
-│   ├── components/
-│   │   ├── domain/todo/   # Todo domain components
-│   │   │   ├── TodoList.tsx
-│   │   │   ├── TodoItem.tsx
-│   │   │   └── TodoForm.tsx
-│   │   └── ui/            # ShadCN UI components (Button, Card, Dialog, etc.)
-│   ├── routes/
-│   │   └── todos.tsx      # '/todos' route with GET_MY_TODOS query
-│   └── __generated__/     # GraphQL Codegen output (gitignored)
-│       ├── gql.ts         # ~30 typed GraphQL operations (~520 lines)
-│       └── graphql.ts     # TypeScript types for GraphQL operations (generated)
-└── (generated files)      # ~250 JS files (build output)
+packages/server/src/
+├── index.ts                  # Express + Apollo bootstrap, auth context
+├── auth.ts                   # JWT sign/verify (jose), magic-link token helpers
+├── auth.test.ts
+├── context.ts                # GraphQL Context type + DataLoader factory
+├── ical-route.ts             # GET /ical?userId=… — public iCal feed
+├── routes/
+│   └── auth.ts               # Magic-link HTTP route handlers (if any)
+├── services/
+│   ├── scheduler.ts          # Pure scheduling algorithm
+│   ├── scheduler.test.ts
+│   └── scheduler-writeback.ts # DB-backed wrapper, fire-and-forget
+├── schema/
+│   ├── index.ts              # buildSchema → applyCustomResolvers → blockUnscoped
+│   ├── validators.ts         # Zod validators for resolver inputs
+│   ├── validators.test.ts
+│   └── resolvers/
+│       ├── index.ts          # extensionSDL + wires apply* functions
+│       ├── todos.ts
+│       ├── habits.ts
+│       ├── time-blocks.ts
+│       ├── activity-types.ts
+│       ├── schedule.ts
+│       ├── stats.ts
+│       ├── profile.ts
+│       └── auth.ts
+└── __generated__/            # Server schema + resolver types (codegen output)
+    ├── schema.graphql
+    └── resolvers.ts
 ```
+
+Imports **must** include `.ts` extension (Node 22 `--experimental-strip-types`).
+
+### `packages/client/`
+
+```
+packages/client/src/
+├── main.tsx              # App entry — Apollo + Router providers
+├── lib/utils.ts          # cn(), priorityLabel()
+├── hooks/                # form-hook, etc.
+├── components/
+│   ├── ui/               # ShadCN primitives + custom (route-error, inline-length-edit)
+│   └── domain/
+│       ├── todo/
+│       ├── habit/
+│       └── time-block/
+├── routes/               # File-based TanStack Router
+│   ├── __root.tsx
+│   ├── index.tsx
+│   ├── login.tsx
+│   ├── auth.verify.tsx
+│   ├── onboarding.tsx
+│   ├── dashboard.tsx
+│   ├── todos.tsx
+│   ├── habits.tsx
+│   ├── habits.index.tsx
+│   ├── habits.$habitId.tsx
+│   ├── time-blocks.tsx
+│   ├── activity-types.tsx
+│   ├── stats.tsx
+│   └── settings.tsx
+└── __generated__/        # GraphQL Codegen output (gitignored)
+    ├── gql.ts
+    └── graphql.ts
+```
+
+There is no centralized `App.tsx` — routing and providers live in `main.tsx`.
 
 ---
 
 ## 3. Database Schema
 
-### 3.1 `todos` Table
-
-| Column | Type | Constraints |
-|--------|------|-------------|
-| `id` | UUID | Primary Key, `defaultRandom()` |
-| `userId` | UUID | FK → users (cascade delete) |
-| `title` | text | notNull |
-| `description` | text | nullable |
-| `priority` | integer | default 0 |
-| `estimatedLength` | integer | notNull (minutes) |
-| `activityTypeId` | UUID | FK → activity_types (set null) |
-| `scheduledAt` | timestamp | nullable |
-| `completedAt` | timestamp | nullable |
-| `createdAt` | timestamp | defaultNow() |
-| `updatedAt` | timestamp | defaultNow() |
-
-**Inferred types:**
-```typescript
-export type Todo = typeof todos.$inferSelect;
-export type NewTodo = typeof todos.$inferInsert;
-```
-
-### 3.2 `todos` Relations
-
-- **User** (`todos.userId` → `users.id`) — cascade delete
-- **ActivityType** (`todos.activityTypeId` → `activity_types.id`) — set null on delete
-
-### 3.3 Other Tables
+Full column definitions live in `packages/db/src/models/`. Summary:
 
 **`users`**
 
-| Column | Type | Constraints |
-|--------|------|-------------|
-| `id` | UUID | Primary Key |
+| Column | Type | Notes |
+|--------|------|-------|
+| id | uuid | PK, defaultRandom |
+| email | text | notNull, unique |
+| timezone | text | notNull, default `'UTC'` (IANA zone) |
+| createdAt / updatedAt | timestamp | defaultNow |
 
 **`activity_types`**
 
-| Column | Type | Constraints |
-|--------|------|-------------|
-| `id` | UUID | Primary Key |
-| (activity type fields) | varies | per implementation |
+| Column | Type | Notes |
+|--------|------|-------|
+| id | uuid | PK |
+| userId | uuid | FK users (cascade delete) |
+| name | text | notNull |
+| color | text | notNull, default `'#6366f1'` (hex with `#`) |
+| createdAt / updatedAt | timestamp | |
+
+**`todos`**
+
+| Column | Type | Notes |
+|--------|------|-------|
+| id | uuid | PK |
+| userId | uuid | FK users (cascade delete) |
+| title | text | notNull |
+| description | text | nullable |
+| priority | integer | notNull, default 0 |
+| estimatedLength | integer | notNull (minutes; 0 = unestimated) |
+| activityTypeId | uuid | FK activity_types (set null) — currently nullable, scheduler skips items without one |
+| scheduledAt | timestamp | nullable |
+| completedAt | timestamp | nullable |
+| manuallyScheduled | boolean | notNull, default false |
+| createdAt / updatedAt | timestamp | |
 
 **`habits`**
 
-| Column | Type | Constraints |
-|--------|------|-------------|
-| `id` | UUID | Primary Key |
-| (habit-specific fields) | varies | per implementation |
+| Column | Type | Notes |
+|--------|------|-------|
+| id | uuid | PK |
+| userId | uuid | FK users (cascade delete) |
+| title | text | notNull |
+| description | text | nullable |
+| priority | integer | notNull, default 0 |
+| estimatedLength | integer | notNull |
+| activityTypeId | uuid | FK activity_types (set null) — nullable |
+| frequencyCount | integer | notNull (e.g. 3) |
+| frequencyUnit | text | notNull, `'week' \| 'month'` (typed via `$type<FrequencyUnit>`) |
+| createdAt / updatedAt | timestamp | |
 
 **`time_blocks`**
 
-| Column | Type | Constraints |
-|--------|------|-------------|
-| `id` | UUID | Primary Key |
-| (time block fields) | varies | per implementation |
+| Column | Type | Notes |
+|--------|------|-------|
+| id | uuid | PK |
+| userId | uuid | FK users (cascade delete) |
+| activityTypeId | uuid | FK activity_types (set null) — nullable |
+| daysOfWeek | integer[] | notNull (0=Sun … 6=Sat) |
+| startTime | text | `'HH:mm'` |
+| endTime | text | `'HH:mm'` |
+| priority | integer | notNull, default 0 |
+| createdAt / updatedAt | timestamp | |
 
 **`habit_completions`**
 
-| Column | Type | Constraints |
-|--------|------|-------------|
-| `id` | UUID | Primary Key |
-| (completion fields) | varies | per implementation |
+| Column | Type | Notes |
+|--------|------|-------|
+| id | uuid | PK |
+| habitId | uuid | FK habits (cascade delete) |
+| scheduledAt | timestamp | nullable — set for tentative (scheduler-generated) rows |
+| completedAt | timestamp | nullable — set for actual completions; null = tentative |
+| createdAt | timestamp | |
 
-All user-owned resources use **cascade deletes** for referential integrity. All timestamps use the Postgres `timestamp` type.
-
----
-
-## 4. GraphQL Schema
-
-The GraphQL schema is generated from the Drizzle tables via `drizzle-graphql`'s `buildSchema(db)`, then extended with custom resolvers and types.
-
-### 4.1 Query: `myTodos`
-
-Fetches the authenticated user's todos with filtering and ordering.
-
-**Input Arguments:**
-
-| Argument | Type | Description |
-|----------|------|-------------|
-| `activityTypeId` | `String` (optional) | Filter by activity type |
-| `completed` | `Boolean` (optional) | Filter by completion status |
-
-**Return type:** `[Todo!]!`
-
-**Resolver logic:**
-- Guard clause: rejects if no `context.userId`
-- Query `todos` filtered by `userId`, `activityTypeId` (if provided), and `completed` status
-- Ordered by **priority descending**, then **createdAt descending**
-
-### 4.2 Mutation: `myCreateTodo`
-
-Creates a new todo.
-
-**Input (`CreateTodoInput`):**
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `title` | `String!` | Yes | Todo title |
-| `description` | `String` | No | Optional description |
-| `priority` | `Int` | No | Default: 0 |
-| `estimatedLength` | `Int!` | Yes | Estimated duration in minutes |
-| `activityTypeId` | `String` | No | Optional activity type |
-| `scheduledAt` | `String` | No | Optional scheduled time |
-
-**Return type:** `Todo` (includes `activityType` via custom resolver)
-
-**Resolver logic:**
-1. Guard clause: rejects if no `context.userId`
-2. Zod validation: `CreateTodoInput.parse(input)` at resolver boundary
-3. Insert into `todos` with `userId` from context
-4. Returns the created todo with the associated `activityType` populated
-
-### 4.3 Mutation: `myUpdateTodo`
-
-Updates an existing todo.
-
-**Input (`UpdateTodoInput`):**
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `id` | `String!` | Yes | Todo ID to update |
-| `title` | `String` | No | New title |
-| `description` | `String` | No | New description |
-| `priority` | `Int` | No | New priority |
-| `estimatedLength` | `Int` | No | New estimated length |
-| `activityTypeId` | `String` | No | New activity type |
-| `scheduledAt` | `String` | No | New scheduled time |
-
-**Return type:** `Todo`
-
-**Resolver logic:**
-1. Auth + ownership checks
-2. Zod validation
-3. Partial update on existing todo
-4. Returns updated todo with `activityType`
-
-### 4.4 Mutation: `myCompleteTodo`
-
-Marks a todo as complete.
-
-**Input:**
-
-| Field | Type | Required |
-|-------|------|----------|
-| `id` | `String!` | Yes |
-
-**Return type:** `Todo` (with `completedAt` set)
-
-**Resolver logic:**
-1. Auth + ownership checks
-2. Update `completedAt` to current timestamp
-3. Return updated todo
-
-### 4.5 Mutation: `myDeleteTodo`
-
-Deletes a todo.
-
-**Input:**
-
-| Field | Type | Required |
-|-------|------|----------|
-| `id` | `String!` | Yes |
-
-**Return type:** `Boolean`
-
-**Resolver logic:**
-1. Auth + ownership checks
-2. Hard delete from `todos` table
-3. Returns `true` on success
-
-### 4.6 Extended Types
-
-| Type | Additional Fields |
-|------|-------------------|
-| `Todo` | `activityType: ActivityType` — resolved in custom resolver via activity lookup |
+Conventions: all PKs use `uuid`+`defaultRandom`; user-owned tables cascade-delete; optional FKs use `onDelete: 'set null'`; timestamps are `timestamp` (not `timestamptz`). Types are inferred via `$inferSelect` / `$inferInsert` — never duplicated.
 
 ---
 
-## 5. Client Components
+## 4. GraphQL Schema (high level)
 
-### 5.1 Routes
+The base schema is auto-generated from Drizzle by `@vantreeseba/drizzle-graphql`, then extended in `packages/server/src/schema/resolvers/index.ts` (`extensionSDL`) and locked down by `blockUnscopedResolvers()` so only `my*` fields and the `PUBLIC_MUTATIONS` set are reachable. Full SDL details in `graphql-patterns.md` and `server-patterns.md`.
 
-| Path | File | Query | Component |
-|------|------|-------|-----------|
-| `/todos` | `src/routes/todos.tsx` | `GET_MY_TODOS` | `<TodoList>` |
+### Queries (`my*` scoped)
 
-### 5.2 Todo Domain Components
+| Query | Notes |
+|-------|-------|
+| `myProfile` | Returns `UserProfile` (id, email, timezone) |
+| `myActivityTypes` | All activity types for the user |
+| `myTodos(activityTypeId, completed, orderBy)` | Filterable; orderBy via `TodoOrderBy` |
+| `myHabits(activityTypeId)` | |
+| `myTimeBlocks(activityTypeId, containsDay)` | |
+| `mySchedule(weekStart, timezone)` | Live-recomputed schedule for the week (see `scheduling.md`) |
+| `myStats(startDate, endDate)` | Composite + per-habit + todo summary |
+| `myHabitDetail(habitId, periods)` | Per-period rates for a habit |
+| `activityTypeStats(startDate, endDate)` | |
+| `habitStats(habitId, startDate, endDate)` | |
 
-#### `<TodoList>` — `src/components/domain/todo/TodoList.tsx`
+### Mutations (`my*` scoped)
 
-- Displays the `GET_MY_TODOS` data via `Todo_TodoListFragment` fragment
-- Provides controls to show/hide completedTodos
-- "New Todo" button to open the create dialog
+| Domain | Mutations |
+|--------|-----------|
+| Profile | `myUpdateProfile` |
+| Activity types | `myCreateActivityType`, `myUpdateActivityType`, `myDeleteActivityType` |
+| Todos | `myCreateTodo`, `myUpdateTodo`, `myCompleteTodo`, `myDeleteTodo` |
+| Habits | `myCreateHabit`, `myUpdateHabit`, `myDeleteHabit`, `myCompleteHabit` |
+| Time blocks | `myCreateTimeBlock`, `myUpdateTimeBlock`, `myDeleteTimeBlock` |
+| Schedule | `myReschedule` (only mutation that **awaits** the writeback) |
 
-#### `<TodoItem>` — `src/components/domain/todo/TodoItem.tsx`
+### Public mutations (no auth)
 
-- Card displaying a single todo with:
-  - **Title** — primary display text
-  - **Activity type badge** — color-coded by activity
-  - **Estimated length** — displayed as duration
-  - **Priority** — shown visually by level
-  - **Completion state** — clickable completion toggle
-- Uses the `COMPLETE_TODO` mutation for inline completion
-- Accepts an `onEdit` callback to open the edit form
+`requestMagicLink(email)` → `RequestMagicLinkResult { ok, magicLink }`
+`verifyMagicLink(token)` → `VerifyMagicLinkResult { token, userId }`
 
-#### `<TodoForm>` — `src/components/domain/todo/TodoForm.tsx`
+`PUBLIC_MUTATIONS` is a hard-coded set in `packages/server/src/schema/index.ts`; new public endpoints must be added there.
 
-- Dialog-based form for creating and updating todos
-- Fields:
-  - **Title** — text input
-  - **Description** — text area
-  - **Activity type** — `ActivityTypeSelect` dropdown
-  - **Priority** — selector (Low / Medium / High / Urgent)
-  - **Duration** — range selector (15 min to 480 min)
-- Handles both creation and update via `CREATE_TODO` and `UPDATE_TODO` mutations
+### Custom types
 
-### 5.3 ShadCN UI Components (used by todo components)
+`ScheduledItem`, `StatsOverview`, `HabitStatSummary`, `TodoStatSummary`, `HabitDetail`, `HabitPeriod`, `ActivityTypeStats`, `HabitStats`, `UserProfile`, `RequestMagicLinkResult`, `VerifyMagicLinkResult`. See `extensionSDL` for the source-of-truth definitions.
 
-`Button`, `Card`, `Dialog`, `Form`, and related primitives from `src/components/ui/`.
+### Field resolvers
 
----
-
-## 6. Server Resolvers — Todo Implementation
-
-Todo resolvers live in `packages/server/src/schema/resolvers.ts` and follow a consistent pattern:
-
-### Resolver Pipeline
-
-```
-Resolver entry point
-  → Guard clause (auth check: if (!context.userId) throw)
-  → Guard clause (ownership check: userId === context.userId)
-  → Zod validation (parse input at boundary)
-  → Database operation (drizzle query)
-  → Return result with custom joins (activityType)
-```
-
-### Key Implementation Details
-
-1. **Schema extension** — Each resolver adds SDL to the auto-generated base schema:
-   ```typescript
-   const extended = extendSchema(schema, parse(`
-     extend type Query { myTodos: [todos!]! }
-     extend type Mutation { myCreateTodo(...): Todo }
-   `));
-   ```
-
-2. **Activity type resolution** — The `activityType` field on `Todo` is resolved in the custom resolver by joining to `activity_types`, not in the base drizzle-graphql schema.
-
-3. **Zod validation** — All mutation inputs use Zod schemas at the resolver boundary:
-   ```typescript
-   const input = CreateTodoInput.parse(args.input);
-   ```
-
-4. **Error handling** — Never suppressed. Fail fast:
-   ```typescript
-   if (!context.userId) throw new Error('Not authenticated');
-   if (todo.userId !== context.userId) throw new Error('Forbidden');
-   ```
+`activityType` is field-resolved on `Todo`, `Habit`, and `TimeBlock` via a per-request `DataLoader` (`context.loaders.activityType`) to prevent N+1.
 
 ---
 
-## 7. Key Patterns
+## 5. Client Routes
 
-### Type Inference (No Manual Duplication)
+| Path | File | Purpose |
+|------|------|---------|
+| `/` | `index.tsx` | Landing/redirect |
+| `/login` | `login.tsx` | Magic-link request form |
+| `/auth/verify` | `auth.verify.tsx` | Consumes magic-link token, stores JWT |
+| `/onboarding` | `onboarding.tsx` | 4-step wizard (activity types → time blocks → habits → todos) |
+| `/dashboard` | `dashboard.tsx` | Calendar + schedule sidebar |
+| `/todos` | `todos.tsx` | Todo list |
+| `/habits` | `habits.tsx` + `habits.index.tsx` | Habit list |
+| `/habits/$habitId` | `habits.$habitId.tsx` | Habit detail (rates, periods) |
+| `/time-blocks` | `time-blocks.tsx` | Time block CRUD |
+| `/activity-types` | `activity-types.tsx` | Activity type CRUD |
+| `/stats` | `stats.tsx` | Analytics surface (todo.md #9) |
+| `/settings` | `settings.tsx` | iCal feed URL, re-run onboarding |
 
-Types are inferred directly from the Drizzle schema:
-
-```typescript
-export type Todo = typeof todos.$inferSelect;
-export type NewTodo = typeof todos.$inferInsert;
-```
-
-These are re-exported from `packages/db/src/models/index.ts` and consumed by the server and client packages.
-
-### Enum Pattern
-
-```typescript
-// packages/db/src/models/enums.ts
-export const ACTIVITY_TYPES = ['work', 'exercise', 'learning'] as const;
-export type ActivityType = (typeof ACTIVITY_TYPES)[number];
-```
-
-### Validation Pattern (Zod at Resolver Boundary)
-
-Every mutation validates its input with Zod before touching the database:
-
-```typescript
-const input = CreateTodoInput.parse(args.input); // throws ZodError if invalid
-```
-
-### Guard Clause Pattern
-
-Checks are performed in order — auth, existence, ownership — with early returns:
-
-```typescript
-// 1. Auth
-if (!context.userId) throw new Error('Not authenticated');
-
-// 2. Existence
-const todo = await context.db.query.todos.findFirst({
-  where: eq(todos.id, id),
-});
-if (!todo) throw new Error(`Todo ${id} not found`);
-
-// 3. Ownership
-if (todo.userId !== context.userId) throw new Error('Forbidden');
-```
-
-### drizzle-graphql Schema Generation
-
-The base GraphQL schema is auto-generated from the Drizzle tables, then extended:
-
-```typescript
-const drizzleSchema = buildSchema(db);    // auto-generated from tables
-export const schema = applyCustomResolvers(drizzleSchema); // extend with custom logic
-```
-
-This eliminates the need to manually write type fields, query definitions, and mutation signatures for CRUD operations.
-
-### UUID for All IDs
-
-Every primary key uses `uuid` with `pgUUID` and `defaultRandom()`. No auto-incrementing integers.
-
-### GraphQL Operations Colocated with Components
-
-Operations use `gql` from `@apollo/client` and live alongside the components that consume them. There is no centralized `queries.ts` file.
-
-### GraphQL Codegen
-
-TypeScript types for GraphQL operations are auto-generated and kept in `src/__generated__/`:
-- `gql.ts` — compiled GraphQL operations
-- `graphql.ts` — TypeScript types
-
-Regenerate after adding/modifying operations:
-
-```bash
-npm run codegen  # requires server running
-```
+The auth guard lives in `__root.tsx` — redirects to `/login` without a token, `/onboarding` if `localStorage.onboarding_done` is unset.
 
 ---
 
-## 8. Generated Types Structure
-
-Generated code lives in `packages/client/src/__generated__/` and is **gitignored** (never committed).
+## 6. Server Resolver Pipeline
 
 ```
-packages/client/src/__generated__/
-├── gql.ts        # Compiled GraphQL operations (~30 operations, ~520 lines)
-└── graphql.ts    # TypeScript types for operations (~200 lines)
+Request
+  → Apollo context: extract Bearer token → JWT verify → fall back to raw-UUID (dev-only) → set context.userId
+  → Resolver entry
+    → Guard: if (!context.userId) throw 'Not authenticated'
+    → For mutations on existing rows: fetch row, check ownership, throw 'Forbidden' if mismatch
+    → Zod validation: <Input>.parse(args.input)
+    → Drizzle query
+    → For mutations that affect schedule: runSchedulerWriteback(db, userId).catch(console.error)  // fire-and-forget (myReschedule is the only awaited one)
+    → Return row; field resolvers (activityType) lazily load via DataLoader
 ```
 
-### How Types Flow Through the Stack
+Resolvers are split per-domain under `schema/resolvers/`. New domains follow the same pattern: SDL in `extensionSDL` (`schema/resolvers/index.ts`), `apply<Domain>Resolvers(queryFields, mutationFields)` in a sibling file, wired in `applyCustomResolvers`.
 
-```
-1. GraphQL operations (gql tagged) in components
-       ↓
-2. GraphQL Codegen reads operations
-       ↓
-3. graphql.ts — TypeScript types generated (queries, mutations, inputs)
-       ↓
-4. TypeScript types consumed by components via auto-import
-```
+---
 
-The generated `graphql.ts` types include:
-- Typed query results (e.g., `GetMyTodosQuery`, `GetMyTodosQueryVariables`)
-- Typed mutation inputs/outputs (e.g., `CreateTodoMutation`, `UpdateTodoMutation`)
-- Fragment types for component data requirements
+## 7. Tests
 
-### Regenerating Types
+There are existing vitest suites — the project is not test-free:
 
-```bash
-npm run codegen
-```
+- `packages/server/src/auth.test.ts` — magic-link token + JWT helpers
+- `packages/server/src/schema/validators.test.ts` — Zod validator coverage
+- `packages/server/src/services/scheduler.test.ts` — pure scheduler algorithm
 
-Requires the GraphQL server to be running (port 4000).
+Run with `npm test`. todo.md #15 ("test suite") covers the gaps that remain (resolver integration tests, CI workflow, coverage targets).
+
+---
+
+## 8. Generated Code
+
+| Location | What | Regenerate |
+|----------|------|------------|
+| `packages/server/src/__generated__/schema.graphql` | Full SDL (drizzle-generated + extensions) | `npm run codegen:server` |
+| `packages/server/src/__generated__/resolvers.ts` | Resolver types | `npm run codegen:server` |
+| `packages/client/src/__generated__/gql.ts` + `graphql.ts` | Typed operations + result types | `npm run codegen` (requires server running on :4000) |
+
+All `__generated__/` directories are gitignored.
 
 ---
 
 ## 9. Commands
 
-### Development
-
-| Command | Description |
-|---------|-------------|
-| `npm run dev` | Start everything (frontend + backend) via concurrently |
-| `npm run dev:server` | Start GraphQL server only (localhost:4000) |
-| `npm run dev:client` | Start React client only (localhost:3000) |
-
-### Type Checking & Linting
-
-| Command | Description |
-|---------|-------------|
-| `npm run typecheck` | `tsc --noEmit` across all packages |
-| `npm run lint` | `biome check .` |
-| `npm run lint:fix` | `biome check --apply .` |
-
-### Database
-
-| Command | Description |
-|---------|-------------|
-| `npm run db:generate` | `drizzle-kit generate` (after schema changes) |
-| `npm run db:migrate` | `drizzle-kit migrate` |
-| `npm run db:studio` | Open Drizzle Studio GUI |
-
-### GraphQL
-
-| Command | Description |
-|---------|-------------|
-| `npm run codegen` | Generate TypeScript types from GraphQL operations (requires server running) |
-
-### Build & Deploy
-
-| Command | Description |
-|---------|-------------|
-| `npm run build` | Build client and server for production |
-| `npm run build:docker` | Build Docker image |
-| `npm test` | Run vitest |
-
----
-
-## Appendix: Directory Tree (High-Level)
-
-```
-auto-cal/
-├── AGENTS.md
-├── AGENTS.md
-├── sst.config.ts
-├── package.json
-├── pnpm-workspace.yaml
-├── packages/
-│   ├── db/
-│   │   ├── src/
-│   │   │   ├── index.ts          # PGLite singleton
-│   │   │   └── models/
-│   │   │       ├── enums.ts
-│   │   │       ├── index.ts      # Re-exports
-│   │   │       ├── users.ts
-│   │   │       ├── todos.ts
-│   │   │       ├── activity_types.ts
-│   │   │       ├── habits.ts
-│   │   │       ├── time_blocks.ts
-│   │   │       └── habit_completions.ts
-│   │   └── drizzle/
-│   │       └── migrations/
-│   ├── server/
-│   │   └── src/
-│   │       ├── index.ts
-│   │       ├── context.ts
-│   │       └── schema/
-│   │           ├── index.ts
-│   │           └── resolvers.ts
-│   └── client/
-│       └── src/
-│           ├── main.tsx
-│           ├── App.tsx
-│           ├── lib/
-│           │   └── utils.ts
-│           ├── __generated__/
-│           │   ├── gql.ts
-│           │   └── graphql.ts
-│           ├── components/
-│           │   ├── domain/todo/
-│           │   │   ├── TodoList.tsx
-│           │   │   ├── TodoItem.tsx
-│           │   │   └── TodoForm.tsx
-│           │   └── ui/
-│           └── routes/
-│               └── todos.tsx
-└── .agentic/
-    └── project-structure.md       # ← This file
-```
+| Command | Purpose |
+|---------|---------|
+| `npm run dev` | Frontend + backend (concurrently) |
+| `npm run dev:server` | API only on :4000 |
+| `npm run dev:client` | Vite on :3000 |
+| `npm run typecheck` | `tsc --noEmit` across packages |
+| `npm run lint` / `lint:fix` | Biome |
+| `npm test` | vitest |
+| `npm run db:generate` | drizzle-kit generate (after schema changes) |
+| `npm run db:migrate` | Apply pending migrations |
+| `npm run db:studio` | Drizzle Studio GUI |
+| `npm run codegen` | Client GraphQL codegen (server must be up) |
+| `npm run codegen:server` | Emit server SDL + resolver types |
+| `npm run build` | codegen + Vite + tsc |
+| `npm run build:docker` | `docker build -t auto-cal .` |

--- a/.agents/scheduling.md
+++ b/.agents/scheduling.md
@@ -9,6 +9,7 @@ The scheduler auto-assigns `scheduledAt` timestamps to todos and habit instances
 | File | Role |
 |------|------|
 | `packages/server/src/services/scheduler.ts` | Pure scheduling algorithm — no DB calls |
+| `packages/server/src/services/scheduler.test.ts` | Vitest coverage of `computeSchedule` |
 | `packages/server/src/services/scheduler-writeback.ts` | Fetches data, runs the algorithm, writes results back |
 
 ## Algorithm (`computeSchedule`)
@@ -18,7 +19,7 @@ The scheduler auto-assigns `scheduledAt` timestamps to todos and habit instances
 3. Sort all tasks (todos + habit instances) by **priority DESC**, then **estimatedLength ASC**
 4. For each task, find the first slot for its `activityTypeId` with enough remaining capacity (`effectiveSlotStart`)
    - Habit instances additionally try to spread across different days before falling back to any available slot
-5. Return `ScheduledItem[]` with `scheduledStart`/`scheduledEnd` as naive ISO strings (`YYYY-MM-DDTHH:mm:ss`, no `Z`) so browsers interpret them as local time
+5. Return `ScheduledItem[]` with `scheduledStart`/`scheduledEnd` as naive ISO strings (`YYYY-MM-DDTHH:mm:ss`, no `Z`) so browsers interpret them as local time. **Note:** the naive-string convention is a stopgap until proper UTC + timezone handling lands — see todo.md #3.
 
 ## Writeback (`runSchedulerWriteback`)
 

--- a/.agents/server-patterns.md
+++ b/.agents/server-patterns.md
@@ -6,9 +6,21 @@ Express + Apollo Server, no build step (`--experimental-strip-types`). All impor
 
 `seedDemoUser()` always runs on startup. `seedDemoData()` runs in non-production and is idempotent (skips if the demo user already has activity types). Demo seed creates 3 activity types (Work, Exercise, Learning), 6 time blocks, 5 todos, 3 habits.
 
-## Auth — UUID Bearer Fallback (Dev Only)
+## Auth — UUID Bearer Fallback (Dev Only, currently active in prod too — see todo.md #25)
 
-The server context accepts a raw UUID as a Bearer token for backwards compatibility with the demo user (`DEMO_USER_ID`). **This fallback must be removed before production deployment** (guard with `NODE_ENV !== 'production'` or remove entirely once real auth replaces the demo user flow). See `packages/server/src/index.ts`.
+The server context accepts a raw UUID as a Bearer token for backwards compatibility with the demo user (`DEMO_USER_ID`). The fallback runs in **all environments today** — there is no `NODE_ENV` guard. The check lives in `packages/server/src/index.ts` after JWT verification fails:
+
+```typescript
+// Try JWT first
+const payload = await verifyToken(rawToken);
+if (payload?.sub) return { db, userId: payload.sub, loaders };
+
+// Fall back to raw UUID for backwards-compat with dev/seed
+if (/^[0-9a-f-]{36}$/i.test(rawToken))
+  return { db, userId: rawToken, loaders };
+```
+
+This must be guarded with `NODE_ENV !== 'production'` (or removed) before any real public deployment. Tracked in `todo.md` #25.
 
 ## mySchedule vs DB scheduledAt
 
@@ -136,7 +148,7 @@ if (todo.userId !== context.userId) throw new Error('Forbidden');
 
 ## Zod Validation at Resolver Boundary
 
-All validators live in `packages/server/src/schema/validators.ts`. Key constraints:
+All validators live in `packages/server/src/schema/validators.ts`, with coverage in `packages/server/src/schema/validators.test.ts`. Key constraints:
 
 | Field | Rule |
 |-------|------|
@@ -243,4 +255,14 @@ export function computeSchedule(
 ): ScheduledItem[] { ... }
 ```
 
-Pure function — deterministic, easy to unit test.
+Pure function — deterministic, easy to unit test. Coverage in `packages/server/src/services/scheduler.test.ts`.
+
+## Tests
+
+The server package has the following vitest suites — run with `npm test` from the repo root:
+
+- `packages/server/src/auth.test.ts` — magic-link token + JWT helpers
+- `packages/server/src/schema/validators.test.ts` — Zod validator coverage
+- `packages/server/src/services/scheduler.test.ts` — pure scheduler algorithm
+
+Resolver-level integration tests (PGLite in-memory) are not yet in place — see todo.md #15.

--- a/.agents/todo.md
+++ b/.agents/todo.md
@@ -6,26 +6,31 @@
 
 ## Recommended starting points
 
-If you're unsure what to work on, these three are the highest-leverage next steps:
+If you're unsure what to work on, these are the highest-leverage next steps (#17 has shipped, removed from this list):
 
-1. **#17 — Seed data** — makes development and demos usable in minutes (2-3 hours)
-2. **#7 — Weekly navigation on dashboard** — obvious UX gap any user will hit immediately (half day)
-3. **#19 — Completion datetime dialog** — core UX for completing tasks accurately (1 day)
+1. **#7 — Weekly navigation on dashboard** — obvious UX gap any user will hit immediately (half day)
+2. **#19 — Completion datetime dialog** — core UX for completing tasks accurately (1 day)
+3. **#21 — Activity type required (residual)** — closes the silent "item never schedules" failure mode for new todos/habits
 
 ---
 
 ## P0 — Core correctness / blocking
 
-### #21 — Remove isPinnedSchedule, make activity type required, add drag-to-schedule
-**Problem:** `isPinnedSchedule` adds complexity with no defined behavior. Activity type is currently optional, making items unschedulable by default. There is no way to manually place an item on the calendar.
+### #21 — Make activity type required on todos and habits
+**Status:** Originally bundled `isPinnedSchedule` removal, drag-to-schedule, and activity-type-required. The first two have shipped:
+- `manuallyScheduled` is the live signal (`todos.manually_scheduled` boolean, default false). `isPinnedSchedule` never made it into the schema.
+- Drag-to-reschedule is live for todos in `CalendarView` (see #4).
+
+**What's left:** Activity type is still nullable in the database and accepted as `undefined` by the form Zod schemas (`activityTypeId: z.string().uuid().or(z.undefined())` in both `TodoForm.tsx` and `HabitForm.tsx`). The scheduler silently skips items without an activity type, which is the user-visible bug.
+
 **Spec:** See `specifications.md` → "Scheduler" section.
 **Work:**
-- Replace `isPinnedSchedule` with `manuallyScheduled` boolean on `todos` (and equivalent on `habit_completions`): set true when user drags the item, false when scheduler places it; manually scheduled items resist eviction by lower-priority auto-scheduler runs but can still be bumped by a higher-priority item
-- Make `activityTypeId` non-nullable on `todos` and `habits` tables + migration
-- Enforce activity type selection in `TodoForm` and `HabitForm` (required field, block save without it)
-- Implement drag-to-schedule on `CalendarView` (react-big-calendar DnD addon); on drop call `myUpdateTodo`/`myUpdateHabit` with the new `scheduledAt`; dragged items outside time blocks are allowed
+- Make `activityTypeId` `notNull` on `todos` and `habits` tables + migration (handle existing nulls — backfill or block)
+- Update Zod inputs (`CreateTodoInput`, `UpdateTodoInput`, `CreateHabitInput`, `UpdateHabitInput`) to require `activityTypeId`
+- Update `TodoForm` and `HabitForm` Zod + UI to require selection (block save without it; show inline validation)
+- Surface the migration concern: existing rows with null `activityTypeId` need a strategy (e.g. assign to a default "General" activity type per user, or block migration if any exist)
 
-**Acceptance:** Saving a todo without an activity type is blocked. Dragging a todo to any calendar slot updates its scheduled time. `isPinnedSchedule` is gone everywhere.
+**Acceptance:** Saving a todo or habit without an activity type is blocked at form, resolver, and DB layers. Existing data either has a default applied or migration is gated until cleaned up.
 
 ---
 
@@ -54,28 +59,40 @@ If you're unsure what to work on, these three are the highest-leverage next step
 
 **Acceptance:** Completing a todo early moves it on the calendar and immediately schedules something else in the freed slot. Uncompleting returns it to the queue.
 
-### #1 — Real authentication (magic link + JWT)
-**Problem:** The app currently hard-codes a demo user ID sent as a Bearer token. There is no real login or user isolation.  
-**Work:**
-- Add magic-link email flow (e.g. Resend or Nodemailer)
-- Issue signed JWTs on login; verify in server context
-- Store sessions (or keep stateless with short-lived tokens)
-- Replace `DEMO_USER_ID` env var with real token extraction
-- Add a login/signup page in the client
+### #1 — Wire magic-link email delivery (auth is otherwise live)
+**Status:** Magic-link + JWT auth is implemented end-to-end:
+- `requestMagicLink` / `verifyMagicLink` mutations exist (`packages/server/src/schema/resolvers/auth.ts`)
+- JWT sign/verify via `jose` in `packages/server/src/auth.ts`
+- Login flow (`/login`) and verify route (`/auth/verify`) live in the client
+- Apollo client attaches `Bearer <token>` from `localStorage.auth_token`; expired-auth errors redirect to `/login`
+- Server context extracts JWT first, falls back to raw UUID for dev/seed (see #25)
 
-**Acceptance:** A new user can sign up via email, log in with a magic link, and see only their own data.
+**What's left:** The magic link is logged to the server console but no email is actually sent. In dev the `requestMagicLink` mutation also returns the link in the response; in prod the response has `magicLink: null`.
+
+**Work:**
+- Pick a provider (Resend or Nodemailer) and wire the send call in `requestMagicLink`'s resolver where the `// TODO: send email` comment lives
+- Provider creds in env (`RESEND_API_KEY` or SMTP equivalent)
+- Keep console logging as a fallback when no provider is configured
+
+**Acceptance:** Requesting a magic link in production triggers an actual email; dev can still use console-logged links when no provider is set.
 
 ---
 
-### #3 — Timezone handling
-**Problem:** The scheduler returns naive ISO strings with no timezone suffix ("local time"). With a real multi-user deployment, times need to be stored in UTC and displayed in the user's local timezone.  
-**Work:**
-- Store all timestamps as UTC in Postgres (already the default — but verify)
-- Add a `timezone` field to the `users` table (IANA zone string)
-- Accept `weekStart` in the user's local timezone in `mySchedule`; convert to UTC before querying
-- Return UTC from the API; convert to local time in the client using `date-fns-tz` or `Intl`
+### #3 — Finish UTC migration (partially shipped)
+**Status:** Partially done.
+- `users.timezone` column exists (IANA string, default `'UTC'`)
+- `mySchedule` accepts a `timezone` argument; client syncs the browser timezone via `myUpdateProfile` on dashboard mount
+- iCal endpoint converts naive datetimes to UTC via `fromZonedTime(datetime, user.timezone)` from `date-fns-tz`
 
-**Acceptance:** A user in UTC-5 and a user in UTC+9 both see the correct local times for the same schedule.
+**What's left:** The GraphQL API still returns naive datetime strings (`YYYY-MM-DDTHH:mm:ss`, no `Z`) and relies on the browser interpreting them as local time. This is the stopgap that needs to go away.
+
+**Work:**
+- Switch the scheduler / `mySchedule` to emit UTC ISO strings (`Z` suffix or explicit offset)
+- Verify `scheduledAt` / `completedAt` are stored as true UTC in the DB (not naive)
+- Convert UTC → user.timezone client-side using `date-fns-tz` or `Intl.DateTimeFormat`
+- Update `CalendarView` and `ScheduleView` to do the conversion at render time
+
+**Acceptance:** Two browsers in different timezones, hitting the same backend, both render the schedule in their respective local times correctly. The naive-string convention is gone from the API surface.
 
 ---
 
@@ -141,12 +158,15 @@ Drag-and-drop is implemented for todos in `CalendarView`. Dragging a todo sets `
 
 ---
 
-### #9 — Analytics page
-**Problem:** The `activityTypeStats` and `habitStats` queries exist but nothing is surfaced beyond raw numbers. There is no `/analytics` route.
+### #9 — Analytics page on `/stats`
+**Note:** The route is `/stats`, not `/analytics` — the existing `/stats` route IS the surface this item describes; there is no separate `/analytics` planned.
+
+**Status:** A `/stats` route exists with a `StatsOverview` component backed by the `myStats` query (composite score + per-habit summary + todo summary). Charts and the full layout below are not yet built out.
+
 **Spec:** See `specifications.md` → "Analytics" section.
 **Work:**
 - Install shadcn charts (Recharts 3); do not add a second charting library
-- Add `/analytics` route and nav link; rename "Dashboard" nav link to "Calendar"
+- Verify the "Dashboard" nav rename to "Calendar" — confirm/adjust as needed
 - **Composite score** at top: weighted average of habit consistency + todo completion rate, displayed as % with a plain-English label
 - **Habit consistency section**: bar chart (one bar per habit, completion rate % capped at 100%, colored by activity type); click a bar to expand a week-by-week trend line
 - **Time distribution section**: grouped bar or donut chart — scheduled time vs completed time side-by-side per activity type
@@ -154,7 +174,7 @@ Drag-and-drop is implemented for todos in `CalendarView`. Dragging a todo sets `
 - All sections share a single fixed time-range filter: This week / This month / Last 3 months / All time
 - All data real-time (no caching layer yet)
 
-**Acceptance:** User can open `/analytics`, select "Last 3 months", and see habit rates, time distribution, and todo throughput with working charts. Clicking a habit bar shows its week-by-week trend.
+**Acceptance:** User can open `/stats`, select "Last 3 months", and see habit rates, time distribution, and todo throughput with working charts. Clicking a habit bar shows its week-by-week trend.
 
 ---
 
@@ -240,38 +260,38 @@ Drag-and-drop is implemented for todos in `CalendarView`. Dragging a todo sets `
 
 ## P3 — Infrastructure & DX
 
-### #15 — Test suite (unit + integration)
-**Problem:** There are zero automated tests. The scheduling algorithm, resolvers, and Zod validators are completely untested.  
-**Work:**
-- Unit tests for `scheduler.ts` with known fixture inputs (Vitest)
-- Integration tests for all custom resolvers using PGLite in-memory
-- Snapshot/type tests for Zod validators
-- Set up a CI workflow (GitHub Actions) that runs `npm test` and `npm run typecheck`
+### #15 — Expand test suite + CI
+**Status:** Partially done. Existing vitest suites:
+- `packages/server/src/auth.test.ts` — JWT + magic-link helpers
+- `packages/server/src/schema/validators.test.ts` — Zod validators
+- `packages/server/src/services/scheduler.test.ts` — pure scheduler algorithm
 
-**Acceptance:** `npm test` passes with >80% coverage on the scheduler and resolvers; CI blocks merges on failure.
+**What's left:**
+- Resolver integration tests (PGLite in-memory) for the `my*` mutations and queries
+- Client component / route smoke tests
+- CI workflow (GitHub Actions) that runs `npm run typecheck`, `npm run lint`, `npm test` on PRs and blocks merges on failure
+- Coverage targets (e.g. >80% on scheduler / resolvers)
 
----
-
-### #16 — Replace PGLite with full Postgres for production
-**Problem:** PGLite is a single-process embedded database. It cannot handle concurrent connections, making it unsuitable for a multi-user hosted deployment.  
-**Work:**
-- Add a `DATABASE_URL` env var and switch the DB driver based on it
-- Test migrations against real Postgres
-- Update Docker Compose to include a Postgres service
-- Document the swap in AGENTS.md
-
-**Acceptance:** `docker compose up` starts the app backed by real Postgres; PGLite still works for local dev without `DATABASE_URL`.
+**Acceptance:** PRs cannot merge with failing typecheck/lint/tests; resolver and validator paths are exercised end-to-end via PGLite.
 
 ---
 
-### #17 — Seed data for development
-**Problem:** The seed file creates a demo user but no sample todos, habits, or time blocks. Starting the app for the first time shows an empty state with no guidance.  
-**Work:**
-- Extend `seed.ts` with realistic sample data (3 activity types, 5 todos, 3 habits, 6 time blocks)
-- Guard with `NODE_ENV !== 'production'` check
-- Add a `npm run db:seed` script
+### #16 — Postgres production path (dual-backend shipped, end-to-end test pending)
+**Status:** The driver switch is implemented — `packages/db/src/index.ts` selects `postgres.js` when `DATABASE_URL` is set, PGLite otherwise. `.env.example` and `docker-compose.yml` cover both modes.
 
-**Acceptance:** Running `npm run db:seed` populates a useful demo state; the dashboard is non-empty on first load.
+**What's left:**
+- Run migrations against a real Postgres instance and confirm there are no PGLite-specific oddities (e.g. array column behavior in `time_blocks.daysOfWeek`)
+- Smoke-test the app under a real Postgres deployment (concurrency, connection pooling)
+- Decide on a connection-pool config (pg pool defaults, or pgBouncer)
+
+**Acceptance:** A real Postgres deployment runs the full app without surprises; PGLite remains the no-config dev default.
+
+---
+
+### #17 — Seed data for development ✓ Done
+`seedDemoData()` in `packages/db/src/seed.ts` creates 3 activity types (Work / Exercise / Learning), 6 time blocks, 5 todos, 3 habits, all guarded by `NODE_ENV !== 'production'` and idempotent. It runs automatically on server start in dev (see `packages/server/src/index.ts`). A standalone `npm run db:seed` script is **not** wired up — the only entry point is the server-startup hook.
+
+If a CLI seed entry is wanted, `packages/db/src/seed-runner.ts` exists as the scaffolding; just add the `db:seed` script to `package.json`.
 
 ---
 


### PR DESCRIPTION
## Summary

Audit pass over the `.agents/*.md` reference docs and `todo.md` to bring them back in sync with what the code actually does. Eight focused commits, one per file, no code changes.

The big drift items:

- **`project-structure.md`** had stale architecture (referenced `App.tsx`, `sst.config.ts`, `pnpm-workspace.yaml`, `.agentic/` typo, single `resolvers.ts` file). Rewritten with the real layout, full DB column tables, complete mutation inventory (16 `my*` + 2 public), and a Tests section.
- **`todo.md`** had several items wildly out of sync with reality:
  - #1 "real auth" — magic-link + JWT + login flow are live; only email delivery remains.
  - #3 "timezone" — `users.timezone`, `mySchedule` timezone arg, and iCal conversion all shipped; what's left is the API switch from naive ISO to UTC.
  - #9 "analytics" — the route is `/stats`, not `/analytics`. Same surface.
  - #15 "tests" — three vitest suites already exist (auth, validators, scheduler); only resolver integration tests + CI remain.
  - #17 "seed data" — ✓ Done; `seed.ts` already creates the documented fixtures.
  - #21 "isPinnedSchedule / activity-type required / drag-to-schedule" — drag-to-schedule and `manuallyScheduled` shipped; `isPinnedSchedule` never made it into the schema; **only the activity-type-required half remains** (forms still accept undefined `activityTypeId`, DB column is still nullable).
- Smaller fixes: server-patterns clarifies the UUID fallback is active in prod (no `NODE_ENV` guard), client-patterns corrects component count and expands the routes table, scheduling notes the naive-string stopgap, deployment pastes the actual Dockerfile CMD, db-patterns documents the seed entry points, graphql-patterns adds missing `UpdateTodoArgs` fields.

## Test plan

- [x] `npm run lint` passes
- [ ] Manual readthrough of each modified `.agents/*.md` for tone/format consistency
- [ ] Spot-check that `todo.md` priority groupings still make sense after status updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)