### PR TITLE
feat(#21): require activity type on todos, habits, time blocks

### DIFF
--- a/.agents/plan-21-activity-type-required.md
+++ b/.agents/plan-21-activity-type-required.md
@@ -1,0 +1,67 @@
+# Plan: #21 — Make activity type required on todos and habits
+
+**Branch:** `feat/activity-type-required`
+**Scope:** Closes the silent "item never schedules" failure mode by requiring `activityTypeId` at form, resolver, and DB layers.
+
+## Goal
+
+Today, both `todos.activityTypeId` and `habits.activityTypeId` are nullable; the form Zod schemas accept `undefined`; the scheduler silently skips items without an activity type. Make activity type required end-to-end so the failure mode is impossible to enter.
+
+## Decisions (locked)
+
+1. **Null-row migration strategy: DELETE null rows** from `todos`, `habits`, `time_blocks`. Destructive. Single-user hobby DB; user explicitly chose this over backfill.
+2. **Bundle `time_blocks.activityTypeId` notNull**: yes. Same migration touches all three tables.
+3. **Empty-state UX**: link to `/activity-types` from the form when no activity types exist. No inline-create.
+
+Additional decision made during planning:
+- **FK `onDelete` behavior on `activity_types`**: change from `'set null'` to `'restrict'` for `todos.activity_type_id`, `habits.activity_type_id`, `time_blocks.activity_type_id`. With the column becoming `NOT NULL`, `set null` is no longer valid. `restrict` blocks deletion of an activity type that has dependents — surfaces a clear error rather than silent data loss. UX layer can add a "you have N todos using this — reassign or delete first" message later (separate PR).
+
+## Work units
+
+1. **DB migration: delete + notNull + restrict**
+   - Update Drizzle models (`todos.ts`, `habits.ts`, `time_blocks.ts`) to add `.notNull()` on `activityTypeId` and change `onDelete: 'set null'` to `onDelete: 'restrict'`
+   - `npm run db:generate` to scaffold the migration file
+   - Hand-edit the generated migration to prepend `DELETE FROM <table> WHERE activity_type_id IS NULL;` for `time_blocks`, `todos`, `habits` (in that order; `habits` cascades to `habit_completions`, fine)
+   - User runs `npm run db:migrate` themselves (don't apply unprompted)
+
+2. **Tighten server-side Zod validators** (`packages/server/src/schema/validators.ts`)
+   - `CreateTodoInput.activityTypeId`: required (drop `.optional()`)
+   - `UpdateTodoInput.activityTypeId`: required when present (drop `.nullable()`, keep `.optional()` for partial updates)
+   - Same for `CreateHabitInput` / `UpdateHabitInput` / `CreateTimeBlockInput` / `UpdateTimeBlockInput`
+   - Update `validators.test.ts` to cover the new required-field behavior
+
+3. **Tighten client-side form validation**
+   - `TodoForm.tsx` Zod: `activityTypeId: z.string().uuid()` (drop `.or(z.undefined())`)
+   - `HabitForm.tsx` Zod: same
+   - `TimeBlockForm.tsx` Zod: same (verify current state)
+   - Add inline error rendering on the field
+   - Add empty-state copy when `activityTypes.length === 0` with a link to `/activity-types`
+
+4. **GraphQL SDL update** (`schema/resolvers/index.ts`)
+   - Mark `activityTypeId` as `ID!` (non-nullable) on `CreateTodoArgs`, `CreateHabitArgs`, `CreateTimeBlockArgs`
+   - On the `Update*Args` inputs keep it nullable for partial-update reasons (the resolver / Zod handles required-on-create)
+   - Mark `Todo.activityTypeId`, `Habit.activityTypeId`, `TimeBlock.activityTypeId` as `String!` in the auto-generated types — actually this is drizzle-generated, may just flip when the column becomes notNull, verify
+
+5. **Scheduler simplification (optional)**
+   - The scheduler currently has guards for `if (!item.activityTypeId)` skips. Once required, those branches become unreachable and can be removed. Low priority — leave for a follow-up.
+
+6. **Client codegen**
+   - Run `npm run codegen:server` then `npm run codegen` after SDL changes
+
+## Quality gates
+
+- `npm run typecheck` (will catch any client code that assumed activityTypeId could be null)
+- `npm run lint`
+- `npm test` (validators tests should be updated)
+- Manual smoke: create a new todo without selecting an activity type → should be blocked at form
+
+## Out of scope
+
+- The `myCompleteHabit` `activityTypeId` lookup (it reads from the parent habit, no change needed)
+- Migrating existing `activityTypes` shape — only the FKs change
+- Improving the activity-type dropdown UX beyond the empty-state guard
+
+## Risk
+
+- **PGLite migration behavior with backfill loops** — the backfill needs to insert General activity types per user, then update FKs. PGLite supports this but worth running on a copy of `pgdata/` first to confirm.
+- **Breaking change for any external consumers of the iCal feed or GraphQL API** — none expected, single-user app.

--- a/packages/client/src/components/domain/activity-type/ActivityTypeSelect.tsx
+++ b/packages/client/src/components/domain/activity-type/ActivityTypeSelect.tsx
@@ -7,6 +7,7 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { useQuery } from '@apollo/client/react';
+import { Link } from '@tanstack/react-router';
 
 const GET_ACTIVITY_TYPES = graphql(`
   query GetActivityTypesForSelect {
@@ -24,8 +25,6 @@ interface ActivityTypeSelectProps {
   onBlur?: () => void;
 }
 
-const NONE_VALUE = '__none__';
-
 export function ActivityTypeSelect({
   value,
   onValueChange,
@@ -35,13 +34,22 @@ export function ActivityTypeSelect({
 
   const activityTypes = data?.myActivityTypes ?? [];
 
+  if (activityTypes.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        No activity types yet —{' '}
+        <Link to="/activity-types" className="underline">
+          create one first
+        </Link>
+        .
+      </p>
+    );
+  }
+
   return (
-    <Select
-      value={value ?? NONE_VALUE}
-      onValueChange={(v) => onValueChange(v === NONE_VALUE ? undefined : v)}
-    >
+    <Select value={value ?? ''} onValueChange={(v) => onValueChange(v)}>
       <SelectTrigger onBlur={onBlur}>
-        <SelectValue placeholder="None">
+        <SelectValue placeholder="Select an activity type">
           {value
             ? (() => {
                 const at = activityTypes.find((a) => a.id === value);
@@ -54,16 +62,13 @@ export function ActivityTypeSelect({
                     {at.name}
                   </span>
                 ) : (
-                  'None'
+                  'Select an activity type'
                 );
               })()
-            : 'None'}
+            : 'Select an activity type'}
         </SelectValue>
       </SelectTrigger>
       <SelectContent>
-        <SelectItem value={NONE_VALUE}>
-          <span className="text-muted-foreground">None</span>
-        </SelectItem>
         {activityTypes.map((at) => (
           <SelectItem key={at.id} value={at.id}>
             <span className="flex items-center gap-2">

--- a/packages/client/src/components/domain/habit/HabitForm.tsx
+++ b/packages/client/src/components/domain/habit/HabitForm.tsx
@@ -98,7 +98,7 @@ const FREQUENCY_UNIT_OPTIONS = [
 const habitSchema = z.object({
   title: z.string().min(1, 'Title is required').max(200, 'Max 200 characters'),
   description: z.string().max(2000, 'Max 2000 characters'),
-  activityTypeId: z.string().uuid().or(z.undefined()),
+  activityTypeId: z.string().uuid('Activity type is required'),
   priority: z.string().min(1, 'Priority is required'),
   estimatedLength: z.string().min(1, 'Duration is required'),
   frequencyCount: z
@@ -142,7 +142,7 @@ export function HabitForm({ habit, open, onOpenChange }: HabitFormProps) {
     defaultValues: {
       title: habit?.title ?? '',
       description: habit?.description ?? '',
-      activityTypeId: habit?.activityType?.id ?? undefined,
+      activityTypeId: habit?.activityType?.id ?? '',
       priority: String(habit?.priority ?? 0),
       estimatedLength: String(habit?.estimatedLength ?? 30),
       frequencyCount: habit?.frequencyCount ?? 1,
@@ -159,7 +159,7 @@ export function HabitForm({ habit, open, onOpenChange }: HabitFormProps) {
               id: habit.id,
               title: value.title,
               description: value.description ?? null,
-              activityTypeId: value.activityTypeId ?? null,
+              activityTypeId: value.activityTypeId,
               priority: Number(value.priority),
               estimatedLength: Number(value.estimatedLength),
               frequencyCount: value.frequencyCount,
@@ -173,7 +173,7 @@ export function HabitForm({ habit, open, onOpenChange }: HabitFormProps) {
             input: {
               title: value.title,
               description: value.description ?? null,
-              activityTypeId: value.activityTypeId ?? null,
+              activityTypeId: value.activityTypeId,
               priority: Number(value.priority),
               estimatedLength: Number(value.estimatedLength),
               frequencyCount: value.frequencyCount,
@@ -224,11 +224,11 @@ export function HabitForm({ habit, open, onOpenChange }: HabitFormProps) {
             <form.AppField name="activityTypeId">
               {(field) => (
                 <Field>
-                  <FieldLabel>Activity Type (optional)</FieldLabel>
+                  <FieldLabel>Activity Type</FieldLabel>
                   <FieldControl>
                     <ActivityTypeSelect
-                      value={field.state.value}
-                      onValueChange={(v) => field.handleChange(v)}
+                      value={field.state.value || undefined}
+                      onValueChange={(v) => field.handleChange(v ?? '')}
                       onBlur={field.handleBlur}
                     />
                   </FieldControl>

--- a/packages/client/src/components/domain/onboarding/StepHabits.tsx
+++ b/packages/client/src/components/domain/onboarding/StepHabits.tsx
@@ -57,7 +57,7 @@ const CREATE_HABIT = graphql(`
 
 const schema = z.object({
   title: z.string().min(1, 'Title is required').max(200),
-  activityTypeId: z.string().uuid().optional(),
+  activityTypeId: z.string().uuid('Activity type is required'),
   frequencyCount: z.number().int().min(1).max(30),
   frequencyUnit: z.enum(['week', 'month']),
 });
@@ -85,7 +85,7 @@ export function StepHabits({ onBack, onNext, onSkip }: StepHabitsProps) {
   const form = useAppForm({
     defaultValues: {
       title: '',
-      activityTypeId: undefined,
+      activityTypeId: '',
       frequencyCount: 3,
       frequencyUnit: 'week',
     } as FormValues,
@@ -185,8 +185,8 @@ export function StepHabits({ onBack, onNext, onSkip }: StepHabitsProps) {
                   <FieldLabel>Activity type</FieldLabel>
                   <FieldControl>
                     <ActivityTypeSelect
-                      value={field.state.value}
-                      onValueChange={field.handleChange}
+                      value={field.state.value || undefined}
+                      onValueChange={(v) => field.handleChange(v ?? '')}
                       onBlur={field.handleBlur}
                     />
                   </FieldControl>

--- a/packages/client/src/components/domain/onboarding/StepTimeBlocks.tsx
+++ b/packages/client/src/components/domain/onboarding/StepTimeBlocks.tsx
@@ -57,7 +57,7 @@ const WEEKEND = [0, 6];
 
 const schema = z
   .object({
-    activityTypeId: z.string().uuid().optional(),
+    activityTypeId: z.string().uuid('Activity type is required'),
     daysOfWeek: z
       .array(z.number().int().min(0).max(6))
       .min(1, 'Select at least one day'),
@@ -94,7 +94,7 @@ export function StepTimeBlocks({ onBack, onNext }: StepTimeBlocksProps) {
 
   const form = useAppForm({
     defaultValues: {
-      activityTypeId: undefined,
+      activityTypeId: '',
       daysOfWeek: [...WEEKDAYS],
       startTime: '09:00',
       endTime: '17:00',
@@ -136,8 +136,8 @@ export function StepTimeBlocks({ onBack, onNext }: StepTimeBlocksProps) {
                   <FieldLabel>Activity type</FieldLabel>
                   <FieldControl>
                     <ActivityTypeSelect
-                      value={field.state.value}
-                      onValueChange={field.handleChange}
+                      value={field.state.value || undefined}
+                      onValueChange={(v) => field.handleChange(v ?? '')}
                       onBlur={field.handleBlur}
                     />
                   </FieldControl>

--- a/packages/client/src/components/domain/onboarding/StepTodos.tsx
+++ b/packages/client/src/components/domain/onboarding/StepTodos.tsx
@@ -61,7 +61,7 @@ const PRIORITY_OPTIONS = [
 
 const schema = z.object({
   title: z.string().min(1, 'Title is required').max(200),
-  activityTypeId: z.string().uuid().optional(),
+  activityTypeId: z.string().uuid('Activity type is required'),
   priority: z.number().int().min(0).max(100),
 });
 
@@ -85,7 +85,7 @@ export function StepTodos({ onBack, onFinish, onSkip }: StepTodosProps) {
   const form = useAppForm({
     defaultValues: {
       title: '',
-      activityTypeId: undefined,
+      activityTypeId: '',
       priority: 0,
     } as FormValues,
     validators: { onChange: schema },
@@ -162,8 +162,8 @@ export function StepTodos({ onBack, onFinish, onSkip }: StepTodosProps) {
                     <FieldLabel>Activity type</FieldLabel>
                     <FieldControl>
                       <ActivityTypeSelect
-                        value={field.state.value}
-                        onValueChange={field.handleChange}
+                        value={field.state.value || undefined}
+                        onValueChange={(v) => field.handleChange(v ?? '')}
                         onBlur={field.handleBlur}
                       />
                     </FieldControl>

--- a/packages/client/src/components/domain/time-block/TimeBlockForm.tsx
+++ b/packages/client/src/components/domain/time-block/TimeBlockForm.tsx
@@ -74,7 +74,7 @@ const WEEKEND = [0, 6];
 
 const timeBlockSchema = z
   .object({
-    activityTypeId: z.string().uuid().or(z.undefined()),
+    activityTypeId: z.string().uuid('Activity type is required'),
     daysOfWeek: z
       .array(z.number().int().min(0).max(6))
       .min(1, 'Select at least one day')
@@ -126,7 +126,7 @@ export function TimeBlockForm({
 
   const form = useAppForm({
     defaultValues: {
-      activityTypeId: timeBlock?.activityType?.id ?? undefined,
+      activityTypeId: timeBlock?.activityType?.id ?? '',
       daysOfWeek: timeBlock?.daysOfWeek ?? [1],
       startTime: timeBlock?.startTime ?? '09:00',
       endTime: timeBlock?.endTime ?? '10:00',
@@ -141,7 +141,7 @@ export function TimeBlockForm({
           variables: {
             input: {
               id: timeBlock.id,
-              activityTypeId: value.activityTypeId ?? null,
+              activityTypeId: value.activityTypeId,
               daysOfWeek: value.daysOfWeek,
               startTime: value.startTime,
               endTime: value.endTime,
@@ -153,7 +153,7 @@ export function TimeBlockForm({
         await createTimeBlock({
           variables: {
             input: {
-              activityTypeId: value.activityTypeId ?? null,
+              activityTypeId: value.activityTypeId,
               daysOfWeek: value.daysOfWeek,
               startTime: value.startTime,
               endTime: value.endTime,
@@ -186,11 +186,11 @@ export function TimeBlockForm({
             <form.AppField name="activityTypeId">
               {(field) => (
                 <Field>
-                  <FieldLabel>Activity Type (optional)</FieldLabel>
+                  <FieldLabel>Activity Type</FieldLabel>
                   <FieldControl>
                     <ActivityTypeSelect
-                      value={field.state.value}
-                      onValueChange={(v) => field.handleChange(v)}
+                      value={field.state.value || undefined}
+                      onValueChange={(v) => field.handleChange(v ?? '')}
                       onBlur={field.handleBlur}
                     />
                   </FieldControl>

--- a/packages/client/src/components/domain/todo/TodoForm.tsx
+++ b/packages/client/src/components/domain/todo/TodoForm.tsx
@@ -102,7 +102,7 @@ const DURATION_OPTIONS = [
 const todoSchema = z.object({
   title: z.string().min(1, 'Title is required').max(200, 'Max 200 characters'),
   description: z.string().max(2000, 'Max 2000 characters'),
-  activityTypeId: z.string().uuid().or(z.undefined()),
+  activityTypeId: z.string().uuid('Activity type is required'),
   priority: z.string().min(1, 'Priority is required'),
   estimatedLength: z.string().min(1, 'Duration is required'),
 });
@@ -148,7 +148,7 @@ export function TodoForm({ todo, open, onOpenChange }: TodoFormProps) {
     defaultValues: {
       title: todo?.title ?? '',
       description: todo?.description ?? '',
-      activityTypeId: todo?.activityType?.id ?? undefined,
+      activityTypeId: todo?.activityType?.id ?? '',
       priority: String(todo?.priority ?? 0),
       estimatedLength: String(todo?.estimatedLength ?? 30),
     } as TodoFormValues,
@@ -163,7 +163,7 @@ export function TodoForm({ todo, open, onOpenChange }: TodoFormProps) {
               id: todo.id,
               title: value.title,
               description: value.description ?? null,
-              activityTypeId: value.activityTypeId ?? null,
+              activityTypeId: value.activityTypeId,
               priority: Number(value.priority),
               estimatedLength: Number(value.estimatedLength),
             },
@@ -175,7 +175,7 @@ export function TodoForm({ todo, open, onOpenChange }: TodoFormProps) {
             input: {
               title: value.title,
               description: value.description ?? null,
-              activityTypeId: value.activityTypeId ?? null,
+              activityTypeId: value.activityTypeId,
               priority: Number(value.priority),
               estimatedLength: Number(value.estimatedLength),
             },
@@ -223,11 +223,11 @@ export function TodoForm({ todo, open, onOpenChange }: TodoFormProps) {
             <form.AppField name="activityTypeId">
               {(field) => (
                 <Field>
-                  <FieldLabel>Activity Type (optional)</FieldLabel>
+                  <FieldLabel>Activity Type</FieldLabel>
                   <FieldControl>
                     <ActivityTypeSelect
-                      value={field.state.value}
-                      onValueChange={(v) => field.handleChange(v)}
+                      value={field.state.value || undefined}
+                      onValueChange={(v) => field.handleChange(v ?? '')}
                       onBlur={field.handleBlur}
                     />
                   </FieldControl>

--- a/packages/db/drizzle/20260509062909_cynical_starhawk/migration.sql
+++ b/packages/db/drizzle/20260509062909_cynical_starhawk/migration.sql
@@ -1,0 +1,11 @@
+-- Drop rows with null activity_type_id before adding NOT NULL constraint.
+-- habits cascade-deletes habit_completions; time_blocks and todos have no children.
+DELETE FROM "time_blocks" WHERE "activity_type_id" IS NULL;--> statement-breakpoint
+DELETE FROM "todos" WHERE "activity_type_id" IS NULL;--> statement-breakpoint
+DELETE FROM "habits" WHERE "activity_type_id" IS NULL;--> statement-breakpoint
+ALTER TABLE "todos" ALTER COLUMN "activity_type_id" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "habits" ALTER COLUMN "activity_type_id" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "time_blocks" ALTER COLUMN "activity_type_id" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "todos" DROP CONSTRAINT "todos_activity_type_id_activity_types_id_fkey", ADD CONSTRAINT "todos_activity_type_id_activity_types_id_fkey" FOREIGN KEY ("activity_type_id") REFERENCES "activity_types"("id") ON DELETE RESTRICT;--> statement-breakpoint
+ALTER TABLE "habits" DROP CONSTRAINT "habits_activity_type_id_activity_types_id_fkey", ADD CONSTRAINT "habits_activity_type_id_activity_types_id_fkey" FOREIGN KEY ("activity_type_id") REFERENCES "activity_types"("id") ON DELETE RESTRICT;--> statement-breakpoint
+ALTER TABLE "time_blocks" DROP CONSTRAINT "time_blocks_activity_type_id_activity_types_id_fkey", ADD CONSTRAINT "time_blocks_activity_type_id_activity_types_id_fkey" FOREIGN KEY ("activity_type_id") REFERENCES "activity_types"("id") ON DELETE RESTRICT;

--- a/packages/db/drizzle/20260509062909_cynical_starhawk/snapshot.json
+++ b/packages/db/drizzle/20260509062909_cynical_starhawk/snapshot.json
@@ -1,0 +1,878 @@
+{
+  "version": "8",
+  "dialect": "postgres",
+  "id": "fe3021fb-dc55-47f0-ac47-18390bbad136",
+  "prevIds": [
+    "8bc67fc0-4e62-47ac-bca7-efdefa56793d"
+  ],
+  "ddl": [
+    {
+      "isRlsEnabled": false,
+      "name": "users",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "activity_types",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "todos",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "habits",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "time_blocks",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "habit_completions",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "email",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'UTC'",
+      "generated": null,
+      "identity": null,
+      "name": "timezone",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "activity_types"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "activity_types"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "activity_types"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'#6366f1'",
+      "generated": null,
+      "identity": null,
+      "name": "color",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "activity_types"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "activity_types"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "activity_types"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "todos"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "todos"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "title",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "todos"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "description",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "todos"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "priority",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "todos"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "estimated_length",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "todos"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "activity_type_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "todos"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "scheduled_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "todos"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "completed_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "todos"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "manually_scheduled",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "todos"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "todos"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "todos"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "habits"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "habits"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "title",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "habits"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "description",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "habits"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "priority",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "habits"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "estimated_length",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "habits"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "activity_type_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "habits"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "frequency_count",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "habits"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "frequency_unit",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "habits"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "habits"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "habits"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "time_blocks"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "time_blocks"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "activity_type_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "time_blocks"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 1,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "days_of_week",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "time_blocks"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "start_time",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "time_blocks"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "end_time",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "time_blocks"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "priority",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "time_blocks"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "time_blocks"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "time_blocks"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "habit_completions"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "habit_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "habit_completions"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "scheduled_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "habit_completions"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "completed_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "habit_completions"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "habit_completions"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "activity_types_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "activity_types"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "todos_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "todos"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "activity_type_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "activity_types",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "RESTRICT",
+      "name": "todos_activity_type_id_activity_types_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "todos"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "habits_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "habits"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "activity_type_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "activity_types",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "RESTRICT",
+      "name": "habits_activity_type_id_activity_types_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "habits"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "time_blocks_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "time_blocks"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "activity_type_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "activity_types",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "RESTRICT",
+      "name": "time_blocks_activity_type_id_activity_types_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "time_blocks"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "habit_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "habits",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "habit_completions_habit_id_habits_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "habit_completions"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "users_pkey",
+      "schema": "public",
+      "table": "users",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "activity_types_pkey",
+      "schema": "public",
+      "table": "activity_types",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "todos_pkey",
+      "schema": "public",
+      "table": "todos",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "habits_pkey",
+      "schema": "public",
+      "table": "habits",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "time_blocks_pkey",
+      "schema": "public",
+      "table": "time_blocks",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "habit_completions_pkey",
+      "schema": "public",
+      "table": "habit_completions",
+      "entityType": "pks"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "email"
+      ],
+      "nullsNotDistinct": false,
+      "name": "users_email_key",
+      "schema": "public",
+      "table": "users",
+      "entityType": "uniques"
+    }
+  ],
+  "renames": []
+}

--- a/packages/db/src/models/habits.ts
+++ b/packages/db/src/models/habits.ts
@@ -12,9 +12,9 @@ export const habits = pgTable('habits', {
   description: text('description'),
   priority: integer('priority').notNull().default(0),
   estimatedLength: integer('estimated_length').notNull(),
-  activityTypeId: uuid('activity_type_id').references(() => activityTypes.id, {
-    onDelete: 'set null',
-  }),
+  activityTypeId: uuid('activity_type_id')
+    .notNull()
+    .references(() => activityTypes.id, { onDelete: 'restrict' }),
   frequencyCount: integer('frequency_count').notNull(),
   frequencyUnit: text('frequency_unit').notNull().$type<FrequencyUnit>(),
   createdAt: timestamp('created_at').notNull().defaultNow(),

--- a/packages/db/src/models/time_blocks.ts
+++ b/packages/db/src/models/time_blocks.ts
@@ -7,9 +7,9 @@ export const timeBlocks = pgTable('time_blocks', {
   userId: uuid('user_id')
     .notNull()
     .references(() => users.id, { onDelete: 'cascade' }),
-  activityTypeId: uuid('activity_type_id').references(() => activityTypes.id, {
-    onDelete: 'set null',
-  }),
+  activityTypeId: uuid('activity_type_id')
+    .notNull()
+    .references(() => activityTypes.id, { onDelete: 'restrict' }),
   daysOfWeek: integer('days_of_week').array().notNull(),
   startTime: text('start_time').notNull(),
   endTime: text('end_time').notNull(),

--- a/packages/db/src/models/todos.ts
+++ b/packages/db/src/models/todos.ts
@@ -18,9 +18,9 @@ export const todos = pgTable('todos', {
   description: text('description'),
   priority: integer('priority').notNull().default(0),
   estimatedLength: integer('estimated_length').notNull(),
-  activityTypeId: uuid('activity_type_id').references(() => activityTypes.id, {
-    onDelete: 'set null',
-  }),
+  activityTypeId: uuid('activity_type_id')
+    .notNull()
+    .references(() => activityTypes.id, { onDelete: 'restrict' }),
   scheduledAt: timestamp('scheduled_at'),
   completedAt: timestamp('completed_at'),
   manuallyScheduled: boolean('manually_scheduled').notNull().default(false),

--- a/packages/server/src/__generated__/schema.graphql
+++ b/packages/server/src/__generated__/schema.graphql
@@ -276,7 +276,7 @@ input CreateHabitInput {
   description: String
   priority: Int
   estimatedLength: Int!
-  activityTypeId: String
+  activityTypeId: String!
   frequencyCount: Int!
   frequencyUnit: String!
 
@@ -351,7 +351,7 @@ input HabitOrderBy {
 input CreateTimeBlockInput {
   id: String
   userId: String!
-  activityTypeId: String
+  activityTypeId: String!
   daysOfWeek: [Int!]!
   startTime: String!
   endTime: String!
@@ -467,7 +467,7 @@ input CreateTodoInput {
   description: String
   priority: Int
   estimatedLength: Int!
-  activityTypeId: String
+  activityTypeId: String!
 
   """DateTime"""
   scheduledAt: DateTime
@@ -683,7 +683,7 @@ type Habit {
   description: String
   priority: Int!
   estimatedLength: Int!
-  activityTypeId: String
+  activityTypeId: String!
   frequencyCount: Int!
   frequencyUnit: String!
 
@@ -700,7 +700,7 @@ type Habit {
 type TimeBlock {
   id: String!
   userId: String!
-  activityTypeId: String
+  activityTypeId: String!
   daysOfWeek: [Int!]!
   startTime: String!
   endTime: String!
@@ -722,7 +722,7 @@ type Todo {
   description: String
   priority: Int!
   estimatedLength: Int!
-  activityTypeId: String
+  activityTypeId: String!
 
   """DateTime"""
   scheduledAt: DateTime
@@ -931,7 +931,7 @@ input CreateTodoArgs {
   description: String
   priority: Int
   estimatedLength: Int
-  activityTypeId: ID
+  activityTypeId: ID!
   scheduledAt: String
 }
 
@@ -952,13 +952,13 @@ input CreateHabitArgs {
   description: String
   priority: Int
   estimatedLength: Int
-  activityTypeId: ID
+  activityTypeId: ID!
   frequencyCount: Int!
   frequencyUnit: String!
 }
 
 input CreateTimeBlockArgs {
-  activityTypeId: ID
+  activityTypeId: ID!
   daysOfWeek: [Int!]!
   startTime: String!
   endTime: String!

--- a/packages/server/src/schema/resolvers/habits.ts
+++ b/packages/server/src/schema/resolvers/habits.ts
@@ -21,7 +21,7 @@ const UpdateHabitInput = z.object({
   description: z.string().max(2000).optional(),
   priority: z.number().int().min(0).max(100).optional(),
   estimatedLength: z.number().int().min(1).max(1440).optional(),
-  activityTypeId: z.string().uuid().nullable().optional(),
+  activityTypeId: z.string().uuid().optional(),
   frequencyCount: z.number().int().positive().min(1).max(30).optional(),
   frequencyUnit: z.enum(['week', 'month'] as const).optional(),
 });
@@ -106,11 +106,10 @@ export function applyHabitResolvers(
     if (!habit) throw new Error(`Habit ${args.habitId} not found`);
     if (habit.userId !== context.userId) throw new Error('Forbidden');
 
-    const activityType: ActivityType | undefined = habit.activityTypeId
-      ? await context.db.query.activityTypes.findFirst({
-          where: { id: habit.activityTypeId },
-        })
-      : undefined;
+    const activityType: ActivityType | undefined =
+      await context.db.query.activityTypes.findFirst({
+        where: { id: habit.activityTypeId },
+      });
 
     const numPeriods = Math.min(Math.max(args.periods ?? 8, 1), 26);
     const now = new Date();
@@ -205,7 +204,7 @@ export function applyHabitResolvers(
         description: input.description,
         priority: input.priority,
         estimatedLength: input.estimatedLength ?? 0,
-        activityTypeId: input.activityTypeId ?? null,
+        activityTypeId: input.activityTypeId,
         frequencyCount: input.frequencyCount,
         frequencyUnit: input.frequencyUnit,
       })

--- a/packages/server/src/schema/resolvers/index.ts
+++ b/packages/server/src/schema/resolvers/index.ts
@@ -120,7 +120,7 @@ const extensionSDL = `
     description: String
     priority: Int
     estimatedLength: Int
-    activityTypeId: ID
+    activityTypeId: ID!
     scheduledAt: String
   }
 
@@ -141,13 +141,13 @@ const extensionSDL = `
     description: String
     priority: Int
     estimatedLength: Int
-    activityTypeId: ID
+    activityTypeId: ID!
     frequencyCount: Int!
     frequencyUnit: String!
   }
 
   input CreateTimeBlockArgs {
-    activityTypeId: ID
+    activityTypeId: ID!
     daysOfWeek: [Int!]!
     startTime: String!
     endTime: String!
@@ -242,14 +242,13 @@ export function applyCustomResolvers(schema: GraphQLSchema): GraphQLSchema {
   applyAuthResolvers(mutationFields);
 
   // Field resolvers: activityType on Todo, Habit, TimeBlock
-  type RowWithActivityTypeId = { activityTypeId?: string | null };
+  type RowWithActivityTypeId = { activityTypeId: string };
 
   function resolveActivityType(
     parent: RowWithActivityTypeId,
     _args: unknown,
     context: Context,
   ) {
-    if (!parent.activityTypeId) return null;
     return context.loaders.activityType.load(parent.activityTypeId);
   }
 

--- a/packages/server/src/schema/resolvers/time-blocks.ts
+++ b/packages/server/src/schema/resolvers/time-blocks.ts
@@ -11,7 +11,7 @@ type Fields = ReturnType<GraphQLObjectType['getFields']>;
 const UpdateTimeBlockInput = z
   .object({
     id: z.string().uuid(),
-    activityTypeId: z.string().uuid().nullable().optional(),
+    activityTypeId: z.string().uuid().optional(),
     daysOfWeek: z
       .array(z.number().int().min(0).max(6))
       .min(1)
@@ -74,7 +74,7 @@ export function applyTimeBlockResolvers(
       .insert(timeBlocks)
       .values({
         userId: context.userId,
-        activityTypeId: input.activityTypeId ?? null,
+        activityTypeId: input.activityTypeId,
         daysOfWeek: input.daysOfWeek,
         startTime: input.startTime,
         endTime: input.endTime,

--- a/packages/server/src/schema/resolvers/todos.ts
+++ b/packages/server/src/schema/resolvers/todos.ts
@@ -62,7 +62,7 @@ export function applyTodoResolvers(
         description: input.description,
         priority: input.priority,
         estimatedLength: input.estimatedLength ?? 0,
-        activityTypeId: input.activityTypeId ?? null,
+        activityTypeId: input.activityTypeId,
         scheduledAt: input.scheduledAt
           ? new Date(input.scheduledAt)
           : undefined,

--- a/packages/server/src/schema/validators.test.ts
+++ b/packages/server/src/schema/validators.test.ts
@@ -78,10 +78,13 @@ describe('UpdateActivityTypeInput', () => {
 });
 
 describe('CreateTodoInput', () => {
+  const validActivityTypeId = '00000000-0000-0000-0000-000000000001';
+
   it('accepts valid minimal input', () => {
     const result = CreateTodoInput.parse({
       title: 'My todo',
       estimatedLength: 30,
+      activityTypeId: validActivityTypeId,
     });
     expect(result.title).toBe('My todo');
     expect(result.priority).toBe(0); // default
@@ -94,41 +97,68 @@ describe('CreateTodoInput', () => {
         description: 'A description',
         priority: 75,
         estimatedLength: 60,
-        activityTypeId: '00000000-0000-0000-0000-000000000001',
+        activityTypeId: validActivityTypeId,
         scheduledAt: '2026-04-28T09:00:00.000Z',
       }),
     ).not.toThrow();
   });
 
+  it('rejects missing activityTypeId', () => {
+    expect(() => CreateTodoInput.parse({ title: 'Test' })).toThrow();
+  });
+
   it('rejects empty title', () => {
-    expect(() => CreateTodoInput.parse({ title: '' })).toThrow();
+    expect(() =>
+      CreateTodoInput.parse({ title: '', activityTypeId: validActivityTypeId }),
+    ).toThrow();
   });
 
   it('rejects title exceeding 200 characters', () => {
-    expect(() => CreateTodoInput.parse({ title: 'a'.repeat(201) })).toThrow();
+    expect(() =>
+      CreateTodoInput.parse({
+        title: 'a'.repeat(201),
+        activityTypeId: validActivityTypeId,
+      }),
+    ).toThrow();
   });
 
   it('rejects priority below 0', () => {
     expect(() =>
-      CreateTodoInput.parse({ title: 'Test', priority: -1 }),
+      CreateTodoInput.parse({
+        title: 'Test',
+        priority: -1,
+        activityTypeId: validActivityTypeId,
+      }),
     ).toThrow();
   });
 
   it('rejects priority above 100', () => {
     expect(() =>
-      CreateTodoInput.parse({ title: 'Test', priority: 101 }),
+      CreateTodoInput.parse({
+        title: 'Test',
+        priority: 101,
+        activityTypeId: validActivityTypeId,
+      }),
     ).toThrow();
   });
 
   it('rejects estimatedLength of 0', () => {
     expect(() =>
-      CreateTodoInput.parse({ title: 'Test', estimatedLength: 0 }),
+      CreateTodoInput.parse({
+        title: 'Test',
+        estimatedLength: 0,
+        activityTypeId: validActivityTypeId,
+      }),
     ).toThrow();
   });
 
   it('rejects estimatedLength exceeding 1440', () => {
     expect(() =>
-      CreateTodoInput.parse({ title: 'Test', estimatedLength: 1441 }),
+      CreateTodoInput.parse({
+        title: 'Test',
+        estimatedLength: 1441,
+        activityTypeId: validActivityTypeId,
+      }),
     ).toThrow();
   });
 
@@ -146,9 +176,15 @@ describe('UpdateTodoInput', () => {
     expect(() => UpdateTodoInput.parse({ id: validId })).not.toThrow();
   });
 
-  it('accepts setting activityTypeId to null', () => {
+  it('rejects setting activityTypeId to null', () => {
     expect(() =>
       UpdateTodoInput.parse({ id: validId, activityTypeId: null }),
+    ).toThrow();
+  });
+
+  it('accepts changing activityTypeId to a valid uuid', () => {
+    expect(() =>
+      UpdateTodoInput.parse({ id: validId, activityTypeId: validId }),
     ).not.toThrow();
   });
 
@@ -164,14 +200,27 @@ describe('UpdateTodoInput', () => {
 });
 
 describe('CreateHabitInput', () => {
+  const validActivityTypeId = '00000000-0000-0000-0000-000000000001';
+
   it('accepts valid input', () => {
     const result = CreateHabitInput.parse({
       title: 'Exercise',
       frequencyCount: 3,
       frequencyUnit: 'week',
+      activityTypeId: validActivityTypeId,
     });
     expect(result.title).toBe('Exercise');
     expect(result.priority).toBe(0);
+  });
+
+  it('rejects missing activityTypeId', () => {
+    expect(() =>
+      CreateHabitInput.parse({
+        title: 'Test',
+        frequencyCount: 3,
+        frequencyUnit: 'week',
+      }),
+    ).toThrow();
   });
 
   it('rejects empty title', () => {
@@ -180,6 +229,7 @@ describe('CreateHabitInput', () => {
         title: '',
         frequencyCount: 3,
         frequencyUnit: 'week',
+        activityTypeId: validActivityTypeId,
       }),
     ).toThrow();
   });
@@ -190,6 +240,7 @@ describe('CreateHabitInput', () => {
         title: 'Test',
         frequencyCount: 0,
         frequencyUnit: 'week',
+        activityTypeId: validActivityTypeId,
       }),
     ).toThrow();
   });
@@ -200,6 +251,7 @@ describe('CreateHabitInput', () => {
         title: 'Test',
         frequencyCount: 31,
         frequencyUnit: 'week',
+        activityTypeId: validActivityTypeId,
       }),
     ).toThrow();
   });
@@ -210,6 +262,7 @@ describe('CreateHabitInput', () => {
         title: 'Test',
         frequencyCount: 3,
         frequencyUnit: 'day',
+        activityTypeId: validActivityTypeId,
       }),
     ).toThrow();
   });
@@ -220,6 +273,7 @@ describe('CreateHabitInput', () => {
         title: 'Monthly review',
         frequencyCount: 1,
         frequencyUnit: 'month',
+        activityTypeId: validActivityTypeId,
       }),
     ).not.toThrow();
   });
@@ -240,14 +294,27 @@ describe('UpdateHabitInput', () => {
 });
 
 describe('CreateTimeBlockInput', () => {
+  const validActivityTypeId = '00000000-0000-0000-0000-000000000001';
+
   it('accepts valid time block', () => {
     expect(() =>
       CreateTimeBlockInput.parse({
         daysOfWeek: [1, 3, 5],
         startTime: '09:00',
         endTime: '12:00',
+        activityTypeId: validActivityTypeId,
       }),
     ).not.toThrow();
+  });
+
+  it('rejects missing activityTypeId', () => {
+    expect(() =>
+      CreateTimeBlockInput.parse({
+        daysOfWeek: [1],
+        startTime: '09:00',
+        endTime: '12:00',
+      }),
+    ).toThrow();
   });
 
   it('rejects when end time is before start time', () => {
@@ -256,6 +323,7 @@ describe('CreateTimeBlockInput', () => {
         daysOfWeek: [1],
         startTime: '12:00',
         endTime: '09:00',
+        activityTypeId: validActivityTypeId,
       }),
     ).toThrow();
   });
@@ -266,6 +334,7 @@ describe('CreateTimeBlockInput', () => {
         daysOfWeek: [1],
         startTime: '09:00',
         endTime: '09:00',
+        activityTypeId: validActivityTypeId,
       }),
     ).toThrow();
   });
@@ -276,6 +345,7 @@ describe('CreateTimeBlockInput', () => {
         daysOfWeek: [1, 1, 3],
         startTime: '09:00',
         endTime: '12:00',
+        activityTypeId: validActivityTypeId,
       }),
     ).toThrow();
   });
@@ -286,6 +356,7 @@ describe('CreateTimeBlockInput', () => {
         daysOfWeek: [],
         startTime: '09:00',
         endTime: '12:00',
+        activityTypeId: validActivityTypeId,
       }),
     ).toThrow();
   });
@@ -296,6 +367,7 @@ describe('CreateTimeBlockInput', () => {
         daysOfWeek: [7],
         startTime: '09:00',
         endTime: '12:00',
+        activityTypeId: validActivityTypeId,
       }),
     ).toThrow();
   });
@@ -306,19 +378,9 @@ describe('CreateTimeBlockInput', () => {
         daysOfWeek: [1],
         startTime: '9am',
         endTime: '12:00',
+        activityTypeId: validActivityTypeId,
       }),
     ).toThrow();
-  });
-
-  it('accepts optional activityTypeId', () => {
-    expect(() =>
-      CreateTimeBlockInput.parse({
-        activityTypeId: '00000000-0000-0000-0000-000000000001',
-        daysOfWeek: [1],
-        startTime: '08:00',
-        endTime: '09:00',
-      }),
-    ).not.toThrow();
   });
 });
 

--- a/packages/server/src/schema/validators.ts
+++ b/packages/server/src/schema/validators.ts
@@ -22,7 +22,7 @@ export const CreateTodoInput = z.object({
   description: z.string().max(2000).optional(),
   priority: z.number().int().min(0).max(100).default(0),
   estimatedLength: z.number().int().min(1).max(1440).optional(),
-  activityTypeId: z.string().uuid().optional(),
+  activityTypeId: z.string().uuid(),
   scheduledAt: z.string().datetime({ local: true }).optional(),
 });
 
@@ -32,7 +32,7 @@ export const UpdateTodoInput = z.object({
   description: z.string().max(2000).optional(),
   priority: z.number().int().min(0).max(100).optional(),
   estimatedLength: z.number().int().min(1).max(1440).optional(),
-  activityTypeId: z.string().uuid().nullable().optional(),
+  activityTypeId: z.string().uuid().optional(),
   scheduledAt: z.string().optional(),
   manuallyScheduled: z.boolean().optional(),
   completedAt: z.string().nullable().optional(),
@@ -43,7 +43,7 @@ export const CreateHabitInput = z.object({
   description: z.string().max(2000).optional(),
   priority: z.number().int().min(0).max(100).default(0),
   estimatedLength: z.number().int().min(1).max(1440).optional(),
-  activityTypeId: z.string().uuid().optional(),
+  activityTypeId: z.string().uuid(),
   frequencyCount: z.number().int().positive().min(1).max(30),
   frequencyUnit: z.enum(['week', 'month'] as const),
 });
@@ -54,12 +54,12 @@ export const UpdateHabitInput = z.object({
   description: z.string().max(2000).optional(),
   priority: z.number().int().min(0).max(100).optional(),
   estimatedLength: z.number().int().min(1).max(1440).optional(),
-  activityTypeId: z.string().uuid().nullable().optional(),
+  activityTypeId: z.string().uuid().optional(),
 });
 
 export const CreateTimeBlockInput = z
   .object({
-    activityTypeId: z.string().uuid().optional(),
+    activityTypeId: z.string().uuid(),
     daysOfWeek: z
       .array(z.number().int().min(0).max(6))
       .min(1)
@@ -78,7 +78,7 @@ export const CreateTimeBlockInput = z
 
 export const UpdateTimeBlockInput = z.object({
   id: z.string().uuid(),
-  activityTypeId: z.string().uuid().nullable().optional(),
+  activityTypeId: z.string().uuid().optional(),
   daysOfWeek: z
     .array(z.number().int().min(0).max(6))
     .min(1)


### PR DESCRIPTION
## Summary

Closes the residual half of #21 (drag-to-schedule and \`manuallyScheduled\` were already shipped). Makes \`activity_type_id\` required end-to-end on \`todos\`, \`habits\`, and \`time_blocks\` so the silent "item never schedules" failure mode is no longer reachable.

Five commits, one per logical layer:

1. **Plan committed first** (\`docs(plans)\`) — captures the locked design decisions for future agents.
2. **DB layer** — Drizzle models drop nullability on \`activity_type_id\` and switch the FK from \`set null\` to \`restrict\` (deleting an activity type with dependents now errors cleanly). Migration prepends \`DELETE FROM ... WHERE activity_type_id IS NULL;\` for each table per the chosen "delete null rows" strategy.
3. **Server validators** — \`CreateTodoInput\` / \`CreateHabitInput\` / \`CreateTimeBlockInput\` now require \`activityTypeId\`. \`Update*Input\` keep it optional for partial updates but drop \`.nullable()\` so you can't unset to null. Vitest suite updated; 76 tests pass.
4. **SDL + resolvers** — \`Create*Args\` flip to \`activityTypeId: ID!\`. Local resolver Zod schemas (in \`time-blocks.ts\` / \`habits.ts\`) brought in line with the central validators. Now-dead \`?? null\` fallbacks dropped from insert paths. Field-resolver type tightens from \`string | null\` to \`string\`.
5. **Client forms** — \`TodoForm\` / \`HabitForm\` / \`TimeBlockForm\` and the three onboarding step forms tighten their Zod schemas. \`ActivityTypeSelect\` drops the "None" option; when the user has zero activity types it now renders an empty-state with a Link to \`/activity-types\` instead of an empty select.

## Migration impact

The migration \`20260509062909_cynical_starhawk\` is **destructive** — it deletes any existing rows in \`todos\`, \`habits\`, or \`time_blocks\` whose \`activity_type_id\` is null. Order: \`time_blocks\` → \`todos\` → \`habits\` (the \`habits\` deletion cascades to \`habit_completions\`). This was the explicit design choice — single-user hobby DB, user wants to clean rather than backfill.

Migration not auto-applied; run \`npm run db:migrate\` when ready. The local DB hasn't been touched.

## Test plan

- [x] \`npm run typecheck\` (clean)
- [x] \`npm run lint\` (clean)
- [x] \`npm test\` (76 / 76 pass)
- [ ] Apply migration locally and verify (or test in a fresh PGLite dir)
- [ ] Manual smoke: create a todo without picking an activity type → should be blocked at the form
- [ ] Manual smoke: try to delete an activity type that has todos/habits/time-blocks → should error cleanly with the FK restrict message

## Follow-ups (not in this PR)

- UX message when \`myDeleteActivityType\` fails because of dependents — surface the restrict-violation error nicely instead of bubbling the raw DB error
- Scheduler simplification — guards like \`if (!item.activityTypeId)\` are now unreachable; can be removed in a separate cleanup pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)