### PR TITLE
fix: guard UUID Bearer fallback in production (#25)

### DIFF
--- a/.agents/todo.md
+++ b/.agents/todo.md
@@ -16,7 +16,7 @@
 - JWT sign/verify via `jose` in `packages/server/src/auth.ts`
 - Login flow (`/login`) and verify route (`/auth/verify`) live in the client
 - Apollo client attaches `Bearer <token>` from `localStorage.auth_token`; expired-auth errors redirect to `/login`
-- Server context extracts JWT first, falls back to raw UUID for dev/seed (see #25)
+- Server context extracts JWT first, falls back to raw UUID for dev/seed (dev-only, guarded by `NODE_ENV !== 'production'`)
 
 **What's left:** The magic link is logged to the server console but no email is actually sent. In dev the `requestMagicLink` mutation also returns the link in the response; in prod the response has `magicLink: null`.
 
@@ -126,16 +126,6 @@
 - Update the Settings page to show/regenerate the secret
 
 **Acceptance:** The iCal URL contains a random secret that can be rotated without changing the user ID.
-
----
-
-### #25 — Remove UUID Bearer token fallback in production
-**Problem:** The server accepts a raw UUID as a Bearer token for dev convenience (DEMO_USER_ID). This means anyone who knows a user's UUID can authenticate as them in production.
-**Work:**
-- Guard the UUID fallback with `if (process.env.NODE_ENV !== 'production')` in `packages/server/src/index.ts`
-- OR remove it entirely once the demo user flow is replaced by real auth
-
-**Acceptance:** In production, only valid JWTs are accepted as Bearer tokens.
 
 ---
 

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -81,8 +81,12 @@ app.use(
         }
       }
 
-      // Fall back to raw UUID for backwards-compat with dev/seed
-      if (/^[0-9a-f-]{36}$/i.test(rawToken))
+      // Dev-only: accept raw UUID as Bearer token for the demo user.
+      // In production, only JWTs and API keys (acal_ prefix) are valid.
+      if (
+        process.env.NODE_ENV !== 'production' &&
+        /^[0-9a-f-]{36}$/i.test(rawToken)
+      )
         return { db, userId: rawToken, loaders };
 
       return { db, loaders };


### PR DESCRIPTION
## Summary

- **Problem:** The server accepted any raw UUID as a valid Bearer token for backwards-compat with dev/seed workflows. In production this means anyone who knows a user's UUID can authenticate as that user, bypassing JWT/API-key auth entirely.
- **What changed:** The UUID Bearer fallback in `packages/server/src/index.ts` is now gated on `process.env.NODE_ENV !== 'production'`. In production, only valid JWTs and `acal_`-prefixed API keys are accepted. Added inline comment explaining the guard.
- **Dev flow unaffected:** Local dev (where `NODE_ENV` is not `'production'`) continues to accept raw UUIDs as Bearer tokens, so seed data and demo-user workflows work as before.
- Removed #25 from `.agents/todo.md`.

## Test plan
- [ ] `npm run lint:fix` passes (Biome formats the multi-line condition cleanly)
- [ ] `npm test` — all 91 tests pass
- [ ] Manual: confirm dev server still accepts UUID Bearer token when `NODE_ENV=development`
- [ ] Manual: confirm production build rejects UUID Bearer token (returns unauthenticated context)

🤖 Generated with [Claude Code](https://claude.com/claude-code)