### PR TITLE
ci: GitHub Actions CI workflow (#15)

### DIFF
--- a/.agents/todo.md
+++ b/.agents/todo.md
@@ -142,15 +142,19 @@
 ## P3 — Infrastructure & DX
 
 ### #15 — Expand test suite + CI
-**Status:** Partially done. Existing vitest suites:
+**Status:** Substantially done. Shipped:
+- `.github/workflows/ci.yml` — runs codegen, typecheck, lint, and `npm test` on every PR and push to main; blocks merges on failure
+- `packages/server/src/schema/resolvers/resolvers.integration.test.ts` — 3 resolver integration tests (PGLite in-memory) covering `myCreateActivityType`, `myCreateTodoList` + `myCreateTodo`, and `myCompleteTodo`
+- `vitest.config.ts` updated with a `graphql` alias to prevent duplicate-module issues in the ESM test graph
+- `packages/db/package.json` adds `./relations` export for use in test harnesses
+
+Existing vitest suites:
 - `packages/server/src/auth.test.ts` — JWT + magic-link helpers
 - `packages/server/src/schema/validators.test.ts` — Zod validators
 - `packages/server/src/services/scheduler.test.ts` — pure scheduler algorithm
 
 **What's left:**
-- Resolver integration tests (PGLite in-memory) for the `my*` mutations and queries
 - Client component / route smoke tests
-- CI workflow (GitHub Actions) that runs `npm run typecheck`, `npm run lint`, `npm test` on PRs and blocks merges on failure
 - Coverage targets (e.g. >80% on scheduler / resolvers)
 
 **Acceptance:** PRs cannot merge with failing typecheck/lint/tests; resolver and validator paths are exercised end-to-end via PGLite.

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -5,6 +5,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./schema": "./src/schema.ts",
+    "./relations": "./src/relations.ts",
     "./seed": "./src/seed.ts"
   },
   "scripts": {

--- a/packages/server/src/schema/resolvers/resolvers.integration.test.ts
+++ b/packages/server/src/schema/resolvers/resolvers.integration.test.ts
@@ -1,0 +1,266 @@
+/**
+ * Resolver integration tests using PGLite in-memory.
+ *
+ * These tests exercise the full resolver layer without HTTP or a real DB on
+ * disk. Each test gets a fresh in-memory PGLite instance with migrations
+ * applied so there is no cross-test state.
+ *
+ * Import note: we intentionally bypass `packages/server/src/schema/index.ts`
+ * (which pulls in the live `@auto-cal/db` singleton and requires env vars).
+ * Instead we build the test schema directly from the resolver index + a
+ * freshly created PGLite drizzle instance.
+ */
+
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { relations } from '@auto-cal/db/relations';
+import * as schema from '@auto-cal/db/schema';
+import { users } from '@auto-cal/db/schema';
+import { PGlite } from '@electric-sql/pglite';
+import { buildSchema } from '@vantreeseba/drizzle-graphql';
+import { drizzle } from 'drizzle-orm/pglite';
+import { migrate } from 'drizzle-orm/pglite/migrator';
+import { graphql } from 'graphql';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { createLoaders } from '../../context.ts';
+import { applyCustomResolvers } from './index.ts';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const migrationsFolder = resolve(
+  __dirname,
+  '../../../../../packages/db/drizzle',
+);
+
+/** Build a fresh in-memory DB with all migrations applied. */
+async function createTestDb() {
+  const client = new PGlite('memory://');
+  await client.waitReady;
+  // @ts-expect-error drizzle-orm 1.0-beta removed `schema` from config types but it remains valid at runtime
+  const db = drizzle({ client, schema, relations });
+  await migrate(db, { migrationsFolder });
+  return db;
+}
+
+/** Build the full GraphQL schema wired to the given drizzle instance. */
+function buildTestSchema(db: Awaited<ReturnType<typeof createTestDb>>) {
+  const { schema: drizzleSchema } = buildSchema(db, {
+    prefixes: { insert: 'create', update: 'update', delete: 'delete' },
+    suffixes: { list: 's', single: '' },
+    singularTypes: true,
+  });
+  return applyCustomResolvers(drizzleSchema);
+}
+
+/** Execute a GraphQL document against the test schema with an authenticated context. */
+async function exec(
+  testSchema: ReturnType<typeof buildTestSchema>,
+  db: Awaited<ReturnType<typeof createTestDb>>,
+  userId: string,
+  source: string,
+  variableValues?: Record<string, unknown>,
+) {
+  return graphql({
+    schema: testSchema,
+    source,
+    variableValues,
+    contextValue: { db, userId, loaders: createLoaders(db) },
+  });
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('resolver integration tests', () => {
+  let db: Awaited<ReturnType<typeof createTestDb>>;
+  let testSchema: ReturnType<typeof buildTestSchema>;
+  let userId: string;
+
+  beforeEach(async () => {
+    db = await createTestDb();
+    testSchema = buildTestSchema(db);
+    const [user] = await db
+      .insert(users)
+      .values({ email: 'integration@example.com' })
+      .returning();
+    if (!user) throw new Error('Failed to create test user');
+    userId = user.id;
+  });
+
+  it('myCreateActivityType → appears in myActivityTypes', async () => {
+    const createResult = await exec(
+      testSchema,
+      db,
+      userId,
+      `mutation {
+        myCreateActivityType(input: { name: "Work", color: "#6366f1" }) {
+          id
+          name
+          color
+        }
+      }`,
+    );
+
+    expect(createResult.errors).toBeUndefined();
+    const created = createResult.data?.myCreateActivityType as {
+      id: string;
+      name: string;
+      color: string;
+    };
+    expect(created.name).toBe('Work');
+    expect(created.color).toBe('#6366f1');
+
+    const listResult = await exec(
+      testSchema,
+      db,
+      userId,
+      'query { myActivityTypes { id name } }',
+    );
+    expect(listResult.errors).toBeUndefined();
+    const list = listResult.data?.myActivityTypes as Array<{
+      id: string;
+      name: string;
+    }>;
+    expect(list).toHaveLength(1);
+    expect(list[0]?.name).toBe('Work');
+  });
+
+  it('myCreateTodoList + myCreateTodo → todo appears in myTodos', async () => {
+    // Create the prerequisite activity type
+    const atResult = await exec(
+      testSchema,
+      db,
+      userId,
+      `mutation {
+        myCreateActivityType(input: { name: "Personal" }) { id }
+      }`,
+    );
+    expect(atResult.errors).toBeUndefined();
+    const atId = (atResult.data?.myCreateActivityType as { id: string }).id;
+
+    // Create the todo list
+    const listResult = await exec(
+      testSchema,
+      db,
+      userId,
+      `mutation($input: CreateTodoListArgs!) {
+        myCreateTodoList(input: $input) { id name }
+      }`,
+      { input: { name: 'Home Tasks', activityTypeId: atId } },
+    );
+    expect(listResult.errors).toBeUndefined();
+    const listId = (listResult.data?.myCreateTodoList as { id: string }).id;
+
+    // Create a todo
+    const todoResult = await exec(
+      testSchema,
+      db,
+      userId,
+      `mutation($input: CreateTodoArgs!) {
+        myCreateTodo(input: $input) { id title completedAt }
+      }`,
+      { input: { listId, title: 'Buy groceries', estimatedLength: 30 } },
+    );
+    expect(todoResult.errors).toBeUndefined();
+    const todo = todoResult.data?.myCreateTodo as {
+      id: string;
+      title: string;
+      completedAt: string | null;
+    };
+    expect(todo.title).toBe('Buy groceries');
+    expect(todo.completedAt).toBeNull();
+
+    // Verify it appears in myTodos
+    const todosResult = await exec(
+      testSchema,
+      db,
+      userId,
+      'query { myTodos { id title } }',
+    );
+    expect(todosResult.errors).toBeUndefined();
+    const todos = todosResult.data?.myTodos as Array<{
+      id: string;
+      title: string;
+    }>;
+    expect(todos.some((t) => t.title === 'Buy groceries')).toBe(true);
+  });
+
+  it('myCompleteTodo → completedAt is set and appears in myTodos(completed: true)', async () => {
+    // Create activity type, list, and todo
+    const atResult = await exec(
+      testSchema,
+      db,
+      userId,
+      `mutation {
+        myCreateActivityType(input: { name: "Work" }) { id }
+      }`,
+    );
+    const atId = (atResult.data?.myCreateActivityType as { id: string }).id;
+
+    const listResult = await exec(
+      testSchema,
+      db,
+      userId,
+      `mutation($input: CreateTodoListArgs!) {
+        myCreateTodoList(input: $input) { id }
+      }`,
+      { input: { name: 'Sprint', activityTypeId: atId } },
+    );
+    const listId = (listResult.data?.myCreateTodoList as { id: string }).id;
+
+    const todoResult = await exec(
+      testSchema,
+      db,
+      userId,
+      `mutation($input: CreateTodoArgs!) {
+        myCreateTodo(input: $input) { id }
+      }`,
+      { input: { listId, title: 'Fix bug', estimatedLength: 60 } },
+    );
+    const todoId = (todoResult.data?.myCreateTodo as { id: string }).id;
+
+    // Complete the todo
+    const completeResult = await exec(
+      testSchema,
+      db,
+      userId,
+      `mutation($id: ID!) {
+        myCompleteTodo(id: $id) { id completedAt }
+      }`,
+      { id: todoId },
+    );
+    expect(completeResult.errors).toBeUndefined();
+    const completed = completeResult.data?.myCompleteTodo as {
+      id: string;
+      completedAt: string | null;
+    };
+    expect(completed.completedAt).not.toBeNull();
+
+    // It should appear in myTodos(completed: true)
+    const completedList = await exec(
+      testSchema,
+      db,
+      userId,
+      'query { myTodos(completed: true) { id title } }',
+    );
+    expect(completedList.errors).toBeUndefined();
+    const completedTodos = completedList.data?.myTodos as Array<{
+      id: string;
+      title: string;
+    }>;
+    expect(completedTodos.some((t) => t.id === todoId)).toBe(true);
+
+    // It should NOT appear in myTodos(completed: false)
+    const incompleteTodos = await exec(
+      testSchema,
+      db,
+      userId,
+      'query { myTodos(completed: false) { id } }',
+    );
+    expect(incompleteTodos.errors).toBeUndefined();
+    const incompleteList = incompleteTodos.data?.myTodos as Array<{
+      id: string;
+    }>;
+    expect(incompleteList.some((t) => t.id === todoId)).toBe(false);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,15 @@
+import { resolve } from 'node:path';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
+  resolve: {
+    // Ensure only one graphql instance is loaded across all packages.
+    // Without this alias vitest's ESM module graph can end up with two copies
+    // (e.g. drizzle-graphql + server code), causing instanceof checks to fail.
+    alias: {
+      graphql: resolve('./node_modules/graphql/index.js'),
+    },
+  },
   test: {
     globals: true,
     environment: 'node',


### PR DESCRIPTION
## Summary

- Adds 3 PGLite in-memory resolver integration tests in `packages/server/src/schema/resolvers/resolvers.integration.test.ts` covering the `myCreateActivityType`, `myCreateTodoList` + `myCreateTodo`, and `myCompleteTodo` resolver paths end-to-end
- Fixes a vitest ESM duplicate-module issue by adding a `graphql` alias in `vitest.config.ts` (drizzle-graphql and server code must share exactly one graphql instance for `instanceof` checks to pass)
- Adds `./relations` export to `packages/db/package.json` so test harnesses can import Drizzle relations without loading the env-checked DB singleton
- Updates `.agents/todo.md` to reflect #15 status (CI workflow was already shipped; integration tests now done)

Note: the CI workflow (`.github/workflows/ci.yml`) was already in place running codegen → typecheck → lint → test on every PR. This PR adds the missing integration-test layer.

## Test plan

- [ ] `npm test` passes (81 tests across 4 test files, including 3 new integration tests)
- [ ] `npm run typecheck` passes
- [ ] `npm run lint` passes
- [ ] New tests cover: activity type creation + listing, todo list + todo creation + listing, todo completion + completed/incomplete filtering

🤖 Generated with [Claude Code](https://claude.com/claude-code)