### PR TITLE
test(server): integration tests for schedule, stats, todos, and habits resolvers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ pgdata-codegen
 .idea
 .claude/worktrees/
 .claude/scheduled_tasks.lock
+coverage/

--- a/biome.json
+++ b/biome.json
@@ -49,6 +49,7 @@
         "**/dist/**",
         "**/drizzle/**",
         "**/pgdata/**",
+        "**/coverage/**",
         "**/routeTree.gen.ts"
       ],
       "linter": { "enabled": false },

--- a/package.json
+++ b/package.json
@@ -4,9 +4,7 @@
   "type": "module",
   "description": "Auto Cal - Todo and habit scheduling application",
   "private": true,
-  "workspaces": [
-    "packages/*"
-  ],
+  "workspaces": ["packages/*"],
   "scripts": {
     "dev": "concurrently \"npm:dev:server\" \"npm:dev:client\"",
     "dev:server": "npm run dev -w @auto-cal/server",
@@ -25,13 +23,7 @@
     "codegen:server": "graphql-codegen-esm --config codegen.server.ts",
     "test": "vitest"
   },
-  "keywords": [
-    "scheduling",
-    "todo",
-    "habits",
-    "calendar",
-    "productivity"
-  ],
+  "keywords": ["scheduling", "todo", "habits", "calendar", "productivity"],
   "author": "",
   "license": "MIT",
   "devDependencies": {

--- a/packages/server/src/ical-route.test.ts
+++ b/packages/server/src/ical-route.test.ts
@@ -194,7 +194,10 @@ describe('icalHandler', () => {
 
     it('returns 400 when secret contains invalid characters', async () => {
       const res = makeRes();
-      await icalHandler(makeReq({ secret: 'g1b2c3d4-e5f6-7890-abcd-ef1234567890' }), res);
+      await icalHandler(
+        makeReq({ secret: 'g1b2c3d4-e5f6-7890-abcd-ef1234567890' }),
+        res,
+      );
       expect(res.statusCode).toBe(400);
     });
 
@@ -228,7 +231,9 @@ describe('icalHandler', () => {
       const res = makeRes();
       await icalHandler(makeReq({ secret: VALID_SECRET }), res);
       expect(res.headers['Content-Type']).toBe('text/calendar; charset=utf-8');
-      expect(res.headers['Content-Disposition']).toBe('inline; filename="auto-cal.ics"');
+      expect(res.headers['Content-Disposition']).toBe(
+        'inline; filename="auto-cal.ics"',
+      );
     });
 
     it('returns a valid iCal envelope', async () => {
@@ -255,11 +260,17 @@ describe('icalHandler', () => {
     it('generates events for todos that fit in a time block', async () => {
       const user = makeUser();
       vi.mocked(db.query.users.findFirst).mockResolvedValue(user);
-      vi.mocked(db.query.timeBlocks.findMany).mockResolvedValue([makeTimeBlock()]);
+      vi.mocked(db.query.timeBlocks.findMany).mockResolvedValue([
+        makeTimeBlock(),
+      ]);
       vi.mocked(db.query.todos.findMany).mockResolvedValue([makeTodo()]);
-      vi.mocked(db.query.todoLists.findMany).mockResolvedValue([makeTodoList()]);
+      vi.mocked(db.query.todoLists.findMany).mockResolvedValue([
+        makeTodoList(),
+      ]);
       vi.mocked(db.query.habits.findMany).mockResolvedValue([]);
-      vi.mocked(db.query.activityTypes.findMany).mockResolvedValue([makeActivityType()]);
+      vi.mocked(db.query.activityTypes.findMany).mockResolvedValue([
+        makeActivityType(),
+      ]);
 
       const res = makeRes();
       await icalHandler(makeReq({ secret: VALID_SECRET }), res);
@@ -272,11 +283,15 @@ describe('icalHandler', () => {
       const todoList = makeTodoList({ activityTypeId: 'at-work' });
       const todo = makeTodo({ listId: 'list-1' });
       vi.mocked(db.query.users.findFirst).mockResolvedValue(user);
-      vi.mocked(db.query.timeBlocks.findMany).mockResolvedValue([makeTimeBlock()]);
+      vi.mocked(db.query.timeBlocks.findMany).mockResolvedValue([
+        makeTimeBlock(),
+      ]);
       vi.mocked(db.query.todos.findMany).mockResolvedValue([todo]);
       vi.mocked(db.query.todoLists.findMany).mockResolvedValue([todoList]);
       vi.mocked(db.query.habits.findMany).mockResolvedValue([]);
-      vi.mocked(db.query.activityTypes.findMany).mockResolvedValue([makeActivityType()]);
+      vi.mocked(db.query.activityTypes.findMany).mockResolvedValue([
+        makeActivityType(),
+      ]);
 
       const res = makeRes();
       await icalHandler(makeReq({ secret: VALID_SECRET }), res);
@@ -286,11 +301,15 @@ describe('icalHandler', () => {
     it('generates events for habits with a remaining deficit', async () => {
       const habit = makeHabit({ frequencyCount: 3, frequencyUnit: 'week' });
       vi.mocked(db.query.users.findFirst).mockResolvedValue(makeUser());
-      vi.mocked(db.query.timeBlocks.findMany).mockResolvedValue([makeTimeBlock()]);
+      vi.mocked(db.query.timeBlocks.findMany).mockResolvedValue([
+        makeTimeBlock(),
+      ]);
       vi.mocked(db.query.todos.findMany).mockResolvedValue([]);
       vi.mocked(db.query.todoLists.findMany).mockResolvedValue([]);
       vi.mocked(db.query.habits.findMany).mockResolvedValue([habit]);
-      vi.mocked(db.query.activityTypes.findMany).mockResolvedValue([makeActivityType()]);
+      vi.mocked(db.query.activityTypes.findMany).mockResolvedValue([
+        makeActivityType(),
+      ]);
       vi.mocked(db.query.habitCompletions.findMany).mockResolvedValue([]);
 
       const res = makeRes();
@@ -303,12 +322,18 @@ describe('icalHandler', () => {
       const habit = makeHabit({ frequencyCount: 2, frequencyUnit: 'week' });
       const completions = [makeCompletion(), makeCompletion()];
       vi.mocked(db.query.users.findFirst).mockResolvedValue(makeUser());
-      vi.mocked(db.query.timeBlocks.findMany).mockResolvedValue([makeTimeBlock()]);
+      vi.mocked(db.query.timeBlocks.findMany).mockResolvedValue([
+        makeTimeBlock(),
+      ]);
       vi.mocked(db.query.todos.findMany).mockResolvedValue([]);
       vi.mocked(db.query.todoLists.findMany).mockResolvedValue([]);
       vi.mocked(db.query.habits.findMany).mockResolvedValue([habit]);
-      vi.mocked(db.query.activityTypes.findMany).mockResolvedValue([makeActivityType()]);
-      vi.mocked(db.query.habitCompletions.findMany).mockResolvedValue(completions);
+      vi.mocked(db.query.activityTypes.findMany).mockResolvedValue([
+        makeActivityType(),
+      ]);
+      vi.mocked(db.query.habitCompletions.findMany).mockResolvedValue(
+        completions,
+      );
 
       const res = makeRes();
       await icalHandler(makeReq({ secret: VALID_SECRET }), res);
@@ -318,11 +343,15 @@ describe('icalHandler', () => {
     it('queries habit completions for both week and month windows', async () => {
       const habit = makeHabit();
       vi.mocked(db.query.users.findFirst).mockResolvedValue(makeUser());
-      vi.mocked(db.query.timeBlocks.findMany).mockResolvedValue([makeTimeBlock()]);
+      vi.mocked(db.query.timeBlocks.findMany).mockResolvedValue([
+        makeTimeBlock(),
+      ]);
       vi.mocked(db.query.todos.findMany).mockResolvedValue([]);
       vi.mocked(db.query.todoLists.findMany).mockResolvedValue([]);
       vi.mocked(db.query.habits.findMany).mockResolvedValue([habit]);
-      vi.mocked(db.query.activityTypes.findMany).mockResolvedValue([makeActivityType()]);
+      vi.mocked(db.query.activityTypes.findMany).mockResolvedValue([
+        makeActivityType(),
+      ]);
       vi.mocked(db.query.habitCompletions.findMany).mockResolvedValue([]);
 
       await icalHandler(makeReq({ secret: VALID_SECRET }), makeRes());
@@ -340,11 +369,15 @@ describe('icalHandler', () => {
     it('uses monthCounts for habits with monthly frequency', async () => {
       const habit = makeHabit({ frequencyCount: 2, frequencyUnit: 'month' });
       vi.mocked(db.query.users.findFirst).mockResolvedValue(makeUser());
-      vi.mocked(db.query.timeBlocks.findMany).mockResolvedValue([makeTimeBlock()]);
+      vi.mocked(db.query.timeBlocks.findMany).mockResolvedValue([
+        makeTimeBlock(),
+      ]);
       vi.mocked(db.query.todos.findMany).mockResolvedValue([]);
       vi.mocked(db.query.todoLists.findMany).mockResolvedValue([]);
       vi.mocked(db.query.habits.findMany).mockResolvedValue([habit]);
-      vi.mocked(db.query.activityTypes.findMany).mockResolvedValue([makeActivityType()]);
+      vi.mocked(db.query.activityTypes.findMany).mockResolvedValue([
+        makeActivityType(),
+      ]);
       // 0 completions this month → 2 deficit → events generated
       vi.mocked(db.query.habitCompletions.findMany).mockResolvedValue([]);
 
@@ -358,7 +391,9 @@ describe('icalHandler', () => {
       // Pass an empty activityTypes list so the scheduler cannot resolve the type
       const todoList = makeTodoList({ activityTypeId: 'at-work' });
       vi.mocked(db.query.users.findFirst).mockResolvedValue(makeUser());
-      vi.mocked(db.query.timeBlocks.findMany).mockResolvedValue([makeTimeBlock()]);
+      vi.mocked(db.query.timeBlocks.findMany).mockResolvedValue([
+        makeTimeBlock(),
+      ]);
       vi.mocked(db.query.todos.findMany).mockResolvedValue([makeTodo()]);
       vi.mocked(db.query.todoLists.findMany).mockResolvedValue([todoList]);
       vi.mocked(db.query.habits.findMany).mockResolvedValue([]);
@@ -373,13 +408,23 @@ describe('icalHandler', () => {
     it('produces no events when todos have no matching time block', async () => {
       // Todo is Work activity type but time block is for a different type
       const mismatchedBlock = makeTimeBlock({ activityTypeId: 'at-exercise' });
-      const exerciseType = makeActivityType({ id: 'at-exercise', name: 'Exercise' });
+      const exerciseType = makeActivityType({
+        id: 'at-exercise',
+        name: 'Exercise',
+      });
       vi.mocked(db.query.users.findFirst).mockResolvedValue(makeUser());
-      vi.mocked(db.query.timeBlocks.findMany).mockResolvedValue([mismatchedBlock]);
+      vi.mocked(db.query.timeBlocks.findMany).mockResolvedValue([
+        mismatchedBlock,
+      ]);
       vi.mocked(db.query.todos.findMany).mockResolvedValue([makeTodo()]);
-      vi.mocked(db.query.todoLists.findMany).mockResolvedValue([makeTodoList()]);
+      vi.mocked(db.query.todoLists.findMany).mockResolvedValue([
+        makeTodoList(),
+      ]);
       vi.mocked(db.query.habits.findMany).mockResolvedValue([]);
-      vi.mocked(db.query.activityTypes.findMany).mockResolvedValue([makeActivityType(), exerciseType]);
+      vi.mocked(db.query.activityTypes.findMany).mockResolvedValue([
+        makeActivityType(),
+        exerciseType,
+      ]);
 
       const res = makeRes();
       await icalHandler(makeReq({ secret: VALID_SECRET }), res);

--- a/packages/server/src/schema/resolvers/resolvers.habits.integration.test.ts
+++ b/packages/server/src/schema/resolvers/resolvers.habits.integration.test.ts
@@ -36,7 +36,12 @@ describe('habit resolvers', () => {
       const otherAt = await seedActivityType(db, otherId);
       await seedHabit(db, otherId, otherAt.id, { title: 'Theirs' });
 
-      const result = await gql(testSchema, db, userId, 'query { myHabits { title } }');
+      const result = await gql(
+        testSchema,
+        db,
+        userId,
+        'query { myHabits { title } }',
+      );
       expect(result.errors).toBeUndefined();
       const items = result.data?.myHabits as Array<{ title: string }>;
       expect(items.every((i) => i.title !== 'Theirs')).toBe(true);
@@ -50,7 +55,9 @@ describe('habit resolvers', () => {
       await seedHabit(db, userId, at2.id, { title: 'Exercise habit' });
 
       const result = await gql(
-        testSchema, db, userId,
+        testSchema,
+        db,
+        userId,
         'query($id: ID) { myHabits(activityTypeId: $id) { title } }',
         { id: at2.id },
       );
@@ -66,7 +73,12 @@ describe('habit resolvers', () => {
   describe('habitStats', () => {
     it('returns empty array when user has no habits', async () => {
       const { id: userId } = await seedUser(db, 'habitstats-empty@example.com');
-      const result = await gql(testSchema, db, userId, 'query { habitStats { habitId } }');
+      const result = await gql(
+        testSchema,
+        db,
+        userId,
+        'query { habitStats { habitId } }',
+      );
       expect(result.errors).toBeUndefined();
       expect(result.data?.habitStats).toEqual([]);
     });
@@ -75,26 +87,38 @@ describe('habit resolvers', () => {
       const { id: userId } = await seedUser(db, 'habitstats-rate@example.com');
       const at = await seedActivityType(db, userId);
       const habit = await seedHabit(db, userId, at.id, { frequencyCount: 4 });
-      await db.insert(habitCompletions).values({ habitId: habit.id, completedAt: new Date() });
+      await db
+        .insert(habitCompletions)
+        .values({ habitId: habit.id, completedAt: new Date() });
 
       const result = await gql(
-        testSchema, db, userId,
+        testSchema,
+        db,
+        userId,
         'query { habitStats { habitId title completionRate totalCompletions } }',
       );
       expect(result.errors).toBeUndefined();
-      const stats = result.data?.habitStats as Array<{ totalCompletions: number; completionRate: number }>;
+      const stats = result.data?.habitStats as Array<{
+        totalCompletions: number;
+        completionRate: number;
+      }>;
       expect(stats[0]?.totalCompletions).toBe(1);
       expect(stats[0]?.completionRate).toBeCloseTo(0.25);
     });
 
     it('filters by habitId', async () => {
-      const { id: userId } = await seedUser(db, 'habitstats-filter@example.com');
+      const { id: userId } = await seedUser(
+        db,
+        'habitstats-filter@example.com',
+      );
       const at = await seedActivityType(db, userId);
       const h1 = await seedHabit(db, userId, at.id, { title: 'H1' });
       await seedHabit(db, userId, at.id, { title: 'H2' });
 
       const result = await gql(
-        testSchema, db, userId,
+        testSchema,
+        db,
+        userId,
         'query($id: ID) { habitStats(habitId: $id) { habitId } }',
         { id: h1.id },
       );
@@ -105,18 +129,27 @@ describe('habit resolvers', () => {
     });
 
     it('respects startDate/endDate filters for completions', async () => {
-      const { id: userId } = await seedUser(db, 'habitstats-datefilter@example.com');
+      const { id: userId } = await seedUser(
+        db,
+        'habitstats-datefilter@example.com',
+      );
       const at = await seedActivityType(db, userId);
       const habit = await seedHabit(db, userId, at.id);
-      await db.insert(habitCompletions).values({ habitId: habit.id, completedAt: new Date('2020-01-01') });
+      await db
+        .insert(habitCompletions)
+        .values({ habitId: habit.id, completedAt: new Date('2020-01-01') });
 
       const result = await gql(
-        testSchema, db, userId,
+        testSchema,
+        db,
+        userId,
         'query($s: String, $e: String) { habitStats(startDate: $s, endDate: $e) { totalCompletions } }',
         { s: '2025-01-01', e: '2025-12-31' },
       );
       expect(result.errors).toBeUndefined();
-      const stats = result.data?.habitStats as Array<{ totalCompletions: number }>;
+      const stats = result.data?.habitStats as Array<{
+        totalCompletions: number;
+      }>;
       expect(stats[0]?.totalCompletions).toBe(0);
     });
   });
@@ -135,52 +168,96 @@ describe('habit resolvers', () => {
     `;
 
     it('throws when habit not found', async () => {
-      const { id: userId } = await seedUser(db, 'habitdetail-notfound@example.com');
-      const result = await gql(testSchema, db, userId, DETAIL_QUERY, { id: '00000000-0000-0000-0000-000000000000' });
+      const { id: userId } = await seedUser(
+        db,
+        'habitdetail-notfound@example.com',
+      );
+      const result = await gql(testSchema, db, userId, DETAIL_QUERY, {
+        id: '00000000-0000-0000-0000-000000000000',
+      });
       expect(result.errors?.[0]?.message).toMatch(/not found/i);
     });
 
     it('throws Forbidden when habit belongs to another user', async () => {
-      const { id: userId } = await seedUser(db, 'habitdetail-forbidden@example.com');
-      const { id: otherId } = await seedUser(db, 'habitdetail-other@example.com');
+      const { id: userId } = await seedUser(
+        db,
+        'habitdetail-forbidden@example.com',
+      );
+      const { id: otherId } = await seedUser(
+        db,
+        'habitdetail-other@example.com',
+      );
       const otherAt = await seedActivityType(db, otherId);
       const otherHabit = await seedHabit(db, otherId, otherAt.id);
 
-      const result = await gql(testSchema, db, userId, DETAIL_QUERY, { id: otherHabit.id });
+      const result = await gql(testSchema, db, userId, DETAIL_QUERY, {
+        id: otherHabit.id,
+      });
       expect(result.errors?.[0]?.message).toMatch(/forbidden/i);
     });
 
     it('returns weekly period breakdown with completions', async () => {
-      const { id: userId } = await seedUser(db, 'habitdetail-weekly@example.com');
+      const { id: userId } = await seedUser(
+        db,
+        'habitdetail-weekly@example.com',
+      );
       const at = await seedActivityType(db, userId);
-      const habit = await seedHabit(db, userId, at.id, { frequencyUnit: 'week', frequencyCount: 3 });
-      await db.insert(habitCompletions).values({ habitId: habit.id, completedAt: new Date() });
+      const habit = await seedHabit(db, userId, at.id, {
+        frequencyUnit: 'week',
+        frequencyCount: 3,
+      });
+      await db
+        .insert(habitCompletions)
+        .values({ habitId: habit.id, completedAt: new Date() });
 
-      const result = await gql(testSchema, db, userId, DETAIL_QUERY, { id: habit.id, periods: 4 });
+      const result = await gql(testSchema, db, userId, DETAIL_QUERY, {
+        id: habit.id,
+        periods: 4,
+      });
       expect(result.errors).toBeUndefined();
-      const detail = result.data?.myHabitDetail as { totalCompletions: number; periods: unknown[] };
+      const detail = result.data?.myHabitDetail as {
+        totalCompletions: number;
+        periods: unknown[];
+      };
       expect(detail.totalCompletions).toBe(1);
       expect(detail.periods).toHaveLength(4);
     });
 
     it('returns monthly period breakdown', async () => {
-      const { id: userId } = await seedUser(db, 'habitdetail-monthly@example.com');
+      const { id: userId } = await seedUser(
+        db,
+        'habitdetail-monthly@example.com',
+      );
       const at = await seedActivityType(db, userId);
-      const habit = await seedHabit(db, userId, at.id, { frequencyUnit: 'month', frequencyCount: 8 });
+      const habit = await seedHabit(db, userId, at.id, {
+        frequencyUnit: 'month',
+        frequencyCount: 8,
+      });
 
-      const result = await gql(testSchema, db, userId, DETAIL_QUERY, { id: habit.id, periods: 3 });
+      const result = await gql(testSchema, db, userId, DETAIL_QUERY, {
+        id: habit.id,
+        periods: 3,
+      });
       expect(result.errors).toBeUndefined();
-      const detail = result.data?.myHabitDetail as { periods: Array<{ target: number }> };
+      const detail = result.data?.myHabitDetail as {
+        periods: Array<{ target: number }>;
+      };
       expect(detail.periods).toHaveLength(3);
       expect(detail.periods[0]?.target).toBe(8);
     });
 
     it('clamps periods to maximum of 26', async () => {
-      const { id: userId } = await seedUser(db, 'habitdetail-clamp@example.com');
+      const { id: userId } = await seedUser(
+        db,
+        'habitdetail-clamp@example.com',
+      );
       const at = await seedActivityType(db, userId);
       const habit = await seedHabit(db, userId, at.id);
 
-      const result = await gql(testSchema, db, userId, DETAIL_QUERY, { id: habit.id, periods: 999 });
+      const result = await gql(testSchema, db, userId, DETAIL_QUERY, {
+        id: habit.id,
+        periods: 999,
+      });
       expect(result.errors).toBeUndefined();
       const detail = result.data?.myHabitDetail as { periods: unknown[] };
       expect(detail.periods).toHaveLength(26);
@@ -191,9 +268,13 @@ describe('habit resolvers', () => {
       const at = await seedActivityType(db, userId, 'Focus');
       const habit = await seedHabit(db, userId, at.id);
 
-      const result = await gql(testSchema, db, userId, DETAIL_QUERY, { id: habit.id });
+      const result = await gql(testSchema, db, userId, DETAIL_QUERY, {
+        id: habit.id,
+      });
       expect(result.errors).toBeUndefined();
-      const detail = result.data?.myHabitDetail as { activityType: { name: string } | null };
+      const detail = result.data?.myHabitDetail as {
+        activityType: { name: string } | null;
+      };
       expect(detail.activityType?.name).toBe('Focus');
     });
   });
@@ -202,12 +283,25 @@ describe('habit resolvers', () => {
 
   describe('myCreateHabit', () => {
     it('throws when not authenticated', async () => {
-      const { id: userId } = await seedUser(db, 'create-habit-seed@example.com');
+      const { id: userId } = await seedUser(
+        db,
+        'create-habit-seed@example.com',
+      );
       const at = await seedActivityType(db, userId);
       const result = await gql(
-        testSchema, db, '',
+        testSchema,
+        db,
+        '',
         'mutation($input: CreateHabitArgs!) { myCreateHabit(input: $input) { id } }',
-        { input: { title: 'X', activityTypeId: at.id, frequencyCount: 3, frequencyUnit: 'week', estimatedLength: 30 } },
+        {
+          input: {
+            title: 'X',
+            activityTypeId: at.id,
+            frequencyCount: 3,
+            frequencyUnit: 'week',
+            estimatedLength: 30,
+          },
+        },
       );
       expect(result.errors?.[0]?.message).toMatch(/not authenticated/i);
     });
@@ -217,12 +311,25 @@ describe('habit resolvers', () => {
       const at = await seedActivityType(db, userId);
 
       const result = await gql(
-        testSchema, db, userId,
+        testSchema,
+        db,
+        userId,
         'mutation($input: CreateHabitArgs!) { myCreateHabit(input: $input) { id title frequencyCount frequencyUnit } }',
-        { input: { title: 'Daily walk', activityTypeId: at.id, frequencyCount: 5, frequencyUnit: 'week', estimatedLength: 30 } },
+        {
+          input: {
+            title: 'Daily walk',
+            activityTypeId: at.id,
+            frequencyCount: 5,
+            frequencyUnit: 'week',
+            estimatedLength: 30,
+          },
+        },
       );
       expect(result.errors).toBeUndefined();
-      const habit = result.data?.myCreateHabit as { title: string; frequencyCount: number };
+      const habit = result.data?.myCreateHabit as {
+        title: string;
+        frequencyCount: number;
+      };
       expect(habit.title).toBe('Daily walk');
       expect(habit.frequencyCount).toBe(5);
     });
@@ -237,7 +344,9 @@ describe('habit resolvers', () => {
       const habit = await seedHabit(db, userId, at.id);
 
       const result = await gql(
-        testSchema, db, userId,
+        testSchema,
+        db,
+        userId,
         'mutation($id: ID!) { myDeleteHabit(id: $id) }',
         { id: habit.id },
       );
@@ -246,22 +355,35 @@ describe('habit resolvers', () => {
     });
 
     it('throws when habit not found', async () => {
-      const { id: userId } = await seedUser(db, 'delete-habit-notfound@example.com');
+      const { id: userId } = await seedUser(
+        db,
+        'delete-habit-notfound@example.com',
+      );
       const result = await gql(
-        testSchema, db, userId,
+        testSchema,
+        db,
+        userId,
         'mutation { myDeleteHabit(id: "00000000-0000-0000-0000-000000000000") }',
       );
       expect(result.errors?.[0]?.message).toMatch(/not found/i);
     });
 
     it('throws Forbidden when habit belongs to another user', async () => {
-      const { id: userId } = await seedUser(db, 'delete-habit-forbidden@example.com');
-      const { id: otherId } = await seedUser(db, 'delete-habit-other@example.com');
+      const { id: userId } = await seedUser(
+        db,
+        'delete-habit-forbidden@example.com',
+      );
+      const { id: otherId } = await seedUser(
+        db,
+        'delete-habit-other@example.com',
+      );
       const otherAt = await seedActivityType(db, otherId);
       const otherHabit = await seedHabit(db, otherId, otherAt.id);
 
       const result = await gql(
-        testSchema, db, userId,
+        testSchema,
+        db,
+        userId,
         'mutation($id: ID!) { myDeleteHabit(id: $id) }',
         { id: otherHabit.id },
       );
@@ -275,23 +397,36 @@ describe('habit resolvers', () => {
     it('updates habit fields', async () => {
       const { id: userId } = await seedUser(db, 'update-habit@example.com');
       const at = await seedActivityType(db, userId);
-      const habit = await seedHabit(db, userId, at.id, { title: 'Old', frequencyCount: 2 });
+      const habit = await seedHabit(db, userId, at.id, {
+        title: 'Old',
+        frequencyCount: 2,
+      });
 
       const result = await gql(
-        testSchema, db, userId,
+        testSchema,
+        db,
+        userId,
         'mutation($input: UpdateHabitArgs!) { myUpdateHabit(input: $input) { id title frequencyCount } }',
         { input: { id: habit.id, title: 'New', frequencyCount: 5 } },
       );
       expect(result.errors).toBeUndefined();
-      const updated = result.data?.myUpdateHabit as { title: string; frequencyCount: number };
+      const updated = result.data?.myUpdateHabit as {
+        title: string;
+        frequencyCount: number;
+      };
       expect(updated.title).toBe('New');
       expect(updated.frequencyCount).toBe(5);
     });
 
     it('throws when habit not found', async () => {
-      const { id: userId } = await seedUser(db, 'update-habit-notfound@example.com');
+      const { id: userId } = await seedUser(
+        db,
+        'update-habit-notfound@example.com',
+      );
       const result = await gql(
-        testSchema, db, userId,
+        testSchema,
+        db,
+        userId,
         'mutation($input: UpdateHabitArgs!) { myUpdateHabit(input: $input) { id } }',
         { input: { id: '00000000-0000-0000-0000-000000000000', title: 'X' } },
       );
@@ -299,13 +434,21 @@ describe('habit resolvers', () => {
     });
 
     it('throws Forbidden when habit belongs to another user', async () => {
-      const { id: userId } = await seedUser(db, 'update-habit-forbidden@example.com');
-      const { id: otherId } = await seedUser(db, 'update-habit-other@example.com');
+      const { id: userId } = await seedUser(
+        db,
+        'update-habit-forbidden@example.com',
+      );
+      const { id: otherId } = await seedUser(
+        db,
+        'update-habit-other@example.com',
+      );
       const otherAt = await seedActivityType(db, otherId);
       const otherHabit = await seedHabit(db, otherId, otherAt.id);
 
       const result = await gql(
-        testSchema, db, userId,
+        testSchema,
+        db,
+        userId,
         'mutation($input: UpdateHabitArgs!) { myUpdateHabit(input: $input) { id } }',
         { input: { id: otherHabit.id, title: 'Hack' } },
       );
@@ -322,25 +465,41 @@ describe('habit resolvers', () => {
       const habit = await seedHabit(db, userId, at.id);
 
       const result = await gql(
-        testSchema, db, userId,
+        testSchema,
+        db,
+        userId,
         'mutation($input: CompleteHabitArgs!) { myCompleteHabit(input: $input) { id habitId completedAt } }',
         { input: { habitId: habit.id } },
       );
       expect(result.errors).toBeUndefined();
-      const completion = result.data?.myCompleteHabit as { habitId: string; completedAt: string };
+      const completion = result.data?.myCompleteHabit as {
+        habitId: string;
+        completedAt: string;
+      };
       expect(completion.habitId).toBe(habit.id);
       expect(completion.completedAt).not.toBeNull();
     });
 
     it('records a completion with explicit scheduledAt and completedAt', async () => {
-      const { id: userId } = await seedUser(db, 'complete-habit-explicit@example.com');
+      const { id: userId } = await seedUser(
+        db,
+        'complete-habit-explicit@example.com',
+      );
       const at = await seedActivityType(db, userId);
       const habit = await seedHabit(db, userId, at.id);
 
       const result = await gql(
-        testSchema, db, userId,
+        testSchema,
+        db,
+        userId,
         'mutation($input: CompleteHabitArgs!) { myCompleteHabit(input: $input) { scheduledAt completedAt } }',
-        { input: { habitId: habit.id, scheduledAt: '2025-06-01T09:00:00', completedAt: '2025-06-01T10:00:00' } },
+        {
+          input: {
+            habitId: habit.id,
+            scheduledAt: '2025-06-01T09:00:00',
+            completedAt: '2025-06-01T10:00:00',
+          },
+        },
       );
       expect(result.errors).toBeUndefined();
       const c = result.data?.myCompleteHabit as { scheduledAt: string };
@@ -348,9 +507,14 @@ describe('habit resolvers', () => {
     });
 
     it('throws when habit not found', async () => {
-      const { id: userId } = await seedUser(db, 'complete-habit-notfound@example.com');
+      const { id: userId } = await seedUser(
+        db,
+        'complete-habit-notfound@example.com',
+      );
       const result = await gql(
-        testSchema, db, userId,
+        testSchema,
+        db,
+        userId,
         'mutation($input: CompleteHabitArgs!) { myCompleteHabit(input: $input) { id } }',
         { input: { habitId: '00000000-0000-0000-0000-000000000000' } },
       );
@@ -358,13 +522,21 @@ describe('habit resolvers', () => {
     });
 
     it('throws Forbidden when habit belongs to another user', async () => {
-      const { id: userId } = await seedUser(db, 'complete-habit-forbidden@example.com');
-      const { id: otherId } = await seedUser(db, 'complete-habit-other@example.com');
+      const { id: userId } = await seedUser(
+        db,
+        'complete-habit-forbidden@example.com',
+      );
+      const { id: otherId } = await seedUser(
+        db,
+        'complete-habit-other@example.com',
+      );
       const otherAt = await seedActivityType(db, otherId);
       const otherHabit = await seedHabit(db, otherId, otherAt.id);
 
       const result = await gql(
-        testSchema, db, userId,
+        testSchema,
+        db,
+        userId,
         'mutation($input: CompleteHabitArgs!) { myCompleteHabit(input: $input) { id } }',
         { input: { habitId: otherHabit.id } },
       );
@@ -386,7 +558,9 @@ describe('habit resolvers', () => {
       if (!completion) throw new Error('seed failed');
 
       const result = await gql(
-        testSchema, db, userId,
+        testSchema,
+        db,
+        userId,
         'mutation($id: ID!) { myUncompleteHabit(completionId: $id) }',
         { id: completion.id },
       );
@@ -395,17 +569,28 @@ describe('habit resolvers', () => {
     });
 
     it('throws when completion not found', async () => {
-      const { id: userId } = await seedUser(db, 'uncomplete-habit-notfound@example.com');
+      const { id: userId } = await seedUser(
+        db,
+        'uncomplete-habit-notfound@example.com',
+      );
       const result = await gql(
-        testSchema, db, userId,
+        testSchema,
+        db,
+        userId,
         'mutation { myUncompleteHabit(completionId: "00000000-0000-0000-0000-000000000000") }',
       );
       expect(result.errors?.[0]?.message).toMatch(/not found/i);
     });
 
     it("throws Forbidden when completion belongs to another user's habit", async () => {
-      const { id: userId } = await seedUser(db, 'uncomplete-habit-forbidden@example.com');
-      const { id: otherId } = await seedUser(db, 'uncomplete-habit-other@example.com');
+      const { id: userId } = await seedUser(
+        db,
+        'uncomplete-habit-forbidden@example.com',
+      );
+      const { id: otherId } = await seedUser(
+        db,
+        'uncomplete-habit-other@example.com',
+      );
       const otherAt = await seedActivityType(db, otherId);
       const otherHabit = await seedHabit(db, otherId, otherAt.id);
       const [completion] = await db
@@ -415,7 +600,9 @@ describe('habit resolvers', () => {
       if (!completion) throw new Error('seed failed');
 
       const result = await gql(
-        testSchema, db, userId,
+        testSchema,
+        db,
+        userId,
         'mutation($id: ID!) { myUncompleteHabit(completionId: $id) }',
         { id: completion.id },
       );

--- a/packages/server/src/schema/resolvers/resolvers.habits.integration.test.ts
+++ b/packages/server/src/schema/resolvers/resolvers.habits.integration.test.ts
@@ -1,0 +1,425 @@
+import { habitCompletions } from '@auto-cal/db/schema';
+import { beforeAll, describe, expect, it } from 'vitest';
+import {
+  type TestDb,
+  type TestSchema,
+  buildTestSchema,
+  createTestDb,
+  gql,
+  seedActivityType,
+  seedHabit,
+  seedUser,
+} from './test-helpers.ts';
+
+describe('habit resolvers', () => {
+  let db: TestDb;
+  let testSchema: TestSchema;
+
+  beforeAll(async () => {
+    db = await createTestDb();
+    testSchema = buildTestSchema(db);
+  }, 30000);
+
+  // ─── myHabits ─────────────────────────────────────────────────────────────────
+
+  describe('myHabits', () => {
+    it('throws when not authenticated', async () => {
+      const result = await gql(testSchema, db, '', 'query { myHabits { id } }');
+      expect(result.errors?.[0]?.message).toMatch(/not authenticated/i);
+    });
+
+    it("returns only the current user's habits", async () => {
+      const { id: userId } = await seedUser(db, 'habits-isolation@example.com');
+      const { id: otherId } = await seedUser(db, 'habits-other@example.com');
+      const at = await seedActivityType(db, userId);
+      await seedHabit(db, userId, at.id, { title: 'Mine' });
+      const otherAt = await seedActivityType(db, otherId);
+      await seedHabit(db, otherId, otherAt.id, { title: 'Theirs' });
+
+      const result = await gql(testSchema, db, userId, 'query { myHabits { title } }');
+      expect(result.errors).toBeUndefined();
+      const items = result.data?.myHabits as Array<{ title: string }>;
+      expect(items.every((i) => i.title !== 'Theirs')).toBe(true);
+    });
+
+    it('filters by activityTypeId', async () => {
+      const { id: userId } = await seedUser(db, 'habits-atfilter@example.com');
+      const at1 = await seedActivityType(db, userId, 'Work');
+      const at2 = await seedActivityType(db, userId, 'Exercise');
+      await seedHabit(db, userId, at1.id, { title: 'Work habit' });
+      await seedHabit(db, userId, at2.id, { title: 'Exercise habit' });
+
+      const result = await gql(
+        testSchema, db, userId,
+        'query($id: ID) { myHabits(activityTypeId: $id) { title } }',
+        { id: at2.id },
+      );
+      expect(result.errors).toBeUndefined();
+      const items = result.data?.myHabits as Array<{ title: string }>;
+      expect(items).toHaveLength(1);
+      expect(items[0]?.title).toBe('Exercise habit');
+    });
+  });
+
+  // ─── habitStats ───────────────────────────────────────────────────────────────
+
+  describe('habitStats', () => {
+    it('returns empty array when user has no habits', async () => {
+      const { id: userId } = await seedUser(db, 'habitstats-empty@example.com');
+      const result = await gql(testSchema, db, userId, 'query { habitStats { habitId } }');
+      expect(result.errors).toBeUndefined();
+      expect(result.data?.habitStats).toEqual([]);
+    });
+
+    it('returns completion rate per habit', async () => {
+      const { id: userId } = await seedUser(db, 'habitstats-rate@example.com');
+      const at = await seedActivityType(db, userId);
+      const habit = await seedHabit(db, userId, at.id, { frequencyCount: 4 });
+      await db.insert(habitCompletions).values({ habitId: habit.id, completedAt: new Date() });
+
+      const result = await gql(
+        testSchema, db, userId,
+        'query { habitStats { habitId title completionRate totalCompletions } }',
+      );
+      expect(result.errors).toBeUndefined();
+      const stats = result.data?.habitStats as Array<{ totalCompletions: number; completionRate: number }>;
+      expect(stats[0]?.totalCompletions).toBe(1);
+      expect(stats[0]?.completionRate).toBeCloseTo(0.25);
+    });
+
+    it('filters by habitId', async () => {
+      const { id: userId } = await seedUser(db, 'habitstats-filter@example.com');
+      const at = await seedActivityType(db, userId);
+      const h1 = await seedHabit(db, userId, at.id, { title: 'H1' });
+      await seedHabit(db, userId, at.id, { title: 'H2' });
+
+      const result = await gql(
+        testSchema, db, userId,
+        'query($id: ID) { habitStats(habitId: $id) { habitId } }',
+        { id: h1.id },
+      );
+      expect(result.errors).toBeUndefined();
+      const stats = result.data?.habitStats as Array<{ habitId: string }>;
+      expect(stats).toHaveLength(1);
+      expect(stats[0]?.habitId).toBe(h1.id);
+    });
+
+    it('respects startDate/endDate filters for completions', async () => {
+      const { id: userId } = await seedUser(db, 'habitstats-datefilter@example.com');
+      const at = await seedActivityType(db, userId);
+      const habit = await seedHabit(db, userId, at.id);
+      await db.insert(habitCompletions).values({ habitId: habit.id, completedAt: new Date('2020-01-01') });
+
+      const result = await gql(
+        testSchema, db, userId,
+        'query($s: String, $e: String) { habitStats(startDate: $s, endDate: $e) { totalCompletions } }',
+        { s: '2025-01-01', e: '2025-12-31' },
+      );
+      expect(result.errors).toBeUndefined();
+      const stats = result.data?.habitStats as Array<{ totalCompletions: number }>;
+      expect(stats[0]?.totalCompletions).toBe(0);
+    });
+  });
+
+  // ─── myHabitDetail ────────────────────────────────────────────────────────────
+
+  describe('myHabitDetail', () => {
+    const DETAIL_QUERY = `
+      query($id: ID!, $periods: Int) {
+        myHabitDetail(habitId: $id, periods: $periods) {
+          habitId title totalCompletions allTimeRate
+          periods { label completions target rate }
+          activityType { id name }
+        }
+      }
+    `;
+
+    it('throws when habit not found', async () => {
+      const { id: userId } = await seedUser(db, 'habitdetail-notfound@example.com');
+      const result = await gql(testSchema, db, userId, DETAIL_QUERY, { id: '00000000-0000-0000-0000-000000000000' });
+      expect(result.errors?.[0]?.message).toMatch(/not found/i);
+    });
+
+    it('throws Forbidden when habit belongs to another user', async () => {
+      const { id: userId } = await seedUser(db, 'habitdetail-forbidden@example.com');
+      const { id: otherId } = await seedUser(db, 'habitdetail-other@example.com');
+      const otherAt = await seedActivityType(db, otherId);
+      const otherHabit = await seedHabit(db, otherId, otherAt.id);
+
+      const result = await gql(testSchema, db, userId, DETAIL_QUERY, { id: otherHabit.id });
+      expect(result.errors?.[0]?.message).toMatch(/forbidden/i);
+    });
+
+    it('returns weekly period breakdown with completions', async () => {
+      const { id: userId } = await seedUser(db, 'habitdetail-weekly@example.com');
+      const at = await seedActivityType(db, userId);
+      const habit = await seedHabit(db, userId, at.id, { frequencyUnit: 'week', frequencyCount: 3 });
+      await db.insert(habitCompletions).values({ habitId: habit.id, completedAt: new Date() });
+
+      const result = await gql(testSchema, db, userId, DETAIL_QUERY, { id: habit.id, periods: 4 });
+      expect(result.errors).toBeUndefined();
+      const detail = result.data?.myHabitDetail as { totalCompletions: number; periods: unknown[] };
+      expect(detail.totalCompletions).toBe(1);
+      expect(detail.periods).toHaveLength(4);
+    });
+
+    it('returns monthly period breakdown', async () => {
+      const { id: userId } = await seedUser(db, 'habitdetail-monthly@example.com');
+      const at = await seedActivityType(db, userId);
+      const habit = await seedHabit(db, userId, at.id, { frequencyUnit: 'month', frequencyCount: 8 });
+
+      const result = await gql(testSchema, db, userId, DETAIL_QUERY, { id: habit.id, periods: 3 });
+      expect(result.errors).toBeUndefined();
+      const detail = result.data?.myHabitDetail as { periods: Array<{ target: number }> };
+      expect(detail.periods).toHaveLength(3);
+      expect(detail.periods[0]?.target).toBe(8);
+    });
+
+    it('clamps periods to maximum of 26', async () => {
+      const { id: userId } = await seedUser(db, 'habitdetail-clamp@example.com');
+      const at = await seedActivityType(db, userId);
+      const habit = await seedHabit(db, userId, at.id);
+
+      const result = await gql(testSchema, db, userId, DETAIL_QUERY, { id: habit.id, periods: 999 });
+      expect(result.errors).toBeUndefined();
+      const detail = result.data?.myHabitDetail as { periods: unknown[] };
+      expect(detail.periods).toHaveLength(26);
+    });
+
+    it('includes activityType when present', async () => {
+      const { id: userId } = await seedUser(db, 'habitdetail-at@example.com');
+      const at = await seedActivityType(db, userId, 'Focus');
+      const habit = await seedHabit(db, userId, at.id);
+
+      const result = await gql(testSchema, db, userId, DETAIL_QUERY, { id: habit.id });
+      expect(result.errors).toBeUndefined();
+      const detail = result.data?.myHabitDetail as { activityType: { name: string } | null };
+      expect(detail.activityType?.name).toBe('Focus');
+    });
+  });
+
+  // ─── myCreateHabit ────────────────────────────────────────────────────────────
+
+  describe('myCreateHabit', () => {
+    it('throws when not authenticated', async () => {
+      const { id: userId } = await seedUser(db, 'create-habit-seed@example.com');
+      const at = await seedActivityType(db, userId);
+      const result = await gql(
+        testSchema, db, '',
+        'mutation($input: CreateHabitArgs!) { myCreateHabit(input: $input) { id } }',
+        { input: { title: 'X', activityTypeId: at.id, frequencyCount: 3, frequencyUnit: 'week', estimatedLength: 30 } },
+      );
+      expect(result.errors?.[0]?.message).toMatch(/not authenticated/i);
+    });
+
+    it('creates a habit and returns it', async () => {
+      const { id: userId } = await seedUser(db, 'create-habit@example.com');
+      const at = await seedActivityType(db, userId);
+
+      const result = await gql(
+        testSchema, db, userId,
+        'mutation($input: CreateHabitArgs!) { myCreateHabit(input: $input) { id title frequencyCount frequencyUnit } }',
+        { input: { title: 'Daily walk', activityTypeId: at.id, frequencyCount: 5, frequencyUnit: 'week', estimatedLength: 30 } },
+      );
+      expect(result.errors).toBeUndefined();
+      const habit = result.data?.myCreateHabit as { title: string; frequencyCount: number };
+      expect(habit.title).toBe('Daily walk');
+      expect(habit.frequencyCount).toBe(5);
+    });
+  });
+
+  // ─── myDeleteHabit ────────────────────────────────────────────────────────────
+
+  describe('myDeleteHabit', () => {
+    it('deletes a habit and returns true', async () => {
+      const { id: userId } = await seedUser(db, 'delete-habit@example.com');
+      const at = await seedActivityType(db, userId);
+      const habit = await seedHabit(db, userId, at.id);
+
+      const result = await gql(
+        testSchema, db, userId,
+        'mutation($id: ID!) { myDeleteHabit(id: $id) }',
+        { id: habit.id },
+      );
+      expect(result.errors).toBeUndefined();
+      expect(result.data?.myDeleteHabit).toBe(true);
+    });
+
+    it('throws when habit not found', async () => {
+      const { id: userId } = await seedUser(db, 'delete-habit-notfound@example.com');
+      const result = await gql(
+        testSchema, db, userId,
+        'mutation { myDeleteHabit(id: "00000000-0000-0000-0000-000000000000") }',
+      );
+      expect(result.errors?.[0]?.message).toMatch(/not found/i);
+    });
+
+    it('throws Forbidden when habit belongs to another user', async () => {
+      const { id: userId } = await seedUser(db, 'delete-habit-forbidden@example.com');
+      const { id: otherId } = await seedUser(db, 'delete-habit-other@example.com');
+      const otherAt = await seedActivityType(db, otherId);
+      const otherHabit = await seedHabit(db, otherId, otherAt.id);
+
+      const result = await gql(
+        testSchema, db, userId,
+        'mutation($id: ID!) { myDeleteHabit(id: $id) }',
+        { id: otherHabit.id },
+      );
+      expect(result.errors?.[0]?.message).toMatch(/forbidden/i);
+    });
+  });
+
+  // ─── myUpdateHabit ────────────────────────────────────────────────────────────
+
+  describe('myUpdateHabit', () => {
+    it('updates habit fields', async () => {
+      const { id: userId } = await seedUser(db, 'update-habit@example.com');
+      const at = await seedActivityType(db, userId);
+      const habit = await seedHabit(db, userId, at.id, { title: 'Old', frequencyCount: 2 });
+
+      const result = await gql(
+        testSchema, db, userId,
+        'mutation($input: UpdateHabitArgs!) { myUpdateHabit(input: $input) { id title frequencyCount } }',
+        { input: { id: habit.id, title: 'New', frequencyCount: 5 } },
+      );
+      expect(result.errors).toBeUndefined();
+      const updated = result.data?.myUpdateHabit as { title: string; frequencyCount: number };
+      expect(updated.title).toBe('New');
+      expect(updated.frequencyCount).toBe(5);
+    });
+
+    it('throws when habit not found', async () => {
+      const { id: userId } = await seedUser(db, 'update-habit-notfound@example.com');
+      const result = await gql(
+        testSchema, db, userId,
+        'mutation($input: UpdateHabitArgs!) { myUpdateHabit(input: $input) { id } }',
+        { input: { id: '00000000-0000-0000-0000-000000000000', title: 'X' } },
+      );
+      expect(result.errors?.[0]?.message).toMatch(/not found/i);
+    });
+
+    it('throws Forbidden when habit belongs to another user', async () => {
+      const { id: userId } = await seedUser(db, 'update-habit-forbidden@example.com');
+      const { id: otherId } = await seedUser(db, 'update-habit-other@example.com');
+      const otherAt = await seedActivityType(db, otherId);
+      const otherHabit = await seedHabit(db, otherId, otherAt.id);
+
+      const result = await gql(
+        testSchema, db, userId,
+        'mutation($input: UpdateHabitArgs!) { myUpdateHabit(input: $input) { id } }',
+        { input: { id: otherHabit.id, title: 'Hack' } },
+      );
+      expect(result.errors?.[0]?.message).toMatch(/forbidden/i);
+    });
+  });
+
+  // ─── myCompleteHabit ──────────────────────────────────────────────────────────
+
+  describe('myCompleteHabit', () => {
+    it('records a completion', async () => {
+      const { id: userId } = await seedUser(db, 'complete-habit@example.com');
+      const at = await seedActivityType(db, userId);
+      const habit = await seedHabit(db, userId, at.id);
+
+      const result = await gql(
+        testSchema, db, userId,
+        'mutation($input: CompleteHabitArgs!) { myCompleteHabit(input: $input) { id habitId completedAt } }',
+        { input: { habitId: habit.id } },
+      );
+      expect(result.errors).toBeUndefined();
+      const completion = result.data?.myCompleteHabit as { habitId: string; completedAt: string };
+      expect(completion.habitId).toBe(habit.id);
+      expect(completion.completedAt).not.toBeNull();
+    });
+
+    it('records a completion with explicit scheduledAt and completedAt', async () => {
+      const { id: userId } = await seedUser(db, 'complete-habit-explicit@example.com');
+      const at = await seedActivityType(db, userId);
+      const habit = await seedHabit(db, userId, at.id);
+
+      const result = await gql(
+        testSchema, db, userId,
+        'mutation($input: CompleteHabitArgs!) { myCompleteHabit(input: $input) { scheduledAt completedAt } }',
+        { input: { habitId: habit.id, scheduledAt: '2025-06-01T09:00:00', completedAt: '2025-06-01T10:00:00' } },
+      );
+      expect(result.errors).toBeUndefined();
+      const c = result.data?.myCompleteHabit as { scheduledAt: string };
+      expect(c.scheduledAt).not.toBeNull();
+    });
+
+    it('throws when habit not found', async () => {
+      const { id: userId } = await seedUser(db, 'complete-habit-notfound@example.com');
+      const result = await gql(
+        testSchema, db, userId,
+        'mutation($input: CompleteHabitArgs!) { myCompleteHabit(input: $input) { id } }',
+        { input: { habitId: '00000000-0000-0000-0000-000000000000' } },
+      );
+      expect(result.errors?.[0]?.message).toMatch(/not found/i);
+    });
+
+    it('throws Forbidden when habit belongs to another user', async () => {
+      const { id: userId } = await seedUser(db, 'complete-habit-forbidden@example.com');
+      const { id: otherId } = await seedUser(db, 'complete-habit-other@example.com');
+      const otherAt = await seedActivityType(db, otherId);
+      const otherHabit = await seedHabit(db, otherId, otherAt.id);
+
+      const result = await gql(
+        testSchema, db, userId,
+        'mutation($input: CompleteHabitArgs!) { myCompleteHabit(input: $input) { id } }',
+        { input: { habitId: otherHabit.id } },
+      );
+      expect(result.errors?.[0]?.message).toMatch(/forbidden/i);
+    });
+  });
+
+  // ─── myUncompleteHabit ────────────────────────────────────────────────────────
+
+  describe('myUncompleteHabit', () => {
+    it('deletes the completion and returns true', async () => {
+      const { id: userId } = await seedUser(db, 'uncomplete-habit@example.com');
+      const at = await seedActivityType(db, userId);
+      const habit = await seedHabit(db, userId, at.id);
+      const [completion] = await db
+        .insert(habitCompletions)
+        .values({ habitId: habit.id, completedAt: new Date() })
+        .returning();
+      if (!completion) throw new Error('seed failed');
+
+      const result = await gql(
+        testSchema, db, userId,
+        'mutation($id: ID!) { myUncompleteHabit(completionId: $id) }',
+        { id: completion.id },
+      );
+      expect(result.errors).toBeUndefined();
+      expect(result.data?.myUncompleteHabit).toBe(true);
+    });
+
+    it('throws when completion not found', async () => {
+      const { id: userId } = await seedUser(db, 'uncomplete-habit-notfound@example.com');
+      const result = await gql(
+        testSchema, db, userId,
+        'mutation { myUncompleteHabit(completionId: "00000000-0000-0000-0000-000000000000") }',
+      );
+      expect(result.errors?.[0]?.message).toMatch(/not found/i);
+    });
+
+    it("throws Forbidden when completion belongs to another user's habit", async () => {
+      const { id: userId } = await seedUser(db, 'uncomplete-habit-forbidden@example.com');
+      const { id: otherId } = await seedUser(db, 'uncomplete-habit-other@example.com');
+      const otherAt = await seedActivityType(db, otherId);
+      const otherHabit = await seedHabit(db, otherId, otherAt.id);
+      const [completion] = await db
+        .insert(habitCompletions)
+        .values({ habitId: otherHabit.id, completedAt: new Date() })
+        .returning();
+      if (!completion) throw new Error('seed failed');
+
+      const result = await gql(
+        testSchema, db, userId,
+        'mutation($id: ID!) { myUncompleteHabit(completionId: $id) }',
+        { id: completion.id },
+      );
+      expect(result.errors?.[0]?.message).toMatch(/forbidden/i);
+    });
+  });
+});

--- a/packages/server/src/schema/resolvers/resolvers.integration.test.ts
+++ b/packages/server/src/schema/resolvers/resolvers.integration.test.ts
@@ -21,7 +21,7 @@ import { buildSchema } from '@vantreeseba/drizzle-graphql';
 import { drizzle } from 'drizzle-orm/pglite';
 import { migrate } from 'drizzle-orm/pglite/migrator';
 import { graphql } from 'graphql';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import { createLoaders } from '../../context.ts';
 import { applyCustomResolvers } from './index.ts';
 
@@ -76,12 +76,15 @@ describe('resolver integration tests', () => {
   let testSchema: ReturnType<typeof buildTestSchema>;
   let userId: string;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     db = await createTestDb();
     testSchema = buildTestSchema(db);
+  }, 30000);
+
+  beforeEach(async () => {
     const [user] = await db
       .insert(users)
-      .values({ email: 'integration@example.com' })
+      .values({ email: `integration-${Date.now()}@example.com` })
       .returning();
     if (!user) throw new Error('Failed to create test user');
     userId = user.id;

--- a/packages/server/src/schema/resolvers/resolvers.profile-todolists-apikeys.integration.test.ts
+++ b/packages/server/src/schema/resolvers/resolvers.profile-todolists-apikeys.integration.test.ts
@@ -47,13 +47,23 @@ describe('profile, todo-list, and api-key resolvers', () => {
 
   describe('myProfile', () => {
     it('throws when not authenticated', async () => {
-      const result = await gql(testSchema, db, '', 'query { myProfile { id } }');
+      const result = await gql(
+        testSchema,
+        db,
+        '',
+        'query { myProfile { id } }',
+      );
       expect(result.errors?.[0]?.message).toMatch(/not authenticated/i);
     });
 
     it('returns the current user profile', async () => {
       const { id: userId, email } = await seedUser(db, 'profile@example.com');
-      const result = await gql(testSchema, db, userId, 'query { myProfile { id email icalSecret } }');
+      const result = await gql(
+        testSchema,
+        db,
+        userId,
+        'query { myProfile { id email icalSecret } }',
+      );
       expect(result.errors).toBeUndefined();
       const profile = result.data?.myProfile as { id: string; email: string };
       expect(profile.id).toBe(userId);
@@ -65,7 +75,10 @@ describe('profile, todo-list, and api-key resolvers', () => {
 
   describe('myUpdateProfile', () => {
     it('throws when not authenticated', async () => {
-      const result = await gql(testSchema, db, '',
+      const result = await gql(
+        testSchema,
+        db,
+        '',
         'mutation { myUpdateProfile(timezone: "UTC") }',
       );
       expect(result.errors?.[0]?.message).toMatch(/not authenticated/i);
@@ -73,7 +86,10 @@ describe('profile, todo-list, and api-key resolvers', () => {
 
     it('updates the user timezone and returns true', async () => {
       const { id: userId } = await seedUser(db, 'update-profile@example.com');
-      const result = await gql(testSchema, db, userId,
+      const result = await gql(
+        testSchema,
+        db,
+        userId,
         'mutation($tz: String!) { myUpdateProfile(timezone: $tz) }',
         { tz: 'America/New_York' },
       );
@@ -82,8 +98,14 @@ describe('profile, todo-list, and api-key resolvers', () => {
     });
 
     it('throws for an invalid timezone', async () => {
-      const { id: userId } = await seedUser(db, 'update-profile-badtz@example.com');
-      const result = await gql(testSchema, db, userId,
+      const { id: userId } = await seedUser(
+        db,
+        'update-profile-badtz@example.com',
+      );
+      const result = await gql(
+        testSchema,
+        db,
+        userId,
         'mutation { myUpdateProfile(timezone: "Not/ATimezone") }',
       );
       expect(result.errors?.[0]?.message).toMatch(/invalid timezone/i);
@@ -94,13 +116,23 @@ describe('profile, todo-list, and api-key resolvers', () => {
 
   describe('myRegenerateIcalSecret', () => {
     it('throws when not authenticated', async () => {
-      const result = await gql(testSchema, db, '', 'mutation { myRegenerateIcalSecret }');
+      const result = await gql(
+        testSchema,
+        db,
+        '',
+        'mutation { myRegenerateIcalSecret }',
+      );
       expect(result.errors?.[0]?.message).toMatch(/not authenticated/i);
     });
 
     it('returns a new UUID secret', async () => {
       const { id: userId } = await seedUser(db, 'regen-secret@example.com');
-      const result = await gql(testSchema, db, userId, 'mutation { myRegenerateIcalSecret }');
+      const result = await gql(
+        testSchema,
+        db,
+        userId,
+        'mutation { myRegenerateIcalSecret }',
+      );
       expect(result.errors).toBeUndefined();
       const newSecret = result.data?.myRegenerateIcalSecret as string;
       expect(newSecret).toMatch(/^[0-9a-f-]{36}$/i);
@@ -111,19 +143,32 @@ describe('profile, todo-list, and api-key resolvers', () => {
 
   describe('myTodoLists', () => {
     it('throws when not authenticated', async () => {
-      const result = await gql(testSchema, db, '', 'query { myTodoLists { id } }');
+      const result = await gql(
+        testSchema,
+        db,
+        '',
+        'query { myTodoLists { id } }',
+      );
       expect(result.errors?.[0]?.message).toMatch(/not authenticated/i);
     });
 
-    it('returns only the current user\'s lists', async () => {
-      const { id: userId } = await seedUser(db, 'todolists-isolation@example.com');
+    it("returns only the current user's lists", async () => {
+      const { id: userId } = await seedUser(
+        db,
+        'todolists-isolation@example.com',
+      );
       const { id: otherId } = await seedUser(db, 'todolists-other@example.com');
       const at = await seedActivityType(db, userId);
       const otherAt = await seedActivityType(db, otherId);
       await seedTodoList(db, userId, at.id);
       await seedTodoList(db, otherId, otherAt.id);
 
-      const result = await gql(testSchema, db, userId, 'query { myTodoLists { id } }');
+      const result = await gql(
+        testSchema,
+        db,
+        userId,
+        'query { myTodoLists { id } }',
+      );
       expect(result.errors).toBeUndefined();
       expect((result.data?.myTodoLists as unknown[]).length).toBe(1);
     });
@@ -136,29 +181,51 @@ describe('profile, todo-list, and api-key resolvers', () => {
       const { id: userId } = await seedUser(db, 'create-list@example.com');
       const at = await seedActivityType(db, userId);
 
-      const result = await gql(testSchema, db, userId,
+      const result = await gql(
+        testSchema,
+        db,
+        userId,
         'mutation($input: CreateTodoListArgs!) { myCreateTodoList(input: $input) { id name } }',
         { input: { name: 'My List', activityTypeId: at.id } },
       );
       expect(result.errors).toBeUndefined();
-      expect((result.data?.myCreateTodoList as { name: string }).name).toBe('My List');
+      expect((result.data?.myCreateTodoList as { name: string }).name).toBe(
+        'My List',
+      );
     });
 
     it('throws when activity type not found', async () => {
       const { id: userId } = await seedUser(db, 'create-list-noat@example.com');
-      const result = await gql(testSchema, db, userId,
+      const result = await gql(
+        testSchema,
+        db,
+        userId,
         'mutation($input: CreateTodoListArgs!) { myCreateTodoList(input: $input) { id } }',
-        { input: { name: 'X', activityTypeId: '00000000-0000-0000-0000-000000000000' } },
+        {
+          input: {
+            name: 'X',
+            activityTypeId: '00000000-0000-0000-0000-000000000000',
+          },
+        },
       );
       expect(result.errors?.[0]?.message).toMatch(/not found/i);
     });
 
     it('throws Forbidden when activity type belongs to another user', async () => {
-      const { id: userId } = await seedUser(db, 'create-list-forbidden@example.com');
-      const { id: otherId } = await seedUser(db, 'create-list-other@example.com');
+      const { id: userId } = await seedUser(
+        db,
+        'create-list-forbidden@example.com',
+      );
+      const { id: otherId } = await seedUser(
+        db,
+        'create-list-other@example.com',
+      );
       const otherAt = await seedActivityType(db, otherId);
 
-      const result = await gql(testSchema, db, userId,
+      const result = await gql(
+        testSchema,
+        db,
+        userId,
         'mutation($input: CreateTodoListArgs!) { myCreateTodoList(input: $input) { id } }',
         { input: { name: 'Hack', activityTypeId: otherAt.id } },
       );
@@ -174,17 +241,28 @@ describe('profile, todo-list, and api-key resolvers', () => {
       const at = await seedActivityType(db, userId);
       const list = await seedTodoList(db, userId, at.id);
 
-      const result = await gql(testSchema, db, userId,
+      const result = await gql(
+        testSchema,
+        db,
+        userId,
         'mutation($input: UpdateTodoListArgs!) { myUpdateTodoList(input: $input) { id name } }',
         { input: { id: list.id, name: 'Renamed' } },
       );
       expect(result.errors).toBeUndefined();
-      expect((result.data?.myUpdateTodoList as { name: string }).name).toBe('Renamed');
+      expect((result.data?.myUpdateTodoList as { name: string }).name).toBe(
+        'Renamed',
+      );
     });
 
     it('throws when list not found', async () => {
-      const { id: userId } = await seedUser(db, 'update-list-notfound@example.com');
-      const result = await gql(testSchema, db, userId,
+      const { id: userId } = await seedUser(
+        db,
+        'update-list-notfound@example.com',
+      );
+      const result = await gql(
+        testSchema,
+        db,
+        userId,
         'mutation($input: UpdateTodoListArgs!) { myUpdateTodoList(input: $input) { id } }',
         { input: { id: '00000000-0000-0000-0000-000000000000', name: 'X' } },
       );
@@ -192,12 +270,21 @@ describe('profile, todo-list, and api-key resolvers', () => {
     });
 
     it('throws Forbidden when list belongs to another user', async () => {
-      const { id: userId } = await seedUser(db, 'update-list-forbidden@example.com');
-      const { id: otherId } = await seedUser(db, 'update-list-other@example.com');
+      const { id: userId } = await seedUser(
+        db,
+        'update-list-forbidden@example.com',
+      );
+      const { id: otherId } = await seedUser(
+        db,
+        'update-list-other@example.com',
+      );
       const otherAt = await seedActivityType(db, otherId);
       const otherList = await seedTodoList(db, otherId, otherAt.id);
 
-      const result = await gql(testSchema, db, userId,
+      const result = await gql(
+        testSchema,
+        db,
+        userId,
         'mutation($input: UpdateTodoListArgs!) { myUpdateTodoList(input: $input) { id } }',
         { input: { id: otherList.id, name: 'Hack' } },
       );
@@ -209,21 +296,38 @@ describe('profile, todo-list, and api-key resolvers', () => {
       const at = await seedActivityType(db, userId);
       const list = await seedTodoList(db, userId, at.id);
 
-      const result = await gql(testSchema, db, userId,
+      const result = await gql(
+        testSchema,
+        db,
+        userId,
         'mutation($input: UpdateTodoListArgs!) { myUpdateTodoList(input: $input) { id } }',
-        { input: { id: list.id, activityTypeId: '00000000-0000-0000-0000-000000000000' } },
+        {
+          input: {
+            id: list.id,
+            activityTypeId: '00000000-0000-0000-0000-000000000000',
+          },
+        },
       );
       expect(result.errors?.[0]?.message).toMatch(/not found/i);
     });
 
     it('throws Forbidden when new activity type belongs to another user', async () => {
-      const { id: userId } = await seedUser(db, 'update-list-atforbidden@example.com');
-      const { id: otherId } = await seedUser(db, 'update-list-atother@example.com');
+      const { id: userId } = await seedUser(
+        db,
+        'update-list-atforbidden@example.com',
+      );
+      const { id: otherId } = await seedUser(
+        db,
+        'update-list-atother@example.com',
+      );
       const at = await seedActivityType(db, userId);
       const list = await seedTodoList(db, userId, at.id);
       const otherAt = await seedActivityType(db, otherId);
 
-      const result = await gql(testSchema, db, userId,
+      const result = await gql(
+        testSchema,
+        db,
+        userId,
         'mutation($input: UpdateTodoListArgs!) { myUpdateTodoList(input: $input) { id } }',
         { input: { id: list.id, activityTypeId: otherAt.id } },
       );
@@ -239,7 +343,10 @@ describe('profile, todo-list, and api-key resolvers', () => {
       const at = await seedActivityType(db, userId);
       const list = await seedTodoList(db, userId, at.id);
 
-      const result = await gql(testSchema, db, userId,
+      const result = await gql(
+        testSchema,
+        db,
+        userId,
         'mutation($id: ID!) { myDeleteTodoList(id: $id) }',
         { id: list.id },
       );
@@ -248,20 +355,35 @@ describe('profile, todo-list, and api-key resolvers', () => {
     });
 
     it('throws when list not found', async () => {
-      const { id: userId } = await seedUser(db, 'delete-list-notfound@example.com');
-      const result = await gql(testSchema, db, userId,
+      const { id: userId } = await seedUser(
+        db,
+        'delete-list-notfound@example.com',
+      );
+      const result = await gql(
+        testSchema,
+        db,
+        userId,
         'mutation { myDeleteTodoList(id: "00000000-0000-0000-0000-000000000000") }',
       );
       expect(result.errors?.[0]?.message).toMatch(/not found/i);
     });
 
     it('throws Forbidden when list belongs to another user', async () => {
-      const { id: userId } = await seedUser(db, 'delete-list-forbidden@example.com');
-      const { id: otherId } = await seedUser(db, 'delete-list-other@example.com');
+      const { id: userId } = await seedUser(
+        db,
+        'delete-list-forbidden@example.com',
+      );
+      const { id: otherId } = await seedUser(
+        db,
+        'delete-list-other@example.com',
+      );
       const otherAt = await seedActivityType(db, otherId);
       const otherList = await seedTodoList(db, otherId, otherAt.id);
 
-      const result = await gql(testSchema, db, userId,
+      const result = await gql(
+        testSchema,
+        db,
+        userId,
         'mutation($id: ID!) { myDeleteTodoList(id: $id) }',
         { id: otherList.id },
       );
@@ -269,12 +391,18 @@ describe('profile, todo-list, and api-key resolvers', () => {
     });
 
     it('throws when list still contains todos', async () => {
-      const { id: userId } = await seedUser(db, 'delete-list-hastodos@example.com');
+      const { id: userId } = await seedUser(
+        db,
+        'delete-list-hastodos@example.com',
+      );
       const at = await seedActivityType(db, userId);
       const list = await seedTodoList(db, userId, at.id);
       await seedTodo(db, userId, list.id);
 
-      const result = await gql(testSchema, db, userId,
+      const result = await gql(
+        testSchema,
+        db,
+        userId,
         'mutation($id: ID!) { myDeleteTodoList(id: $id) }',
         { id: list.id },
       );
@@ -286,18 +414,31 @@ describe('profile, todo-list, and api-key resolvers', () => {
 
   describe('myApiKeys', () => {
     it('throws when not authenticated', async () => {
-      const result = await gql(testSchema, db, '', 'query { myApiKeys { id } }');
+      const result = await gql(
+        testSchema,
+        db,
+        '',
+        'query { myApiKeys { id } }',
+      );
       expect(result.errors?.[0]?.message).toMatch(/not authenticated/i);
     });
 
     it('returns active (non-revoked) keys', async () => {
       const { id: userId } = await seedUser(db, 'apikeys-list@example.com');
-      await gql(testSchema, db, userId,
+      await gql(
+        testSchema,
+        db,
+        userId,
         'mutation($input: MyCreateApiKeyInput!) { myCreateApiKey(input: $input) { token } }',
         { input: { name: 'Key A', scopes: ['read'] } },
       );
 
-      const result = await gql(testSchema, db, userId, 'query { myApiKeys { id name } }');
+      const result = await gql(
+        testSchema,
+        db,
+        userId,
+        'query { myApiKeys { id name } }',
+      );
       expect(result.errors).toBeUndefined();
       expect((result.data?.myApiKeys as unknown[]).length).toBe(1);
     });
@@ -307,7 +448,10 @@ describe('profile, todo-list, and api-key resolvers', () => {
 
   describe('myCreateApiKey', () => {
     it('throws when not authenticated', async () => {
-      const result = await gql(testSchema, db, '',
+      const result = await gql(
+        testSchema,
+        db,
+        '',
         'mutation($input: MyCreateApiKeyInput!) { myCreateApiKey(input: $input) { token } }',
         { input: { name: 'X', scopes: ['read'] } },
       );
@@ -316,7 +460,10 @@ describe('profile, todo-list, and api-key resolvers', () => {
 
     it('throws when the request itself comes from an API key', async () => {
       const { id: userId } = await seedUser(db, 'apikey-guard@example.com');
-      const result = await gqlWithApiKey(testSchema, db, userId,
+      const result = await gqlWithApiKey(
+        testSchema,
+        db,
+        userId,
         'mutation($input: MyCreateApiKeyInput!) { myCreateApiKey(input: $input) { token } }',
         { input: { name: 'X', scopes: ['read'] } },
       );
@@ -325,25 +472,45 @@ describe('profile, todo-list, and api-key resolvers', () => {
 
     it('creates a key and returns token + row', async () => {
       const { id: userId } = await seedUser(db, 'create-apikey@example.com');
-      const result = await gql(testSchema, db, userId,
+      const result = await gql(
+        testSchema,
+        db,
+        userId,
         'mutation($input: MyCreateApiKeyInput!) { myCreateApiKey(input: $input) { token apiKey { id name keyPrefix } } }',
         { input: { name: 'My Key', scopes: ['read', 'write'] } },
       );
       expect(result.errors).toBeUndefined();
-      const res = result.data?.myCreateApiKey as { token: string; apiKey: { name: string; keyPrefix: string } };
+      const res = result.data?.myCreateApiKey as {
+        token: string;
+        apiKey: { name: string; keyPrefix: string };
+      };
       expect(res.token).toBeDefined();
       expect(res.apiKey.name).toBe('My Key');
       expect(res.apiKey.keyPrefix).toBeDefined();
     });
 
     it('creates a key with expiresAt', async () => {
-      const { id: userId } = await seedUser(db, 'create-apikey-expires@example.com');
-      const result = await gql(testSchema, db, userId,
+      const { id: userId } = await seedUser(
+        db,
+        'create-apikey-expires@example.com',
+      );
+      const result = await gql(
+        testSchema,
+        db,
+        userId,
         'mutation($input: MyCreateApiKeyInput!) { myCreateApiKey(input: $input) { apiKey { expiresAt } } }',
-        { input: { name: 'Expiring', scopes: ['read'], expiresAt: '2099-01-01T00:00:00' } },
+        {
+          input: {
+            name: 'Expiring',
+            scopes: ['read'],
+            expiresAt: '2099-01-01T00:00:00',
+          },
+        },
       );
       expect(result.errors).toBeUndefined();
-      const row = result.data?.myCreateApiKey as { apiKey: { expiresAt: string } };
+      const row = result.data?.myCreateApiKey as {
+        apiKey: { expiresAt: string };
+      };
       expect(row.apiKey.expiresAt).not.toBeNull();
     });
   });
@@ -352,8 +519,14 @@ describe('profile, todo-list, and api-key resolvers', () => {
 
   describe('myRevokeApiKey', () => {
     it('throws when request comes from an API key', async () => {
-      const { id: userId } = await seedUser(db, 'revoke-apikey-guard@example.com');
-      const result = await gqlWithApiKey(testSchema, db, userId,
+      const { id: userId } = await seedUser(
+        db,
+        'revoke-apikey-guard@example.com',
+      );
+      const result = await gqlWithApiKey(
+        testSchema,
+        db,
+        userId,
         'mutation { myRevokeApiKey(id: "00000000-0000-0000-0000-000000000000") }',
       );
       expect(result.errors?.[0]?.message).toMatch(/api keys cannot manage/i);
@@ -361,13 +534,21 @@ describe('profile, todo-list, and api-key resolvers', () => {
 
     it('revokes a key and returns true', async () => {
       const { id: userId } = await seedUser(db, 'revoke-apikey@example.com');
-      const createResult = await gql(testSchema, db, userId,
+      const createResult = await gql(
+        testSchema,
+        db,
+        userId,
         'mutation($input: MyCreateApiKeyInput!) { myCreateApiKey(input: $input) { apiKey { id } } }',
         { input: { name: 'To Revoke', scopes: ['read'] } },
       );
-      const keyId = (createResult.data?.myCreateApiKey as { apiKey: { id: string } }).apiKey.id;
+      const keyId = (
+        createResult.data?.myCreateApiKey as { apiKey: { id: string } }
+      ).apiKey.id;
 
-      const result = await gql(testSchema, db, userId,
+      const result = await gql(
+        testSchema,
+        db,
+        userId,
         'mutation($id: ID!) { myRevokeApiKey(id: $id) }',
         { id: keyId },
       );
@@ -376,23 +557,43 @@ describe('profile, todo-list, and api-key resolvers', () => {
     });
 
     it('throws when key not found', async () => {
-      const { id: userId } = await seedUser(db, 'revoke-apikey-notfound@example.com');
-      const result = await gql(testSchema, db, userId,
+      const { id: userId } = await seedUser(
+        db,
+        'revoke-apikey-notfound@example.com',
+      );
+      const result = await gql(
+        testSchema,
+        db,
+        userId,
         'mutation { myRevokeApiKey(id: "00000000-0000-0000-0000-000000000000") }',
       );
       expect(result.errors?.[0]?.message).toMatch(/not found/i);
     });
 
     it('throws Forbidden when key belongs to another user', async () => {
-      const { id: userId } = await seedUser(db, 'revoke-apikey-forbidden@example.com');
-      const { id: otherId } = await seedUser(db, 'revoke-apikey-other@example.com');
-      const createResult = await gql(testSchema, db, otherId,
+      const { id: userId } = await seedUser(
+        db,
+        'revoke-apikey-forbidden@example.com',
+      );
+      const { id: otherId } = await seedUser(
+        db,
+        'revoke-apikey-other@example.com',
+      );
+      const createResult = await gql(
+        testSchema,
+        db,
+        otherId,
         'mutation($input: MyCreateApiKeyInput!) { myCreateApiKey(input: $input) { apiKey { id } } }',
         { input: { name: 'Other Key', scopes: ['read'] } },
       );
-      const keyId = (createResult.data?.myCreateApiKey as { apiKey: { id: string } }).apiKey.id;
+      const keyId = (
+        createResult.data?.myCreateApiKey as { apiKey: { id: string } }
+      ).apiKey.id;
 
-      const result = await gql(testSchema, db, userId,
+      const result = await gql(
+        testSchema,
+        db,
+        userId,
         'mutation($id: ID!) { myRevokeApiKey(id: $id) }',
         { id: keyId },
       );

--- a/packages/server/src/schema/resolvers/resolvers.profile-todolists-apikeys.integration.test.ts
+++ b/packages/server/src/schema/resolvers/resolvers.profile-todolists-apikeys.integration.test.ts
@@ -1,0 +1,402 @@
+import { graphql } from 'graphql';
+import { beforeAll, describe, expect, it } from 'vitest';
+import { createLoaders } from '../../context.ts';
+import {
+  type TestDb,
+  type TestSchema,
+  buildTestSchema,
+  createTestDb,
+  gql,
+  seedActivityType,
+  seedTodo,
+  seedTodoList,
+  seedUser,
+} from './test-helpers.ts';
+
+/** Execute with an authenticated API key context (for guard tests). */
+async function gqlWithApiKey(
+  testSchema: TestSchema,
+  db: TestDb,
+  userId: string,
+  source: string,
+  variableValues?: Record<string, unknown>,
+) {
+  return graphql({
+    schema: testSchema,
+    source,
+    variableValues,
+    contextValue: {
+      db,
+      userId,
+      loaders: createLoaders(db),
+      apiKey: { id: 'test-key-id', scopes: ['read', 'write'] as const },
+    },
+  });
+}
+
+describe('profile, todo-list, and api-key resolvers', () => {
+  let db: TestDb;
+  let testSchema: TestSchema;
+
+  beforeAll(async () => {
+    db = await createTestDb();
+    testSchema = buildTestSchema(db);
+  }, 30000);
+
+  // ─── myProfile ────────────────────────────────────────────────────────────────
+
+  describe('myProfile', () => {
+    it('throws when not authenticated', async () => {
+      const result = await gql(testSchema, db, '', 'query { myProfile { id } }');
+      expect(result.errors?.[0]?.message).toMatch(/not authenticated/i);
+    });
+
+    it('returns the current user profile', async () => {
+      const { id: userId, email } = await seedUser(db, 'profile@example.com');
+      const result = await gql(testSchema, db, userId, 'query { myProfile { id email icalSecret } }');
+      expect(result.errors).toBeUndefined();
+      const profile = result.data?.myProfile as { id: string; email: string };
+      expect(profile.id).toBe(userId);
+      expect(profile.email).toBe(email);
+    });
+  });
+
+  // ─── myUpdateProfile ──────────────────────────────────────────────────────────
+
+  describe('myUpdateProfile', () => {
+    it('throws when not authenticated', async () => {
+      const result = await gql(testSchema, db, '',
+        'mutation { myUpdateProfile(timezone: "UTC") }',
+      );
+      expect(result.errors?.[0]?.message).toMatch(/not authenticated/i);
+    });
+
+    it('updates the user timezone and returns true', async () => {
+      const { id: userId } = await seedUser(db, 'update-profile@example.com');
+      const result = await gql(testSchema, db, userId,
+        'mutation($tz: String!) { myUpdateProfile(timezone: $tz) }',
+        { tz: 'America/New_York' },
+      );
+      expect(result.errors).toBeUndefined();
+      expect(result.data?.myUpdateProfile).toBe(true);
+    });
+
+    it('throws for an invalid timezone', async () => {
+      const { id: userId } = await seedUser(db, 'update-profile-badtz@example.com');
+      const result = await gql(testSchema, db, userId,
+        'mutation { myUpdateProfile(timezone: "Not/ATimezone") }',
+      );
+      expect(result.errors?.[0]?.message).toMatch(/invalid timezone/i);
+    });
+  });
+
+  // ─── myRegenerateIcalSecret ───────────────────────────────────────────────────
+
+  describe('myRegenerateIcalSecret', () => {
+    it('throws when not authenticated', async () => {
+      const result = await gql(testSchema, db, '', 'mutation { myRegenerateIcalSecret }');
+      expect(result.errors?.[0]?.message).toMatch(/not authenticated/i);
+    });
+
+    it('returns a new UUID secret', async () => {
+      const { id: userId } = await seedUser(db, 'regen-secret@example.com');
+      const result = await gql(testSchema, db, userId, 'mutation { myRegenerateIcalSecret }');
+      expect(result.errors).toBeUndefined();
+      const newSecret = result.data?.myRegenerateIcalSecret as string;
+      expect(newSecret).toMatch(/^[0-9a-f-]{36}$/i);
+    });
+  });
+
+  // ─── myTodoLists ──────────────────────────────────────────────────────────────
+
+  describe('myTodoLists', () => {
+    it('throws when not authenticated', async () => {
+      const result = await gql(testSchema, db, '', 'query { myTodoLists { id } }');
+      expect(result.errors?.[0]?.message).toMatch(/not authenticated/i);
+    });
+
+    it('returns only the current user\'s lists', async () => {
+      const { id: userId } = await seedUser(db, 'todolists-isolation@example.com');
+      const { id: otherId } = await seedUser(db, 'todolists-other@example.com');
+      const at = await seedActivityType(db, userId);
+      const otherAt = await seedActivityType(db, otherId);
+      await seedTodoList(db, userId, at.id);
+      await seedTodoList(db, otherId, otherAt.id);
+
+      const result = await gql(testSchema, db, userId, 'query { myTodoLists { id } }');
+      expect(result.errors).toBeUndefined();
+      expect((result.data?.myTodoLists as unknown[]).length).toBe(1);
+    });
+  });
+
+  // ─── myCreateTodoList ─────────────────────────────────────────────────────────
+
+  describe('myCreateTodoList', () => {
+    it('creates a list and returns it', async () => {
+      const { id: userId } = await seedUser(db, 'create-list@example.com');
+      const at = await seedActivityType(db, userId);
+
+      const result = await gql(testSchema, db, userId,
+        'mutation($input: CreateTodoListArgs!) { myCreateTodoList(input: $input) { id name } }',
+        { input: { name: 'My List', activityTypeId: at.id } },
+      );
+      expect(result.errors).toBeUndefined();
+      expect((result.data?.myCreateTodoList as { name: string }).name).toBe('My List');
+    });
+
+    it('throws when activity type not found', async () => {
+      const { id: userId } = await seedUser(db, 'create-list-noat@example.com');
+      const result = await gql(testSchema, db, userId,
+        'mutation($input: CreateTodoListArgs!) { myCreateTodoList(input: $input) { id } }',
+        { input: { name: 'X', activityTypeId: '00000000-0000-0000-0000-000000000000' } },
+      );
+      expect(result.errors?.[0]?.message).toMatch(/not found/i);
+    });
+
+    it('throws Forbidden when activity type belongs to another user', async () => {
+      const { id: userId } = await seedUser(db, 'create-list-forbidden@example.com');
+      const { id: otherId } = await seedUser(db, 'create-list-other@example.com');
+      const otherAt = await seedActivityType(db, otherId);
+
+      const result = await gql(testSchema, db, userId,
+        'mutation($input: CreateTodoListArgs!) { myCreateTodoList(input: $input) { id } }',
+        { input: { name: 'Hack', activityTypeId: otherAt.id } },
+      );
+      expect(result.errors?.[0]?.message).toMatch(/forbidden/i);
+    });
+  });
+
+  // ─── myUpdateTodoList ─────────────────────────────────────────────────────────
+
+  describe('myUpdateTodoList', () => {
+    it('updates list name', async () => {
+      const { id: userId } = await seedUser(db, 'update-list@example.com');
+      const at = await seedActivityType(db, userId);
+      const list = await seedTodoList(db, userId, at.id);
+
+      const result = await gql(testSchema, db, userId,
+        'mutation($input: UpdateTodoListArgs!) { myUpdateTodoList(input: $input) { id name } }',
+        { input: { id: list.id, name: 'Renamed' } },
+      );
+      expect(result.errors).toBeUndefined();
+      expect((result.data?.myUpdateTodoList as { name: string }).name).toBe('Renamed');
+    });
+
+    it('throws when list not found', async () => {
+      const { id: userId } = await seedUser(db, 'update-list-notfound@example.com');
+      const result = await gql(testSchema, db, userId,
+        'mutation($input: UpdateTodoListArgs!) { myUpdateTodoList(input: $input) { id } }',
+        { input: { id: '00000000-0000-0000-0000-000000000000', name: 'X' } },
+      );
+      expect(result.errors?.[0]?.message).toMatch(/not found/i);
+    });
+
+    it('throws Forbidden when list belongs to another user', async () => {
+      const { id: userId } = await seedUser(db, 'update-list-forbidden@example.com');
+      const { id: otherId } = await seedUser(db, 'update-list-other@example.com');
+      const otherAt = await seedActivityType(db, otherId);
+      const otherList = await seedTodoList(db, otherId, otherAt.id);
+
+      const result = await gql(testSchema, db, userId,
+        'mutation($input: UpdateTodoListArgs!) { myUpdateTodoList(input: $input) { id } }',
+        { input: { id: otherList.id, name: 'Hack' } },
+      );
+      expect(result.errors?.[0]?.message).toMatch(/forbidden/i);
+    });
+
+    it('throws when new activity type not found', async () => {
+      const { id: userId } = await seedUser(db, 'update-list-noat@example.com');
+      const at = await seedActivityType(db, userId);
+      const list = await seedTodoList(db, userId, at.id);
+
+      const result = await gql(testSchema, db, userId,
+        'mutation($input: UpdateTodoListArgs!) { myUpdateTodoList(input: $input) { id } }',
+        { input: { id: list.id, activityTypeId: '00000000-0000-0000-0000-000000000000' } },
+      );
+      expect(result.errors?.[0]?.message).toMatch(/not found/i);
+    });
+
+    it('throws Forbidden when new activity type belongs to another user', async () => {
+      const { id: userId } = await seedUser(db, 'update-list-atforbidden@example.com');
+      const { id: otherId } = await seedUser(db, 'update-list-atother@example.com');
+      const at = await seedActivityType(db, userId);
+      const list = await seedTodoList(db, userId, at.id);
+      const otherAt = await seedActivityType(db, otherId);
+
+      const result = await gql(testSchema, db, userId,
+        'mutation($input: UpdateTodoListArgs!) { myUpdateTodoList(input: $input) { id } }',
+        { input: { id: list.id, activityTypeId: otherAt.id } },
+      );
+      expect(result.errors?.[0]?.message).toMatch(/forbidden/i);
+    });
+  });
+
+  // ─── myDeleteTodoList ─────────────────────────────────────────────────────────
+
+  describe('myDeleteTodoList', () => {
+    it('deletes an empty list and returns true', async () => {
+      const { id: userId } = await seedUser(db, 'delete-list@example.com');
+      const at = await seedActivityType(db, userId);
+      const list = await seedTodoList(db, userId, at.id);
+
+      const result = await gql(testSchema, db, userId,
+        'mutation($id: ID!) { myDeleteTodoList(id: $id) }',
+        { id: list.id },
+      );
+      expect(result.errors).toBeUndefined();
+      expect(result.data?.myDeleteTodoList).toBe(true);
+    });
+
+    it('throws when list not found', async () => {
+      const { id: userId } = await seedUser(db, 'delete-list-notfound@example.com');
+      const result = await gql(testSchema, db, userId,
+        'mutation { myDeleteTodoList(id: "00000000-0000-0000-0000-000000000000") }',
+      );
+      expect(result.errors?.[0]?.message).toMatch(/not found/i);
+    });
+
+    it('throws Forbidden when list belongs to another user', async () => {
+      const { id: userId } = await seedUser(db, 'delete-list-forbidden@example.com');
+      const { id: otherId } = await seedUser(db, 'delete-list-other@example.com');
+      const otherAt = await seedActivityType(db, otherId);
+      const otherList = await seedTodoList(db, otherId, otherAt.id);
+
+      const result = await gql(testSchema, db, userId,
+        'mutation($id: ID!) { myDeleteTodoList(id: $id) }',
+        { id: otherList.id },
+      );
+      expect(result.errors?.[0]?.message).toMatch(/forbidden/i);
+    });
+
+    it('throws when list still contains todos', async () => {
+      const { id: userId } = await seedUser(db, 'delete-list-hastodos@example.com');
+      const at = await seedActivityType(db, userId);
+      const list = await seedTodoList(db, userId, at.id);
+      await seedTodo(db, userId, list.id);
+
+      const result = await gql(testSchema, db, userId,
+        'mutation($id: ID!) { myDeleteTodoList(id: $id) }',
+        { id: list.id },
+      );
+      expect(result.errors?.[0]?.message).toMatch(/cannot delete/i);
+    });
+  });
+
+  // ─── myApiKeys ────────────────────────────────────────────────────────────────
+
+  describe('myApiKeys', () => {
+    it('throws when not authenticated', async () => {
+      const result = await gql(testSchema, db, '', 'query { myApiKeys { id } }');
+      expect(result.errors?.[0]?.message).toMatch(/not authenticated/i);
+    });
+
+    it('returns active (non-revoked) keys', async () => {
+      const { id: userId } = await seedUser(db, 'apikeys-list@example.com');
+      await gql(testSchema, db, userId,
+        'mutation($input: MyCreateApiKeyInput!) { myCreateApiKey(input: $input) { token } }',
+        { input: { name: 'Key A', scopes: ['read'] } },
+      );
+
+      const result = await gql(testSchema, db, userId, 'query { myApiKeys { id name } }');
+      expect(result.errors).toBeUndefined();
+      expect((result.data?.myApiKeys as unknown[]).length).toBe(1);
+    });
+  });
+
+  // ─── myCreateApiKey ───────────────────────────────────────────────────────────
+
+  describe('myCreateApiKey', () => {
+    it('throws when not authenticated', async () => {
+      const result = await gql(testSchema, db, '',
+        'mutation($input: MyCreateApiKeyInput!) { myCreateApiKey(input: $input) { token } }',
+        { input: { name: 'X', scopes: ['read'] } },
+      );
+      expect(result.errors?.[0]?.message).toMatch(/not authenticated/i);
+    });
+
+    it('throws when the request itself comes from an API key', async () => {
+      const { id: userId } = await seedUser(db, 'apikey-guard@example.com');
+      const result = await gqlWithApiKey(testSchema, db, userId,
+        'mutation($input: MyCreateApiKeyInput!) { myCreateApiKey(input: $input) { token } }',
+        { input: { name: 'X', scopes: ['read'] } },
+      );
+      expect(result.errors?.[0]?.message).toMatch(/api keys cannot manage/i);
+    });
+
+    it('creates a key and returns token + row', async () => {
+      const { id: userId } = await seedUser(db, 'create-apikey@example.com');
+      const result = await gql(testSchema, db, userId,
+        'mutation($input: MyCreateApiKeyInput!) { myCreateApiKey(input: $input) { token apiKey { id name keyPrefix } } }',
+        { input: { name: 'My Key', scopes: ['read', 'write'] } },
+      );
+      expect(result.errors).toBeUndefined();
+      const res = result.data?.myCreateApiKey as { token: string; apiKey: { name: string; keyPrefix: string } };
+      expect(res.token).toBeDefined();
+      expect(res.apiKey.name).toBe('My Key');
+      expect(res.apiKey.keyPrefix).toBeDefined();
+    });
+
+    it('creates a key with expiresAt', async () => {
+      const { id: userId } = await seedUser(db, 'create-apikey-expires@example.com');
+      const result = await gql(testSchema, db, userId,
+        'mutation($input: MyCreateApiKeyInput!) { myCreateApiKey(input: $input) { apiKey { expiresAt } } }',
+        { input: { name: 'Expiring', scopes: ['read'], expiresAt: '2099-01-01T00:00:00' } },
+      );
+      expect(result.errors).toBeUndefined();
+      const row = result.data?.myCreateApiKey as { apiKey: { expiresAt: string } };
+      expect(row.apiKey.expiresAt).not.toBeNull();
+    });
+  });
+
+  // ─── myRevokeApiKey ───────────────────────────────────────────────────────────
+
+  describe('myRevokeApiKey', () => {
+    it('throws when request comes from an API key', async () => {
+      const { id: userId } = await seedUser(db, 'revoke-apikey-guard@example.com');
+      const result = await gqlWithApiKey(testSchema, db, userId,
+        'mutation { myRevokeApiKey(id: "00000000-0000-0000-0000-000000000000") }',
+      );
+      expect(result.errors?.[0]?.message).toMatch(/api keys cannot manage/i);
+    });
+
+    it('revokes a key and returns true', async () => {
+      const { id: userId } = await seedUser(db, 'revoke-apikey@example.com');
+      const createResult = await gql(testSchema, db, userId,
+        'mutation($input: MyCreateApiKeyInput!) { myCreateApiKey(input: $input) { apiKey { id } } }',
+        { input: { name: 'To Revoke', scopes: ['read'] } },
+      );
+      const keyId = (createResult.data?.myCreateApiKey as { apiKey: { id: string } }).apiKey.id;
+
+      const result = await gql(testSchema, db, userId,
+        'mutation($id: ID!) { myRevokeApiKey(id: $id) }',
+        { id: keyId },
+      );
+      expect(result.errors).toBeUndefined();
+      expect(result.data?.myRevokeApiKey).toBe(true);
+    });
+
+    it('throws when key not found', async () => {
+      const { id: userId } = await seedUser(db, 'revoke-apikey-notfound@example.com');
+      const result = await gql(testSchema, db, userId,
+        'mutation { myRevokeApiKey(id: "00000000-0000-0000-0000-000000000000") }',
+      );
+      expect(result.errors?.[0]?.message).toMatch(/not found/i);
+    });
+
+    it('throws Forbidden when key belongs to another user', async () => {
+      const { id: userId } = await seedUser(db, 'revoke-apikey-forbidden@example.com');
+      const { id: otherId } = await seedUser(db, 'revoke-apikey-other@example.com');
+      const createResult = await gql(testSchema, db, otherId,
+        'mutation($input: MyCreateApiKeyInput!) { myCreateApiKey(input: $input) { apiKey { id } } }',
+        { input: { name: 'Other Key', scopes: ['read'] } },
+      );
+      const keyId = (createResult.data?.myCreateApiKey as { apiKey: { id: string } }).apiKey.id;
+
+      const result = await gql(testSchema, db, userId,
+        'mutation($id: ID!) { myRevokeApiKey(id: $id) }',
+        { id: keyId },
+      );
+      expect(result.errors?.[0]?.message).toMatch(/forbidden/i);
+    });
+  });
+});

--- a/packages/server/src/schema/resolvers/resolvers.schedule.integration.test.ts
+++ b/packages/server/src/schema/resolvers/resolvers.schedule.integration.test.ts
@@ -27,13 +27,23 @@ describe('schedule resolvers', () => {
 
   describe('mySchedule', () => {
     it('throws when not authenticated', async () => {
-      const result = await gql(testSchema, db, '', 'query { mySchedule { id } }');
+      const result = await gql(
+        testSchema,
+        db,
+        '',
+        'query { mySchedule { id } }',
+      );
       expect(result.errors?.[0]?.message).toMatch(/not authenticated/i);
     });
 
     it('returns empty array with no data', async () => {
       const { id: userId } = await seedUser(db, 'sched-empty@example.com');
-      const result = await gql(testSchema, db, userId, 'query { mySchedule { id } }');
+      const result = await gql(
+        testSchema,
+        db,
+        userId,
+        'query { mySchedule { id } }',
+      );
       expect(result.errors).toBeUndefined();
       expect(result.data?.mySchedule).toEqual([]);
     });
@@ -46,7 +56,9 @@ describe('schedule resolvers', () => {
       await seedTodo(db, userId, list.id);
 
       const result = await gql(
-        testSchema, db, userId,
+        testSchema,
+        db,
+        userId,
         'query { mySchedule { id kind title isScheduled scheduledStart scheduledEnd } }',
       );
       expect(result.errors).toBeUndefined();
@@ -57,7 +69,9 @@ describe('schedule resolvers', () => {
     it('accepts a weekStart param and uses that ISO week', async () => {
       const { id: userId } = await seedUser(db, 'sched-weekstart@example.com');
       const result = await gql(
-        testSchema, db, userId,
+        testSchema,
+        db,
+        userId,
         'query($ws: String) { mySchedule(weekStart: $ws) { id } }',
         { ws: '2025-01-06' },
       );
@@ -68,7 +82,9 @@ describe('schedule resolvers', () => {
     it('rejects a malformed weekStart', async () => {
       const { id: userId } = await seedUser(db, 'sched-bad-ws@example.com');
       const result = await gql(
-        testSchema, db, userId,
+        testSchema,
+        db,
+        userId,
         'query { mySchedule(weekStart: "not-a-date") { id } }',
       );
       expect(result.errors).toBeDefined();
@@ -77,7 +93,9 @@ describe('schedule resolvers', () => {
     it('rejects an invalid calendar date as weekStart', async () => {
       const { id: userId } = await seedUser(db, 'sched-bad-date@example.com');
       const result = await gql(
-        testSchema, db, userId,
+        testSchema,
+        db,
+        userId,
         'query { mySchedule(weekStart: "2025-13-99") { id } }',
       );
       expect(result.errors).toBeDefined();
@@ -87,14 +105,22 @@ describe('schedule resolvers', () => {
       const { id: userId } = await seedUser(db, 'sched-habits@example.com');
       const at = await seedActivityType(db, userId);
       await seedTimeBlock(db, userId, at.id);
-      await seedHabit(db, userId, at.id, { frequencyCount: 2, frequencyUnit: 'week' });
+      await seedHabit(db, userId, at.id, {
+        frequencyCount: 2,
+        frequencyUnit: 'week',
+      });
 
       const result = await gql(
-        testSchema, db, userId,
+        testSchema,
+        db,
+        userId,
         'query { mySchedule { id kind title isScheduled } }',
       );
       expect(result.errors).toBeUndefined();
-      const items = result.data?.mySchedule as Array<{ kind: string; isScheduled: boolean }>;
+      const items = result.data?.mySchedule as Array<{
+        kind: string;
+        isScheduled: boolean;
+      }>;
       expect(items.some((i) => i.kind === 'habit' && i.isScheduled)).toBe(true);
     });
 
@@ -102,10 +128,20 @@ describe('schedule resolvers', () => {
       const { id: userId } = await seedUser(db, 'sched-nodeficit@example.com');
       const at = await seedActivityType(db, userId);
       await seedTimeBlock(db, userId, at.id);
-      const habit = await seedHabit(db, userId, at.id, { frequencyCount: 1, frequencyUnit: 'week' });
-      await db.insert(habitCompletions).values({ habitId: habit.id, completedAt: new Date() });
+      const habit = await seedHabit(db, userId, at.id, {
+        frequencyCount: 1,
+        frequencyUnit: 'week',
+      });
+      await db
+        .insert(habitCompletions)
+        .values({ habitId: habit.id, completedAt: new Date() });
 
-      const result = await gql(testSchema, db, userId, 'query { mySchedule { id kind } }');
+      const result = await gql(
+        testSchema,
+        db,
+        userId,
+        'query { mySchedule { id kind } }',
+      );
       expect(result.errors).toBeUndefined();
       const items = result.data?.mySchedule as Array<{ kind: string }>;
       expect(items.every((i) => i.kind !== 'habit')).toBe(true);
@@ -116,21 +152,31 @@ describe('schedule resolvers', () => {
       const at = await seedActivityType(db, userId);
       const list = await seedTodoList(db, userId, at.id);
       const future = new Date(Date.now() + 86_400_000);
-      await seedTodo(db, userId, list.id, { manuallyScheduled: true, scheduledAt: future });
+      await seedTodo(db, userId, list.id, {
+        manuallyScheduled: true,
+        scheduledAt: future,
+      });
 
       const result = await gql(
-        testSchema, db, userId,
+        testSchema,
+        db,
+        userId,
         'query { mySchedule { id isScheduled scheduledStart } }',
       );
       expect(result.errors).toBeUndefined();
-      const items = result.data?.mySchedule as Array<{ isScheduled: boolean; scheduledStart: string }>;
+      const items = result.data?.mySchedule as Array<{
+        isScheduled: boolean;
+        scheduledStart: string;
+      }>;
       expect(items.some((i) => i.isScheduled && i.scheduledStart)).toBe(true);
     });
 
     it('updates user timezone when timezone arg is provided', async () => {
       const { id: userId } = await seedUser(db, 'sched-timezone@example.com');
       const result = await gql(
-        testSchema, db, userId,
+        testSchema,
+        db,
+        userId,
         'query { mySchedule(timezone: "America/Chicago") { id } }',
       );
       expect(result.errors).toBeUndefined();
@@ -141,9 +187,17 @@ describe('schedule resolvers', () => {
       const at = await seedActivityType(db, userId);
       const list = await seedTodoList(db, userId, at.id);
       const past = new Date(Date.now() - 86_400_000);
-      const todo = await seedTodo(db, userId, list.id, { manuallyScheduled: true, scheduledAt: past });
+      const todo = await seedTodo(db, userId, list.id, {
+        manuallyScheduled: true,
+        scheduledAt: past,
+      });
 
-      const result = await gql(testSchema, db, userId, 'query { mySchedule { id isScheduled } }');
+      const result = await gql(
+        testSchema,
+        db,
+        userId,
+        'query { mySchedule { id isScheduled } }',
+      );
       expect(result.errors).toBeUndefined();
       const items = result.data?.mySchedule as Array<{ id: string }>;
       expect(items.some((i) => i.id === todo.id)).toBe(true);
@@ -160,7 +214,12 @@ describe('schedule resolvers', () => {
 
     it('returns true', async () => {
       const { id: userId } = await seedUser(db, 'reschedule@example.com');
-      const result = await gql(testSchema, db, userId, 'mutation { myReschedule }');
+      const result = await gql(
+        testSchema,
+        db,
+        userId,
+        'mutation { myReschedule }',
+      );
       expect(result.errors).toBeUndefined();
       expect(result.data?.myReschedule).toBe(true);
     });

--- a/packages/server/src/schema/resolvers/resolvers.schedule.integration.test.ts
+++ b/packages/server/src/schema/resolvers/resolvers.schedule.integration.test.ts
@@ -127,6 +127,15 @@ describe('schedule resolvers', () => {
       expect(items.some((i) => i.isScheduled && i.scheduledStart)).toBe(true);
     });
 
+    it('updates user timezone when timezone arg is provided', async () => {
+      const { id: userId } = await seedUser(db, 'sched-timezone@example.com');
+      const result = await gql(
+        testSchema, db, userId,
+        'query { mySchedule(timezone: "America/Chicago") { id } }',
+      );
+      expect(result.errors).toBeUndefined();
+    });
+
     it('re-queues overdue pinned todos as regular items', async () => {
       const { id: userId } = await seedUser(db, 'sched-overdue@example.com');
       const at = await seedActivityType(db, userId);

--- a/packages/server/src/schema/resolvers/resolvers.schedule.integration.test.ts
+++ b/packages/server/src/schema/resolvers/resolvers.schedule.integration.test.ts
@@ -1,0 +1,159 @@
+import { habitCompletions } from '@auto-cal/db/schema';
+import { beforeAll, describe, expect, it } from 'vitest';
+import {
+  type TestDb,
+  type TestSchema,
+  buildTestSchema,
+  createTestDb,
+  gql,
+  seedActivityType,
+  seedHabit,
+  seedTimeBlock,
+  seedTodo,
+  seedTodoList,
+  seedUser,
+} from './test-helpers.ts';
+
+describe('schedule resolvers', () => {
+  let db: TestDb;
+  let testSchema: TestSchema;
+
+  beforeAll(async () => {
+    db = await createTestDb();
+    testSchema = buildTestSchema(db);
+  }, 30000);
+
+  // ─── mySchedule ──────────────────────────────────────────────────────────────
+
+  describe('mySchedule', () => {
+    it('throws when not authenticated', async () => {
+      const result = await gql(testSchema, db, '', 'query { mySchedule { id } }');
+      expect(result.errors?.[0]?.message).toMatch(/not authenticated/i);
+    });
+
+    it('returns empty array with no data', async () => {
+      const { id: userId } = await seedUser(db, 'sched-empty@example.com');
+      const result = await gql(testSchema, db, userId, 'query { mySchedule { id } }');
+      expect(result.errors).toBeUndefined();
+      expect(result.data?.mySchedule).toEqual([]);
+    });
+
+    it('returns scheduled items for todos with matching time blocks', async () => {
+      const { id: userId } = await seedUser(db, 'sched-items@example.com');
+      const at = await seedActivityType(db, userId);
+      await seedTimeBlock(db, userId, at.id);
+      const list = await seedTodoList(db, userId, at.id);
+      await seedTodo(db, userId, list.id);
+
+      const result = await gql(
+        testSchema, db, userId,
+        'query { mySchedule { id kind title isScheduled scheduledStart scheduledEnd } }',
+      );
+      expect(result.errors).toBeUndefined();
+      const items = result.data?.mySchedule as Array<{ isScheduled: boolean }>;
+      expect(items.some((i) => i.isScheduled)).toBe(true);
+    });
+
+    it('accepts a weekStart param and uses that ISO week', async () => {
+      const { id: userId } = await seedUser(db, 'sched-weekstart@example.com');
+      const result = await gql(
+        testSchema, db, userId,
+        'query($ws: String) { mySchedule(weekStart: $ws) { id } }',
+        { ws: '2025-01-06' },
+      );
+      expect(result.errors).toBeUndefined();
+      expect(result.data?.mySchedule).toEqual([]);
+    });
+
+    it('rejects a malformed weekStart', async () => {
+      const { id: userId } = await seedUser(db, 'sched-bad-ws@example.com');
+      const result = await gql(
+        testSchema, db, userId,
+        'query { mySchedule(weekStart: "not-a-date") { id } }',
+      );
+      expect(result.errors).toBeDefined();
+    });
+
+    it('rejects an invalid calendar date as weekStart', async () => {
+      const { id: userId } = await seedUser(db, 'sched-bad-date@example.com');
+      const result = await gql(
+        testSchema, db, userId,
+        'query { mySchedule(weekStart: "2025-13-99") { id } }',
+      );
+      expect(result.errors).toBeDefined();
+    });
+
+    it('generates habit instances for habits with a deficit', async () => {
+      const { id: userId } = await seedUser(db, 'sched-habits@example.com');
+      const at = await seedActivityType(db, userId);
+      await seedTimeBlock(db, userId, at.id);
+      await seedHabit(db, userId, at.id, { frequencyCount: 2, frequencyUnit: 'week' });
+
+      const result = await gql(
+        testSchema, db, userId,
+        'query { mySchedule { id kind title isScheduled } }',
+      );
+      expect(result.errors).toBeUndefined();
+      const items = result.data?.mySchedule as Array<{ kind: string; isScheduled: boolean }>;
+      expect(items.some((i) => i.kind === 'habit' && i.isScheduled)).toBe(true);
+    });
+
+    it('suppresses habit instances when deficit is zero', async () => {
+      const { id: userId } = await seedUser(db, 'sched-nodeficit@example.com');
+      const at = await seedActivityType(db, userId);
+      await seedTimeBlock(db, userId, at.id);
+      const habit = await seedHabit(db, userId, at.id, { frequencyCount: 1, frequencyUnit: 'week' });
+      await db.insert(habitCompletions).values({ habitId: habit.id, completedAt: new Date() });
+
+      const result = await gql(testSchema, db, userId, 'query { mySchedule { id kind } }');
+      expect(result.errors).toBeUndefined();
+      const items = result.data?.mySchedule as Array<{ kind: string }>;
+      expect(items.every((i) => i.kind !== 'habit')).toBe(true);
+    });
+
+    it('includes pinned todos in the result', async () => {
+      const { id: userId } = await seedUser(db, 'sched-pinned@example.com');
+      const at = await seedActivityType(db, userId);
+      const list = await seedTodoList(db, userId, at.id);
+      const future = new Date(Date.now() + 86_400_000);
+      await seedTodo(db, userId, list.id, { manuallyScheduled: true, scheduledAt: future });
+
+      const result = await gql(
+        testSchema, db, userId,
+        'query { mySchedule { id isScheduled scheduledStart } }',
+      );
+      expect(result.errors).toBeUndefined();
+      const items = result.data?.mySchedule as Array<{ isScheduled: boolean; scheduledStart: string }>;
+      expect(items.some((i) => i.isScheduled && i.scheduledStart)).toBe(true);
+    });
+
+    it('re-queues overdue pinned todos as regular items', async () => {
+      const { id: userId } = await seedUser(db, 'sched-overdue@example.com');
+      const at = await seedActivityType(db, userId);
+      const list = await seedTodoList(db, userId, at.id);
+      const past = new Date(Date.now() - 86_400_000);
+      const todo = await seedTodo(db, userId, list.id, { manuallyScheduled: true, scheduledAt: past });
+
+      const result = await gql(testSchema, db, userId, 'query { mySchedule { id isScheduled } }');
+      expect(result.errors).toBeUndefined();
+      const items = result.data?.mySchedule as Array<{ id: string }>;
+      expect(items.some((i) => i.id === todo.id)).toBe(true);
+    });
+  });
+
+  // ─── myReschedule ─────────────────────────────────────────────────────────────
+
+  describe('myReschedule', () => {
+    it('throws when not authenticated', async () => {
+      const result = await gql(testSchema, db, '', 'mutation { myReschedule }');
+      expect(result.errors?.[0]?.message).toMatch(/not authenticated/i);
+    });
+
+    it('returns true', async () => {
+      const { id: userId } = await seedUser(db, 'reschedule@example.com');
+      const result = await gql(testSchema, db, userId, 'mutation { myReschedule }');
+      expect(result.errors).toBeUndefined();
+      expect(result.data?.myReschedule).toBe(true);
+    });
+  });
+});

--- a/packages/server/src/schema/resolvers/resolvers.stats.integration.test.ts
+++ b/packages/server/src/schema/resolvers/resolvers.stats.integration.test.ts
@@ -1,0 +1,144 @@
+import { habitCompletions, todos } from '@auto-cal/db/schema';
+import { beforeAll, describe, expect, it } from 'vitest';
+import {
+  type TestDb,
+  type TestSchema,
+  buildTestSchema,
+  createTestDb,
+  gql,
+  seedActivityType,
+  seedHabit,
+  seedTodoList,
+  seedUser,
+} from './test-helpers.ts';
+
+describe('stats resolvers', () => {
+  let db: TestDb;
+  let testSchema: TestSchema;
+
+  beforeAll(async () => {
+    db = await createTestDb();
+    testSchema = buildTestSchema(db);
+  }, 30000);
+
+  const STATS_QUERY = `
+    query($start: String, $end: String) {
+      myStats(startDate: $start, endDate: $end) {
+        weightedScore habitScore todoScore
+        todos { total completed overdue completionRate }
+        habits { habitId title completionRate completions target frequencyUnit frequencyCount }
+      }
+    }
+  `;
+
+  // ─── myStats ──────────────────────────────────────────────────────────────────
+
+  describe('myStats', () => {
+    it('throws when not authenticated', async () => {
+      const result = await gql(testSchema, db, '', 'query { myStats { weightedScore } }');
+      expect(result.errors?.[0]?.message).toMatch(/not authenticated/i);
+    });
+
+    it('returns null scores with no data', async () => {
+      const { id: userId } = await seedUser(db, 'stats-empty@example.com');
+      const result = await gql(testSchema, db, userId, STATS_QUERY);
+      expect(result.errors).toBeUndefined();
+      const stats = result.data?.myStats as Record<string, unknown>;
+      expect(stats.weightedScore).toBeNull();
+      expect(stats.habitScore).toBeNull();
+      expect(stats.todoScore).toBeNull();
+      expect((stats.todos as { total: number }).total).toBe(0);
+    });
+
+    it('returns habit score based on completions', async () => {
+      const { id: userId } = await seedUser(db, 'stats-habitscore@example.com');
+      const at = await seedActivityType(db, userId);
+      const habit = await seedHabit(db, userId, at.id, { frequencyCount: 2, frequencyUnit: 'week' });
+      await db.insert(habitCompletions).values({ habitId: habit.id, completedAt: new Date() });
+
+      const result = await gql(testSchema, db, userId, STATS_QUERY);
+      expect(result.errors).toBeUndefined();
+      const stats = result.data?.myStats as Record<string, unknown>;
+      expect(stats.habitScore).not.toBeNull();
+      const habitsSummary = stats.habits as Array<{ completions: number }>;
+      expect(habitsSummary[0]?.completions).toBe(1);
+    });
+
+    it('returns 1.0 habitScore when target is zero (no elapsed time)', async () => {
+      const { id: userId } = await seedUser(db, 'stats-zerotarget@example.com');
+      const at = await seedActivityType(db, userId);
+      await seedHabit(db, userId, at.id, { frequencyCount: 3, frequencyUnit: 'week' });
+
+      const now = new Date().toISOString().slice(0, 10);
+      const result = await gql(testSchema, db, userId, STATS_QUERY, { start: now, end: now });
+      expect(result.errors).toBeUndefined();
+      const stats = result.data?.myStats as Record<string, unknown>;
+      const summaries = stats.habits as Array<{ completionRate: number }>;
+      expect(summaries[0]?.completionRate).toBe(1);
+    });
+
+    it('returns todo stats for scheduled todos', async () => {
+      const { id: userId } = await seedUser(db, 'stats-todos@example.com');
+      const at = await seedActivityType(db, userId);
+      const list = await seedTodoList(db, userId, at.id);
+      const now = new Date();
+      const future = new Date(Date.now() + 86_400_000);
+      await db.insert(todos).values([
+        { userId, listId: list.id, title: 'Done', estimatedLength: 30, scheduledAt: now, completedAt: now },
+        { userId, listId: list.id, title: 'Overdue', estimatedLength: 30, scheduledAt: new Date(Date.now() - 86_400_000) },
+        { userId, listId: list.id, title: 'Pending', estimatedLength: 30, scheduledAt: future },
+      ]);
+
+      const farFuture = new Date(Date.now() + 30 * 86_400_000).toISOString();
+      const result = await gql(testSchema, db, userId, STATS_QUERY, { end: farFuture });
+      expect(result.errors).toBeUndefined();
+      const todosData = (result.data?.myStats as Record<string, unknown>).todos as {
+        total: number; completed: number; overdue: number;
+      };
+      expect(todosData.total).toBe(3);
+      expect(todosData.completed).toBe(1);
+      expect(todosData.overdue).toBe(1);
+    });
+
+    it('produces a weighted score when both habit and todo data are present', async () => {
+      const { id: userId } = await seedUser(db, 'stats-weighted@example.com');
+      const at = await seedActivityType(db, userId);
+      const habit = await seedHabit(db, userId, at.id, { frequencyCount: 1, frequencyUnit: 'week' });
+      await db.insert(habitCompletions).values({ habitId: habit.id, completedAt: new Date() });
+      const list = await seedTodoList(db, userId, at.id);
+      const now = new Date();
+      await db.insert(todos).values({ userId, listId: list.id, title: 'Done', estimatedLength: 30, scheduledAt: now, completedAt: now });
+
+      const result = await gql(testSchema, db, userId, STATS_QUERY);
+      expect(result.errors).toBeUndefined();
+      const stats = result.data?.myStats as Record<string, unknown>;
+      expect(stats.weightedScore).not.toBeNull();
+    });
+
+    it('respects startDate filter for todos', async () => {
+      const { id: userId } = await seedUser(db, 'stats-datefilter@example.com');
+      const at = await seedActivityType(db, userId);
+      const list = await seedTodoList(db, userId, at.id);
+      await db.insert(todos).values({ userId, listId: list.id, title: 'Old', estimatedLength: 30, scheduledAt: new Date('2020-01-01') });
+
+      const result = await gql(testSchema, db, userId, STATS_QUERY, {
+        start: '2025-01-01T00:00:00',
+        end: new Date().toISOString(),
+      });
+      expect(result.errors).toBeUndefined();
+      const todosData = (result.data?.myStats as Record<string, unknown>).todos as { total: number };
+      expect(todosData.total).toBe(0);
+    });
+
+    it('uses monthly frequencyUnit for habit rate calculation', async () => {
+      const { id: userId } = await seedUser(db, 'stats-monthly@example.com');
+      const at = await seedActivityType(db, userId);
+      await seedHabit(db, userId, at.id, { frequencyCount: 4, frequencyUnit: 'month' });
+
+      const result = await gql(testSchema, db, userId, STATS_QUERY);
+      expect(result.errors).toBeUndefined();
+      const summaries = (result.data?.myStats as Record<string, unknown>).habits as Array<{ frequencyUnit: string }>;
+      expect(summaries[0]?.frequencyUnit).toBe('month');
+    });
+  });
+});

--- a/packages/server/src/schema/resolvers/resolvers.stats.integration.test.ts
+++ b/packages/server/src/schema/resolvers/resolvers.stats.integration.test.ts
@@ -35,7 +35,12 @@ describe('stats resolvers', () => {
 
   describe('myStats', () => {
     it('throws when not authenticated', async () => {
-      const result = await gql(testSchema, db, '', 'query { myStats { weightedScore } }');
+      const result = await gql(
+        testSchema,
+        db,
+        '',
+        'query { myStats { weightedScore } }',
+      );
       expect(result.errors?.[0]?.message).toMatch(/not authenticated/i);
     });
 
@@ -53,8 +58,13 @@ describe('stats resolvers', () => {
     it('returns habit score based on completions', async () => {
       const { id: userId } = await seedUser(db, 'stats-habitscore@example.com');
       const at = await seedActivityType(db, userId);
-      const habit = await seedHabit(db, userId, at.id, { frequencyCount: 2, frequencyUnit: 'week' });
-      await db.insert(habitCompletions).values({ habitId: habit.id, completedAt: new Date() });
+      const habit = await seedHabit(db, userId, at.id, {
+        frequencyCount: 2,
+        frequencyUnit: 'week',
+      });
+      await db
+        .insert(habitCompletions)
+        .values({ habitId: habit.id, completedAt: new Date() });
 
       const result = await gql(testSchema, db, userId, STATS_QUERY);
       expect(result.errors).toBeUndefined();
@@ -67,10 +77,16 @@ describe('stats resolvers', () => {
     it('returns 1.0 habitScore when target is zero (no elapsed time)', async () => {
       const { id: userId } = await seedUser(db, 'stats-zerotarget@example.com');
       const at = await seedActivityType(db, userId);
-      await seedHabit(db, userId, at.id, { frequencyCount: 3, frequencyUnit: 'week' });
+      await seedHabit(db, userId, at.id, {
+        frequencyCount: 3,
+        frequencyUnit: 'week',
+      });
 
       const now = new Date().toISOString().slice(0, 10);
-      const result = await gql(testSchema, db, userId, STATS_QUERY, { start: now, end: now });
+      const result = await gql(testSchema, db, userId, STATS_QUERY, {
+        start: now,
+        end: now,
+      });
       expect(result.errors).toBeUndefined();
       const stats = result.data?.myStats as Record<string, unknown>;
       const summaries = stats.habits as Array<{ completionRate: number }>;
@@ -84,16 +100,40 @@ describe('stats resolvers', () => {
       const now = new Date();
       const future = new Date(Date.now() + 86_400_000);
       await db.insert(todos).values([
-        { userId, listId: list.id, title: 'Done', estimatedLength: 30, scheduledAt: now, completedAt: now },
-        { userId, listId: list.id, title: 'Overdue', estimatedLength: 30, scheduledAt: new Date(Date.now() - 86_400_000) },
-        { userId, listId: list.id, title: 'Pending', estimatedLength: 30, scheduledAt: future },
+        {
+          userId,
+          listId: list.id,
+          title: 'Done',
+          estimatedLength: 30,
+          scheduledAt: now,
+          completedAt: now,
+        },
+        {
+          userId,
+          listId: list.id,
+          title: 'Overdue',
+          estimatedLength: 30,
+          scheduledAt: new Date(Date.now() - 86_400_000),
+        },
+        {
+          userId,
+          listId: list.id,
+          title: 'Pending',
+          estimatedLength: 30,
+          scheduledAt: future,
+        },
       ]);
 
       const farFuture = new Date(Date.now() + 30 * 86_400_000).toISOString();
-      const result = await gql(testSchema, db, userId, STATS_QUERY, { end: farFuture });
+      const result = await gql(testSchema, db, userId, STATS_QUERY, {
+        end: farFuture,
+      });
       expect(result.errors).toBeUndefined();
-      const todosData = (result.data?.myStats as Record<string, unknown>).todos as {
-        total: number; completed: number; overdue: number;
+      const todosData = (result.data?.myStats as Record<string, unknown>)
+        .todos as {
+        total: number;
+        completed: number;
+        overdue: number;
       };
       expect(todosData.total).toBe(3);
       expect(todosData.completed).toBe(1);
@@ -103,11 +143,23 @@ describe('stats resolvers', () => {
     it('produces a weighted score when both habit and todo data are present', async () => {
       const { id: userId } = await seedUser(db, 'stats-weighted@example.com');
       const at = await seedActivityType(db, userId);
-      const habit = await seedHabit(db, userId, at.id, { frequencyCount: 1, frequencyUnit: 'week' });
-      await db.insert(habitCompletions).values({ habitId: habit.id, completedAt: new Date() });
+      const habit = await seedHabit(db, userId, at.id, {
+        frequencyCount: 1,
+        frequencyUnit: 'week',
+      });
+      await db
+        .insert(habitCompletions)
+        .values({ habitId: habit.id, completedAt: new Date() });
       const list = await seedTodoList(db, userId, at.id);
       const now = new Date();
-      await db.insert(todos).values({ userId, listId: list.id, title: 'Done', estimatedLength: 30, scheduledAt: now, completedAt: now });
+      await db.insert(todos).values({
+        userId,
+        listId: list.id,
+        title: 'Done',
+        estimatedLength: 30,
+        scheduledAt: now,
+        completedAt: now,
+      });
 
       const result = await gql(testSchema, db, userId, STATS_QUERY);
       expect(result.errors).toBeUndefined();
@@ -119,25 +171,36 @@ describe('stats resolvers', () => {
       const { id: userId } = await seedUser(db, 'stats-datefilter@example.com');
       const at = await seedActivityType(db, userId);
       const list = await seedTodoList(db, userId, at.id);
-      await db.insert(todos).values({ userId, listId: list.id, title: 'Old', estimatedLength: 30, scheduledAt: new Date('2020-01-01') });
+      await db.insert(todos).values({
+        userId,
+        listId: list.id,
+        title: 'Old',
+        estimatedLength: 30,
+        scheduledAt: new Date('2020-01-01'),
+      });
 
       const result = await gql(testSchema, db, userId, STATS_QUERY, {
         start: '2025-01-01T00:00:00',
         end: new Date().toISOString(),
       });
       expect(result.errors).toBeUndefined();
-      const todosData = (result.data?.myStats as Record<string, unknown>).todos as { total: number };
+      const todosData = (result.data?.myStats as Record<string, unknown>)
+        .todos as { total: number };
       expect(todosData.total).toBe(0);
     });
 
     it('uses monthly frequencyUnit for habit rate calculation', async () => {
       const { id: userId } = await seedUser(db, 'stats-monthly@example.com');
       const at = await seedActivityType(db, userId);
-      await seedHabit(db, userId, at.id, { frequencyCount: 4, frequencyUnit: 'month' });
+      await seedHabit(db, userId, at.id, {
+        frequencyCount: 4,
+        frequencyUnit: 'month',
+      });
 
       const result = await gql(testSchema, db, userId, STATS_QUERY);
       expect(result.errors).toBeUndefined();
-      const summaries = (result.data?.myStats as Record<string, unknown>).habits as Array<{ frequencyUnit: string }>;
+      const summaries = (result.data?.myStats as Record<string, unknown>)
+        .habits as Array<{ frequencyUnit: string }>;
       expect(summaries[0]?.frequencyUnit).toBe('month');
     });
   });

--- a/packages/server/src/schema/resolvers/resolvers.timeblocks-activitytypes.integration.test.ts
+++ b/packages/server/src/schema/resolvers/resolvers.timeblocks-activitytypes.integration.test.ts
@@ -49,6 +49,29 @@ describe('time-block and activity-type resolvers', () => {
       expect(blocks).toHaveLength(1);
     });
 
+    it('filters by containsDay', async () => {
+      const { id: userId } = await seedUser(db, 'tb-containsday@example.com');
+      const at = await seedActivityType(db, userId);
+      await gql(testSchema, db, userId,
+        'mutation($input: CreateTimeBlockArgs!) { myCreateTimeBlock(input: $input) { id } }',
+        { input: { activityTypeId: at.id, daysOfWeek: [1, 2], startTime: '09:00', endTime: '10:00' } },
+      );
+      await gql(testSchema, db, userId,
+        'mutation($input: CreateTimeBlockArgs!) { myCreateTimeBlock(input: $input) { id } }',
+        { input: { activityTypeId: at.id, daysOfWeek: [5, 6], startTime: '10:00', endTime: '11:00' } },
+      );
+
+      // Day 1 (Monday) should only return the first block
+      const result = await gql(
+        testSchema, db, userId,
+        'query($day: Int) { myTimeBlocks(containsDay: $day) { id daysOfWeek } }',
+        { day: 1 },
+      );
+      expect(result.errors).toBeUndefined();
+      const blocks = result.data?.myTimeBlocks as Array<{ daysOfWeek: number[] }>;
+      expect(blocks.every((b) => b.daysOfWeek.includes(1))).toBe(true);
+    });
+
     it('filters by activityTypeId', async () => {
       const { id: userId } = await seedUser(db, 'tb-atfilter@example.com');
       const at1 = await seedActivityType(db, userId, 'Work');

--- a/packages/server/src/schema/resolvers/resolvers.timeblocks-activitytypes.integration.test.ts
+++ b/packages/server/src/schema/resolvers/resolvers.timeblocks-activitytypes.integration.test.ts
@@ -25,25 +25,55 @@ describe('time-block and activity-type resolvers', () => {
 
   describe('myTimeBlocks', () => {
     it('throws when not authenticated', async () => {
-      const result = await gql(testSchema, db, '', 'query { myTimeBlocks { id } }');
+      const result = await gql(
+        testSchema,
+        db,
+        '',
+        'query { myTimeBlocks { id } }',
+      );
       expect(result.errors?.[0]?.message).toMatch(/not authenticated/i);
     });
 
-    it('returns only the current user\'s time blocks', async () => {
+    it("returns only the current user's time blocks", async () => {
       const { id: userId } = await seedUser(db, 'tb-isolation@example.com');
       const { id: otherId } = await seedUser(db, 'tb-other@example.com');
       const at = await seedActivityType(db, userId);
       const otherAt = await seedActivityType(db, otherId);
-      await gql(testSchema, db, userId,
+      await gql(
+        testSchema,
+        db,
+        userId,
         'mutation($input: CreateTimeBlockArgs!) { myCreateTimeBlock(input: $input) { id } }',
-        { input: { activityTypeId: at.id, daysOfWeek: [1], startTime: '09:00', endTime: '10:00' } },
+        {
+          input: {
+            activityTypeId: at.id,
+            daysOfWeek: [1],
+            startTime: '09:00',
+            endTime: '10:00',
+          },
+        },
       );
-      await gql(testSchema, db, otherId,
+      await gql(
+        testSchema,
+        db,
+        otherId,
         'mutation($input: CreateTimeBlockArgs!) { myCreateTimeBlock(input: $input) { id } }',
-        { input: { activityTypeId: otherAt.id, daysOfWeek: [2], startTime: '11:00', endTime: '12:00' } },
+        {
+          input: {
+            activityTypeId: otherAt.id,
+            daysOfWeek: [2],
+            startTime: '11:00',
+            endTime: '12:00',
+          },
+        },
       );
 
-      const result = await gql(testSchema, db, userId, 'query { myTimeBlocks { id } }');
+      const result = await gql(
+        testSchema,
+        db,
+        userId,
+        'query { myTimeBlocks { id } }',
+      );
       expect(result.errors).toBeUndefined();
       const blocks = result.data?.myTimeBlocks as unknown[];
       expect(blocks).toHaveLength(1);
@@ -52,23 +82,47 @@ describe('time-block and activity-type resolvers', () => {
     it('filters by containsDay', async () => {
       const { id: userId } = await seedUser(db, 'tb-containsday@example.com');
       const at = await seedActivityType(db, userId);
-      await gql(testSchema, db, userId,
+      await gql(
+        testSchema,
+        db,
+        userId,
         'mutation($input: CreateTimeBlockArgs!) { myCreateTimeBlock(input: $input) { id } }',
-        { input: { activityTypeId: at.id, daysOfWeek: [1, 2], startTime: '09:00', endTime: '10:00' } },
+        {
+          input: {
+            activityTypeId: at.id,
+            daysOfWeek: [1, 2],
+            startTime: '09:00',
+            endTime: '10:00',
+          },
+        },
       );
-      await gql(testSchema, db, userId,
+      await gql(
+        testSchema,
+        db,
+        userId,
         'mutation($input: CreateTimeBlockArgs!) { myCreateTimeBlock(input: $input) { id } }',
-        { input: { activityTypeId: at.id, daysOfWeek: [5, 6], startTime: '10:00', endTime: '11:00' } },
+        {
+          input: {
+            activityTypeId: at.id,
+            daysOfWeek: [5, 6],
+            startTime: '10:00',
+            endTime: '11:00',
+          },
+        },
       );
 
       // Day 1 (Monday) should only return the first block
       const result = await gql(
-        testSchema, db, userId,
+        testSchema,
+        db,
+        userId,
         'query($day: Int) { myTimeBlocks(containsDay: $day) { id daysOfWeek } }',
         { day: 1 },
       );
       expect(result.errors).toBeUndefined();
-      const blocks = result.data?.myTimeBlocks as Array<{ daysOfWeek: number[] }>;
+      const blocks = result.data?.myTimeBlocks as Array<{
+        daysOfWeek: number[];
+      }>;
       expect(blocks.every((b) => b.daysOfWeek.includes(1))).toBe(true);
     });
 
@@ -76,17 +130,39 @@ describe('time-block and activity-type resolvers', () => {
       const { id: userId } = await seedUser(db, 'tb-atfilter@example.com');
       const at1 = await seedActivityType(db, userId, 'Work');
       const at2 = await seedActivityType(db, userId, 'Exercise');
-      await gql(testSchema, db, userId,
+      await gql(
+        testSchema,
+        db,
+        userId,
         'mutation($input: CreateTimeBlockArgs!) { myCreateTimeBlock(input: $input) { id } }',
-        { input: { activityTypeId: at1.id, daysOfWeek: [1], startTime: '09:00', endTime: '10:00' } },
+        {
+          input: {
+            activityTypeId: at1.id,
+            daysOfWeek: [1],
+            startTime: '09:00',
+            endTime: '10:00',
+          },
+        },
       );
-      await gql(testSchema, db, userId,
+      await gql(
+        testSchema,
+        db,
+        userId,
         'mutation($input: CreateTimeBlockArgs!) { myCreateTimeBlock(input: $input) { id } }',
-        { input: { activityTypeId: at2.id, daysOfWeek: [2], startTime: '11:00', endTime: '12:00' } },
+        {
+          input: {
+            activityTypeId: at2.id,
+            daysOfWeek: [2],
+            startTime: '11:00',
+            endTime: '12:00',
+          },
+        },
       );
 
       const result = await gql(
-        testSchema, db, userId,
+        testSchema,
+        db,
+        userId,
         'query($id: ID) { myTimeBlocks(activityTypeId: $id) { id } }',
         { id: at2.id },
       );
@@ -101,9 +177,19 @@ describe('time-block and activity-type resolvers', () => {
     it('throws when not authenticated', async () => {
       const { id: userId } = await seedUser(db, 'create-tb-seed@example.com');
       const at = await seedActivityType(db, userId);
-      const result = await gql(testSchema, db, '',
+      const result = await gql(
+        testSchema,
+        db,
+        '',
         'mutation($input: CreateTimeBlockArgs!) { myCreateTimeBlock(input: $input) { id } }',
-        { input: { activityTypeId: at.id, daysOfWeek: [1], startTime: '09:00', endTime: '10:00' } },
+        {
+          input: {
+            activityTypeId: at.id,
+            daysOfWeek: [1],
+            startTime: '09:00',
+            endTime: '10:00',
+          },
+        },
       );
       expect(result.errors?.[0]?.message).toMatch(/not authenticated/i);
     });
@@ -111,9 +197,19 @@ describe('time-block and activity-type resolvers', () => {
     it('creates a time block and returns it', async () => {
       const { id: userId } = await seedUser(db, 'create-tb@example.com');
       const at = await seedActivityType(db, userId);
-      const result = await gql(testSchema, db, userId,
+      const result = await gql(
+        testSchema,
+        db,
+        userId,
         'mutation($input: CreateTimeBlockArgs!) { myCreateTimeBlock(input: $input) { id startTime endTime daysOfWeek } }',
-        { input: { activityTypeId: at.id, daysOfWeek: [1, 2, 3], startTime: '09:00', endTime: '17:00' } },
+        {
+          input: {
+            activityTypeId: at.id,
+            daysOfWeek: [1, 2, 3],
+            startTime: '09:00',
+            endTime: '17:00',
+          },
+        },
       );
       expect(result.errors).toBeUndefined();
       const block = result.data?.myCreateTimeBlock as { startTime: string };
@@ -127,42 +223,87 @@ describe('time-block and activity-type resolvers', () => {
     it('updates time block fields', async () => {
       const { id: userId } = await seedUser(db, 'update-tb@example.com');
       const at = await seedActivityType(db, userId);
-      const createResult = await gql(testSchema, db, userId,
+      const createResult = await gql(
+        testSchema,
+        db,
+        userId,
         'mutation($input: CreateTimeBlockArgs!) { myCreateTimeBlock(input: $input) { id } }',
-        { input: { activityTypeId: at.id, daysOfWeek: [1], startTime: '09:00', endTime: '10:00' } },
+        {
+          input: {
+            activityTypeId: at.id,
+            daysOfWeek: [1],
+            startTime: '09:00',
+            endTime: '10:00',
+          },
+        },
       );
-      const blockId = (createResult.data?.myCreateTimeBlock as { id: string }).id;
+      const blockId = (createResult.data?.myCreateTimeBlock as { id: string })
+        .id;
 
-      const result = await gql(testSchema, db, userId,
+      const result = await gql(
+        testSchema,
+        db,
+        userId,
         'mutation($input: UpdateTimeBlockArgs!) { myUpdateTimeBlock(input: $input) { id startTime endTime } }',
         { input: { id: blockId, startTime: '10:00', endTime: '11:00' } },
       );
       expect(result.errors).toBeUndefined();
-      const updated = result.data?.myUpdateTimeBlock as { startTime: string; endTime: string };
+      const updated = result.data?.myUpdateTimeBlock as {
+        startTime: string;
+        endTime: string;
+      };
       expect(updated.startTime).toBe('10:00');
       expect(updated.endTime).toBe('11:00');
     });
 
     it('throws when time block not found', async () => {
-      const { id: userId } = await seedUser(db, 'update-tb-notfound@example.com');
-      const result = await gql(testSchema, db, userId,
+      const { id: userId } = await seedUser(
+        db,
+        'update-tb-notfound@example.com',
+      );
+      const result = await gql(
+        testSchema,
+        db,
+        userId,
         'mutation($input: UpdateTimeBlockArgs!) { myUpdateTimeBlock(input: $input) { id } }',
-        { input: { id: '00000000-0000-0000-0000-000000000000', startTime: '09:00' } },
+        {
+          input: {
+            id: '00000000-0000-0000-0000-000000000000',
+            startTime: '09:00',
+          },
+        },
       );
       expect(result.errors?.[0]?.message).toMatch(/not found/i);
     });
 
     it('throws Forbidden when time block belongs to another user', async () => {
-      const { id: userId } = await seedUser(db, 'update-tb-forbidden@example.com');
+      const { id: userId } = await seedUser(
+        db,
+        'update-tb-forbidden@example.com',
+      );
       const { id: otherId } = await seedUser(db, 'update-tb-other@example.com');
       const otherAt = await seedActivityType(db, otherId);
-      const createResult = await gql(testSchema, db, otherId,
+      const createResult = await gql(
+        testSchema,
+        db,
+        otherId,
         'mutation($input: CreateTimeBlockArgs!) { myCreateTimeBlock(input: $input) { id } }',
-        { input: { activityTypeId: otherAt.id, daysOfWeek: [1], startTime: '09:00', endTime: '10:00' } },
+        {
+          input: {
+            activityTypeId: otherAt.id,
+            daysOfWeek: [1],
+            startTime: '09:00',
+            endTime: '10:00',
+          },
+        },
       );
-      const blockId = (createResult.data?.myCreateTimeBlock as { id: string }).id;
+      const blockId = (createResult.data?.myCreateTimeBlock as { id: string })
+        .id;
 
-      const result = await gql(testSchema, db, userId,
+      const result = await gql(
+        testSchema,
+        db,
+        userId,
         'mutation($input: UpdateTimeBlockArgs!) { myUpdateTimeBlock(input: $input) { id } }',
         { input: { id: blockId, startTime: '11:00' } },
       );
@@ -176,13 +317,27 @@ describe('time-block and activity-type resolvers', () => {
     it('deletes a time block and returns true', async () => {
       const { id: userId } = await seedUser(db, 'delete-tb@example.com');
       const at = await seedActivityType(db, userId);
-      const createResult = await gql(testSchema, db, userId,
+      const createResult = await gql(
+        testSchema,
+        db,
+        userId,
         'mutation($input: CreateTimeBlockArgs!) { myCreateTimeBlock(input: $input) { id } }',
-        { input: { activityTypeId: at.id, daysOfWeek: [1], startTime: '09:00', endTime: '10:00' } },
+        {
+          input: {
+            activityTypeId: at.id,
+            daysOfWeek: [1],
+            startTime: '09:00',
+            endTime: '10:00',
+          },
+        },
       );
-      const blockId = (createResult.data?.myCreateTimeBlock as { id: string }).id;
+      const blockId = (createResult.data?.myCreateTimeBlock as { id: string })
+        .id;
 
-      const result = await gql(testSchema, db, userId,
+      const result = await gql(
+        testSchema,
+        db,
+        userId,
         'mutation($id: ID!) { myDeleteTimeBlock(id: $id) }',
         { id: blockId },
       );
@@ -191,24 +346,47 @@ describe('time-block and activity-type resolvers', () => {
     });
 
     it('throws when time block not found', async () => {
-      const { id: userId } = await seedUser(db, 'delete-tb-notfound@example.com');
-      const result = await gql(testSchema, db, userId,
+      const { id: userId } = await seedUser(
+        db,
+        'delete-tb-notfound@example.com',
+      );
+      const result = await gql(
+        testSchema,
+        db,
+        userId,
         'mutation { myDeleteTimeBlock(id: "00000000-0000-0000-0000-000000000000") }',
       );
       expect(result.errors?.[0]?.message).toMatch(/not found/i);
     });
 
     it('throws Forbidden when time block belongs to another user', async () => {
-      const { id: userId } = await seedUser(db, 'delete-tb-forbidden@example.com');
+      const { id: userId } = await seedUser(
+        db,
+        'delete-tb-forbidden@example.com',
+      );
       const { id: otherId } = await seedUser(db, 'delete-tb-other@example.com');
       const otherAt = await seedActivityType(db, otherId);
-      const createResult = await gql(testSchema, db, otherId,
+      const createResult = await gql(
+        testSchema,
+        db,
+        otherId,
         'mutation($input: CreateTimeBlockArgs!) { myCreateTimeBlock(input: $input) { id } }',
-        { input: { activityTypeId: otherAt.id, daysOfWeek: [3], startTime: '09:00', endTime: '10:00' } },
+        {
+          input: {
+            activityTypeId: otherAt.id,
+            daysOfWeek: [3],
+            startTime: '09:00',
+            endTime: '10:00',
+          },
+        },
       );
-      const blockId = (createResult.data?.myCreateTimeBlock as { id: string }).id;
+      const blockId = (createResult.data?.myCreateTimeBlock as { id: string })
+        .id;
 
-      const result = await gql(testSchema, db, userId,
+      const result = await gql(
+        testSchema,
+        db,
+        userId,
         'mutation($id: ID!) { myDeleteTimeBlock(id: $id) }',
         { id: blockId },
       );
@@ -220,17 +398,27 @@ describe('time-block and activity-type resolvers', () => {
 
   describe('myActivityTypes', () => {
     it('throws when not authenticated', async () => {
-      const result = await gql(testSchema, db, '', 'query { myActivityTypes { id } }');
+      const result = await gql(
+        testSchema,
+        db,
+        '',
+        'query { myActivityTypes { id } }',
+      );
       expect(result.errors?.[0]?.message).toMatch(/not authenticated/i);
     });
 
-    it('returns only the current user\'s activity types', async () => {
+    it("returns only the current user's activity types", async () => {
       const { id: userId } = await seedUser(db, 'at-isolation@example.com');
       const { id: otherId } = await seedUser(db, 'at-other@example.com');
       await seedActivityType(db, userId, 'Mine');
       await seedActivityType(db, otherId, 'Theirs');
 
-      const result = await gql(testSchema, db, userId, 'query { myActivityTypes { name } }');
+      const result = await gql(
+        testSchema,
+        db,
+        userId,
+        'query { myActivityTypes { name } }',
+      );
       expect(result.errors).toBeUndefined();
       const items = result.data?.myActivityTypes as Array<{ name: string }>;
       expect(items.every((i) => i.name !== 'Theirs')).toBe(true);
@@ -241,7 +429,12 @@ describe('time-block and activity-type resolvers', () => {
 
   describe('activityTypeStats', () => {
     it('throws when not authenticated', async () => {
-      const result = await gql(testSchema, db, '', 'query { activityTypeStats { activityTypeId } }');
+      const result = await gql(
+        testSchema,
+        db,
+        '',
+        'query { activityTypeStats { activityTypeId } }',
+      );
       expect(result.errors?.[0]?.message).toMatch(/not authenticated/i);
     });
 
@@ -250,11 +443,16 @@ describe('time-block and activity-type resolvers', () => {
       await seedActivityType(db, userId, 'Empty');
 
       const result = await gql(
-        testSchema, db, userId,
+        testSchema,
+        db,
+        userId,
         'query { activityTypeStats { activityTypeId activityTypeName totalTodos completedTodos totalHabits } }',
       );
       expect(result.errors).toBeUndefined();
-      const stats = result.data?.activityTypeStats as Array<{ totalTodos: number; totalHabits: number }>;
+      const stats = result.data?.activityTypeStats as Array<{
+        totalTodos: number;
+        totalHabits: number;
+      }>;
       expect(stats[0]?.totalTodos).toBe(0);
       expect(stats[0]?.totalHabits).toBe(0);
     });
@@ -264,47 +462,90 @@ describe('time-block and activity-type resolvers', () => {
       const at = await seedActivityType(db, userId, 'Work');
       const list = await seedTodoList(db, userId, at.id);
       const now = new Date();
-      await db.insert(todos).values({ userId, listId: list.id, title: 'Done', estimatedLength: 30, scheduledAt: now, completedAt: now });
-      await db.insert(todos).values({ userId, listId: list.id, title: 'Pending', estimatedLength: 30 });
+      await db.insert(todos).values({
+        userId,
+        listId: list.id,
+        title: 'Done',
+        estimatedLength: 30,
+        scheduledAt: now,
+        completedAt: now,
+      });
+      await db.insert(todos).values({
+        userId,
+        listId: list.id,
+        title: 'Pending',
+        estimatedLength: 30,
+      });
       await seedHabit(db, userId, at.id);
 
       const result = await gql(
-        testSchema, db, userId,
+        testSchema,
+        db,
+        userId,
         'query { activityTypeStats { totalTodos completedTodos totalHabits } }',
       );
       expect(result.errors).toBeUndefined();
-      const stats = result.data?.activityTypeStats as Array<{ totalTodos: number; completedTodos: number; totalHabits: number }>;
+      const stats = result.data?.activityTypeStats as Array<{
+        totalTodos: number;
+        completedTodos: number;
+        totalHabits: number;
+      }>;
       expect(stats[0]?.totalHabits).toBe(1);
     });
 
     it('respects startDate/endDate for todo counts', async () => {
-      const { id: userId } = await seedUser(db, 'atstats-datefilter@example.com');
+      const { id: userId } = await seedUser(
+        db,
+        'atstats-datefilter@example.com',
+      );
       const at = await seedActivityType(db, userId, 'Work');
       const list = await seedTodoList(db, userId, at.id);
-      await db.insert(todos).values({ userId, listId: list.id, title: 'Old', estimatedLength: 30, scheduledAt: new Date('2020-01-01') });
+      await db.insert(todos).values({
+        userId,
+        listId: list.id,
+        title: 'Old',
+        estimatedLength: 30,
+        scheduledAt: new Date('2020-01-01'),
+      });
 
       const result = await gql(
-        testSchema, db, userId,
+        testSchema,
+        db,
+        userId,
         'query($s: String, $e: String) { activityTypeStats(startDate: $s, endDate: $e) { totalTodos } }',
         { s: '2025-01-01', e: '2025-12-31' },
       );
       expect(result.errors).toBeUndefined();
-      const stats = result.data?.activityTypeStats as Array<{ totalTodos: number }>;
+      const stats = result.data?.activityTypeStats as Array<{
+        totalTodos: number;
+      }>;
       expect(stats[0]?.totalTodos).toBe(0);
     });
 
     it('counts todos without scheduledAt or completedAt when no date range is given', async () => {
-      const { id: userId } = await seedUser(db, 'atstats-unscheduled@example.com');
+      const { id: userId } = await seedUser(
+        db,
+        'atstats-unscheduled@example.com',
+      );
       const at = await seedActivityType(db, userId, 'Work');
       const list = await seedTodoList(db, userId, at.id);
-      await db.insert(todos).values({ userId, listId: list.id, title: 'Unscheduled', estimatedLength: 30 });
+      await db.insert(todos).values({
+        userId,
+        listId: list.id,
+        title: 'Unscheduled',
+        estimatedLength: 30,
+      });
 
       const result = await gql(
-        testSchema, db, userId,
+        testSchema,
+        db,
+        userId,
         'query { activityTypeStats { totalTodos } }',
       );
       expect(result.errors).toBeUndefined();
-      const stats = result.data?.activityTypeStats as Array<{ totalTodos: number }>;
+      const stats = result.data?.activityTypeStats as Array<{
+        totalTodos: number;
+      }>;
       expect(stats[0]?.totalTodos).toBe(1);
     });
   });
@@ -316,19 +557,31 @@ describe('time-block and activity-type resolvers', () => {
       const { id: userId } = await seedUser(db, 'update-at@example.com');
       const at = await seedActivityType(db, userId, 'Old');
 
-      const result = await gql(testSchema, db, userId,
+      const result = await gql(
+        testSchema,
+        db,
+        userId,
         'mutation($input: UpdateActivityTypeArgs!) { myUpdateActivityType(input: $input) { id name color } }',
         { input: { id: at.id, name: 'New', color: '#ff0000' } },
       );
       expect(result.errors).toBeUndefined();
-      const updated = result.data?.myUpdateActivityType as { name: string; color: string };
+      const updated = result.data?.myUpdateActivityType as {
+        name: string;
+        color: string;
+      };
       expect(updated.name).toBe('New');
       expect(updated.color).toBe('#ff0000');
     });
 
     it('throws when activity type not found', async () => {
-      const { id: userId } = await seedUser(db, 'update-at-notfound@example.com');
-      const result = await gql(testSchema, db, userId,
+      const { id: userId } = await seedUser(
+        db,
+        'update-at-notfound@example.com',
+      );
+      const result = await gql(
+        testSchema,
+        db,
+        userId,
         'mutation($input: UpdateActivityTypeArgs!) { myUpdateActivityType(input: $input) { id } }',
         { input: { id: '00000000-0000-0000-0000-000000000000', name: 'X' } },
       );
@@ -336,11 +589,17 @@ describe('time-block and activity-type resolvers', () => {
     });
 
     it('throws Forbidden when activity type belongs to another user', async () => {
-      const { id: userId } = await seedUser(db, 'update-at-forbidden@example.com');
+      const { id: userId } = await seedUser(
+        db,
+        'update-at-forbidden@example.com',
+      );
       const { id: otherId } = await seedUser(db, 'update-at-other@example.com');
       const otherAt = await seedActivityType(db, otherId);
 
-      const result = await gql(testSchema, db, userId,
+      const result = await gql(
+        testSchema,
+        db,
+        userId,
         'mutation($input: UpdateActivityTypeArgs!) { myUpdateActivityType(input: $input) { id } }',
         { input: { id: otherAt.id, name: 'Hack' } },
       );
@@ -355,7 +614,10 @@ describe('time-block and activity-type resolvers', () => {
       const { id: userId } = await seedUser(db, 'delete-at@example.com');
       const at = await seedActivityType(db, userId);
 
-      const result = await gql(testSchema, db, userId,
+      const result = await gql(
+        testSchema,
+        db,
+        userId,
         'mutation($id: ID!) { myDeleteActivityType(id: $id) }',
         { id: at.id },
       );
@@ -364,19 +626,31 @@ describe('time-block and activity-type resolvers', () => {
     });
 
     it('throws when activity type not found', async () => {
-      const { id: userId } = await seedUser(db, 'delete-at-notfound@example.com');
-      const result = await gql(testSchema, db, userId,
+      const { id: userId } = await seedUser(
+        db,
+        'delete-at-notfound@example.com',
+      );
+      const result = await gql(
+        testSchema,
+        db,
+        userId,
         'mutation { myDeleteActivityType(id: "00000000-0000-0000-0000-000000000000") }',
       );
       expect(result.errors?.[0]?.message).toMatch(/not found/i);
     });
 
     it('throws Forbidden when activity type belongs to another user', async () => {
-      const { id: userId } = await seedUser(db, 'delete-at-forbidden@example.com');
+      const { id: userId } = await seedUser(
+        db,
+        'delete-at-forbidden@example.com',
+      );
       const { id: otherId } = await seedUser(db, 'delete-at-other@example.com');
       const otherAt = await seedActivityType(db, otherId);
 
-      const result = await gql(testSchema, db, userId,
+      const result = await gql(
+        testSchema,
+        db,
+        userId,
         'mutation($id: ID!) { myDeleteActivityType(id: $id) }',
         { id: otherAt.id },
       );

--- a/packages/server/src/schema/resolvers/resolvers.timeblocks-activitytypes.integration.test.ts
+++ b/packages/server/src/schema/resolvers/resolvers.timeblocks-activitytypes.integration.test.ts
@@ -1,0 +1,363 @@
+import { todos } from '@auto-cal/db/schema';
+import { beforeAll, describe, expect, it } from 'vitest';
+import {
+  type TestDb,
+  type TestSchema,
+  buildTestSchema,
+  createTestDb,
+  gql,
+  seedActivityType,
+  seedHabit,
+  seedTodoList,
+  seedUser,
+} from './test-helpers.ts';
+
+describe('time-block and activity-type resolvers', () => {
+  let db: TestDb;
+  let testSchema: TestSchema;
+
+  beforeAll(async () => {
+    db = await createTestDb();
+    testSchema = buildTestSchema(db);
+  }, 30000);
+
+  // ─── myTimeBlocks ─────────────────────────────────────────────────────────────
+
+  describe('myTimeBlocks', () => {
+    it('throws when not authenticated', async () => {
+      const result = await gql(testSchema, db, '', 'query { myTimeBlocks { id } }');
+      expect(result.errors?.[0]?.message).toMatch(/not authenticated/i);
+    });
+
+    it('returns only the current user\'s time blocks', async () => {
+      const { id: userId } = await seedUser(db, 'tb-isolation@example.com');
+      const { id: otherId } = await seedUser(db, 'tb-other@example.com');
+      const at = await seedActivityType(db, userId);
+      const otherAt = await seedActivityType(db, otherId);
+      await gql(testSchema, db, userId,
+        'mutation($input: CreateTimeBlockArgs!) { myCreateTimeBlock(input: $input) { id } }',
+        { input: { activityTypeId: at.id, daysOfWeek: [1], startTime: '09:00', endTime: '10:00' } },
+      );
+      await gql(testSchema, db, otherId,
+        'mutation($input: CreateTimeBlockArgs!) { myCreateTimeBlock(input: $input) { id } }',
+        { input: { activityTypeId: otherAt.id, daysOfWeek: [2], startTime: '11:00', endTime: '12:00' } },
+      );
+
+      const result = await gql(testSchema, db, userId, 'query { myTimeBlocks { id } }');
+      expect(result.errors).toBeUndefined();
+      const blocks = result.data?.myTimeBlocks as unknown[];
+      expect(blocks).toHaveLength(1);
+    });
+
+    it('filters by activityTypeId', async () => {
+      const { id: userId } = await seedUser(db, 'tb-atfilter@example.com');
+      const at1 = await seedActivityType(db, userId, 'Work');
+      const at2 = await seedActivityType(db, userId, 'Exercise');
+      await gql(testSchema, db, userId,
+        'mutation($input: CreateTimeBlockArgs!) { myCreateTimeBlock(input: $input) { id } }',
+        { input: { activityTypeId: at1.id, daysOfWeek: [1], startTime: '09:00', endTime: '10:00' } },
+      );
+      await gql(testSchema, db, userId,
+        'mutation($input: CreateTimeBlockArgs!) { myCreateTimeBlock(input: $input) { id } }',
+        { input: { activityTypeId: at2.id, daysOfWeek: [2], startTime: '11:00', endTime: '12:00' } },
+      );
+
+      const result = await gql(
+        testSchema, db, userId,
+        'query($id: ID) { myTimeBlocks(activityTypeId: $id) { id } }',
+        { id: at2.id },
+      );
+      expect(result.errors).toBeUndefined();
+      expect((result.data?.myTimeBlocks as unknown[]).length).toBe(1);
+    });
+  });
+
+  // ─── myCreateTimeBlock ────────────────────────────────────────────────────────
+
+  describe('myCreateTimeBlock', () => {
+    it('throws when not authenticated', async () => {
+      const { id: userId } = await seedUser(db, 'create-tb-seed@example.com');
+      const at = await seedActivityType(db, userId);
+      const result = await gql(testSchema, db, '',
+        'mutation($input: CreateTimeBlockArgs!) { myCreateTimeBlock(input: $input) { id } }',
+        { input: { activityTypeId: at.id, daysOfWeek: [1], startTime: '09:00', endTime: '10:00' } },
+      );
+      expect(result.errors?.[0]?.message).toMatch(/not authenticated/i);
+    });
+
+    it('creates a time block and returns it', async () => {
+      const { id: userId } = await seedUser(db, 'create-tb@example.com');
+      const at = await seedActivityType(db, userId);
+      const result = await gql(testSchema, db, userId,
+        'mutation($input: CreateTimeBlockArgs!) { myCreateTimeBlock(input: $input) { id startTime endTime daysOfWeek } }',
+        { input: { activityTypeId: at.id, daysOfWeek: [1, 2, 3], startTime: '09:00', endTime: '17:00' } },
+      );
+      expect(result.errors).toBeUndefined();
+      const block = result.data?.myCreateTimeBlock as { startTime: string };
+      expect(block.startTime).toBe('09:00');
+    });
+  });
+
+  // ─── myUpdateTimeBlock ────────────────────────────────────────────────────────
+
+  describe('myUpdateTimeBlock', () => {
+    it('updates time block fields', async () => {
+      const { id: userId } = await seedUser(db, 'update-tb@example.com');
+      const at = await seedActivityType(db, userId);
+      const createResult = await gql(testSchema, db, userId,
+        'mutation($input: CreateTimeBlockArgs!) { myCreateTimeBlock(input: $input) { id } }',
+        { input: { activityTypeId: at.id, daysOfWeek: [1], startTime: '09:00', endTime: '10:00' } },
+      );
+      const blockId = (createResult.data?.myCreateTimeBlock as { id: string }).id;
+
+      const result = await gql(testSchema, db, userId,
+        'mutation($input: UpdateTimeBlockArgs!) { myUpdateTimeBlock(input: $input) { id startTime endTime } }',
+        { input: { id: blockId, startTime: '10:00', endTime: '11:00' } },
+      );
+      expect(result.errors).toBeUndefined();
+      const updated = result.data?.myUpdateTimeBlock as { startTime: string; endTime: string };
+      expect(updated.startTime).toBe('10:00');
+      expect(updated.endTime).toBe('11:00');
+    });
+
+    it('throws when time block not found', async () => {
+      const { id: userId } = await seedUser(db, 'update-tb-notfound@example.com');
+      const result = await gql(testSchema, db, userId,
+        'mutation($input: UpdateTimeBlockArgs!) { myUpdateTimeBlock(input: $input) { id } }',
+        { input: { id: '00000000-0000-0000-0000-000000000000', startTime: '09:00' } },
+      );
+      expect(result.errors?.[0]?.message).toMatch(/not found/i);
+    });
+
+    it('throws Forbidden when time block belongs to another user', async () => {
+      const { id: userId } = await seedUser(db, 'update-tb-forbidden@example.com');
+      const { id: otherId } = await seedUser(db, 'update-tb-other@example.com');
+      const otherAt = await seedActivityType(db, otherId);
+      const createResult = await gql(testSchema, db, otherId,
+        'mutation($input: CreateTimeBlockArgs!) { myCreateTimeBlock(input: $input) { id } }',
+        { input: { activityTypeId: otherAt.id, daysOfWeek: [1], startTime: '09:00', endTime: '10:00' } },
+      );
+      const blockId = (createResult.data?.myCreateTimeBlock as { id: string }).id;
+
+      const result = await gql(testSchema, db, userId,
+        'mutation($input: UpdateTimeBlockArgs!) { myUpdateTimeBlock(input: $input) { id } }',
+        { input: { id: blockId, startTime: '11:00' } },
+      );
+      expect(result.errors?.[0]?.message).toMatch(/forbidden/i);
+    });
+  });
+
+  // ─── myDeleteTimeBlock ────────────────────────────────────────────────────────
+
+  describe('myDeleteTimeBlock', () => {
+    it('deletes a time block and returns true', async () => {
+      const { id: userId } = await seedUser(db, 'delete-tb@example.com');
+      const at = await seedActivityType(db, userId);
+      const createResult = await gql(testSchema, db, userId,
+        'mutation($input: CreateTimeBlockArgs!) { myCreateTimeBlock(input: $input) { id } }',
+        { input: { activityTypeId: at.id, daysOfWeek: [1], startTime: '09:00', endTime: '10:00' } },
+      );
+      const blockId = (createResult.data?.myCreateTimeBlock as { id: string }).id;
+
+      const result = await gql(testSchema, db, userId,
+        'mutation($id: ID!) { myDeleteTimeBlock(id: $id) }',
+        { id: blockId },
+      );
+      expect(result.errors).toBeUndefined();
+      expect(result.data?.myDeleteTimeBlock).toBe(true);
+    });
+
+    it('throws when time block not found', async () => {
+      const { id: userId } = await seedUser(db, 'delete-tb-notfound@example.com');
+      const result = await gql(testSchema, db, userId,
+        'mutation { myDeleteTimeBlock(id: "00000000-0000-0000-0000-000000000000") }',
+      );
+      expect(result.errors?.[0]?.message).toMatch(/not found/i);
+    });
+
+    it('throws Forbidden when time block belongs to another user', async () => {
+      const { id: userId } = await seedUser(db, 'delete-tb-forbidden@example.com');
+      const { id: otherId } = await seedUser(db, 'delete-tb-other@example.com');
+      const otherAt = await seedActivityType(db, otherId);
+      const createResult = await gql(testSchema, db, otherId,
+        'mutation($input: CreateTimeBlockArgs!) { myCreateTimeBlock(input: $input) { id } }',
+        { input: { activityTypeId: otherAt.id, daysOfWeek: [3], startTime: '09:00', endTime: '10:00' } },
+      );
+      const blockId = (createResult.data?.myCreateTimeBlock as { id: string }).id;
+
+      const result = await gql(testSchema, db, userId,
+        'mutation($id: ID!) { myDeleteTimeBlock(id: $id) }',
+        { id: blockId },
+      );
+      expect(result.errors?.[0]?.message).toMatch(/forbidden/i);
+    });
+  });
+
+  // ─── myActivityTypes ──────────────────────────────────────────────────────────
+
+  describe('myActivityTypes', () => {
+    it('throws when not authenticated', async () => {
+      const result = await gql(testSchema, db, '', 'query { myActivityTypes { id } }');
+      expect(result.errors?.[0]?.message).toMatch(/not authenticated/i);
+    });
+
+    it('returns only the current user\'s activity types', async () => {
+      const { id: userId } = await seedUser(db, 'at-isolation@example.com');
+      const { id: otherId } = await seedUser(db, 'at-other@example.com');
+      await seedActivityType(db, userId, 'Mine');
+      await seedActivityType(db, otherId, 'Theirs');
+
+      const result = await gql(testSchema, db, userId, 'query { myActivityTypes { name } }');
+      expect(result.errors).toBeUndefined();
+      const items = result.data?.myActivityTypes as Array<{ name: string }>;
+      expect(items.every((i) => i.name !== 'Theirs')).toBe(true);
+    });
+  });
+
+  // ─── activityTypeStats ────────────────────────────────────────────────────────
+
+  describe('activityTypeStats', () => {
+    it('throws when not authenticated', async () => {
+      const result = await gql(testSchema, db, '', 'query { activityTypeStats { activityTypeId } }');
+      expect(result.errors?.[0]?.message).toMatch(/not authenticated/i);
+    });
+
+    it('returns stats with zero counts for empty activity type', async () => {
+      const { id: userId } = await seedUser(db, 'atstats-empty@example.com');
+      await seedActivityType(db, userId, 'Empty');
+
+      const result = await gql(
+        testSchema, db, userId,
+        'query { activityTypeStats { activityTypeId activityTypeName totalTodos completedTodos totalHabits } }',
+      );
+      expect(result.errors).toBeUndefined();
+      const stats = result.data?.activityTypeStats as Array<{ totalTodos: number; totalHabits: number }>;
+      expect(stats[0]?.totalTodos).toBe(0);
+      expect(stats[0]?.totalHabits).toBe(0);
+    });
+
+    it('counts todos and habits by activity type', async () => {
+      const { id: userId } = await seedUser(db, 'atstats-counts@example.com');
+      const at = await seedActivityType(db, userId, 'Work');
+      const list = await seedTodoList(db, userId, at.id);
+      const now = new Date();
+      await db.insert(todos).values({ userId, listId: list.id, title: 'Done', estimatedLength: 30, scheduledAt: now, completedAt: now });
+      await db.insert(todos).values({ userId, listId: list.id, title: 'Pending', estimatedLength: 30 });
+      await seedHabit(db, userId, at.id);
+
+      const result = await gql(
+        testSchema, db, userId,
+        'query { activityTypeStats { totalTodos completedTodos totalHabits } }',
+      );
+      expect(result.errors).toBeUndefined();
+      const stats = result.data?.activityTypeStats as Array<{ totalTodos: number; completedTodos: number; totalHabits: number }>;
+      expect(stats[0]?.totalHabits).toBe(1);
+    });
+
+    it('respects startDate/endDate for todo counts', async () => {
+      const { id: userId } = await seedUser(db, 'atstats-datefilter@example.com');
+      const at = await seedActivityType(db, userId, 'Work');
+      const list = await seedTodoList(db, userId, at.id);
+      await db.insert(todos).values({ userId, listId: list.id, title: 'Old', estimatedLength: 30, scheduledAt: new Date('2020-01-01') });
+
+      const result = await gql(
+        testSchema, db, userId,
+        'query($s: String, $e: String) { activityTypeStats(startDate: $s, endDate: $e) { totalTodos } }',
+        { s: '2025-01-01', e: '2025-12-31' },
+      );
+      expect(result.errors).toBeUndefined();
+      const stats = result.data?.activityTypeStats as Array<{ totalTodos: number }>;
+      expect(stats[0]?.totalTodos).toBe(0);
+    });
+
+    it('counts todos without scheduledAt or completedAt when no date range is given', async () => {
+      const { id: userId } = await seedUser(db, 'atstats-unscheduled@example.com');
+      const at = await seedActivityType(db, userId, 'Work');
+      const list = await seedTodoList(db, userId, at.id);
+      await db.insert(todos).values({ userId, listId: list.id, title: 'Unscheduled', estimatedLength: 30 });
+
+      const result = await gql(
+        testSchema, db, userId,
+        'query { activityTypeStats { totalTodos } }',
+      );
+      expect(result.errors).toBeUndefined();
+      const stats = result.data?.activityTypeStats as Array<{ totalTodos: number }>;
+      expect(stats[0]?.totalTodos).toBe(1);
+    });
+  });
+
+  // ─── myUpdateActivityType ─────────────────────────────────────────────────────
+
+  describe('myUpdateActivityType', () => {
+    it('updates name and color', async () => {
+      const { id: userId } = await seedUser(db, 'update-at@example.com');
+      const at = await seedActivityType(db, userId, 'Old');
+
+      const result = await gql(testSchema, db, userId,
+        'mutation($input: UpdateActivityTypeArgs!) { myUpdateActivityType(input: $input) { id name color } }',
+        { input: { id: at.id, name: 'New', color: '#ff0000' } },
+      );
+      expect(result.errors).toBeUndefined();
+      const updated = result.data?.myUpdateActivityType as { name: string; color: string };
+      expect(updated.name).toBe('New');
+      expect(updated.color).toBe('#ff0000');
+    });
+
+    it('throws when activity type not found', async () => {
+      const { id: userId } = await seedUser(db, 'update-at-notfound@example.com');
+      const result = await gql(testSchema, db, userId,
+        'mutation($input: UpdateActivityTypeArgs!) { myUpdateActivityType(input: $input) { id } }',
+        { input: { id: '00000000-0000-0000-0000-000000000000', name: 'X' } },
+      );
+      expect(result.errors?.[0]?.message).toMatch(/not found/i);
+    });
+
+    it('throws Forbidden when activity type belongs to another user', async () => {
+      const { id: userId } = await seedUser(db, 'update-at-forbidden@example.com');
+      const { id: otherId } = await seedUser(db, 'update-at-other@example.com');
+      const otherAt = await seedActivityType(db, otherId);
+
+      const result = await gql(testSchema, db, userId,
+        'mutation($input: UpdateActivityTypeArgs!) { myUpdateActivityType(input: $input) { id } }',
+        { input: { id: otherAt.id, name: 'Hack' } },
+      );
+      expect(result.errors?.[0]?.message).toMatch(/forbidden/i);
+    });
+  });
+
+  // ─── myDeleteActivityType ─────────────────────────────────────────────────────
+
+  describe('myDeleteActivityType', () => {
+    it('deletes an activity type and returns true', async () => {
+      const { id: userId } = await seedUser(db, 'delete-at@example.com');
+      const at = await seedActivityType(db, userId);
+
+      const result = await gql(testSchema, db, userId,
+        'mutation($id: ID!) { myDeleteActivityType(id: $id) }',
+        { id: at.id },
+      );
+      expect(result.errors).toBeUndefined();
+      expect(result.data?.myDeleteActivityType).toBe(true);
+    });
+
+    it('throws when activity type not found', async () => {
+      const { id: userId } = await seedUser(db, 'delete-at-notfound@example.com');
+      const result = await gql(testSchema, db, userId,
+        'mutation { myDeleteActivityType(id: "00000000-0000-0000-0000-000000000000") }',
+      );
+      expect(result.errors?.[0]?.message).toMatch(/not found/i);
+    });
+
+    it('throws Forbidden when activity type belongs to another user', async () => {
+      const { id: userId } = await seedUser(db, 'delete-at-forbidden@example.com');
+      const { id: otherId } = await seedUser(db, 'delete-at-other@example.com');
+      const otherAt = await seedActivityType(db, otherId);
+
+      const result = await gql(testSchema, db, userId,
+        'mutation($id: ID!) { myDeleteActivityType(id: $id) }',
+        { id: otherAt.id },
+      );
+      expect(result.errors?.[0]?.message).toMatch(/forbidden/i);
+    });
+  });
+});

--- a/packages/server/src/schema/resolvers/resolvers.todos.integration.test.ts
+++ b/packages/server/src/schema/resolvers/resolvers.todos.integration.test.ts
@@ -38,7 +38,12 @@ describe('todo resolvers', () => {
       const otherList = await seedTodoList(db, otherId, otherAt.id);
       await seedTodo(db, otherId, otherList.id, { title: 'Theirs' });
 
-      const result = await gql(testSchema, db, userId, 'query { myTodos { title } }');
+      const result = await gql(
+        testSchema,
+        db,
+        userId,
+        'query { myTodos { title } }',
+      );
       expect(result.errors).toBeUndefined();
       const items = result.data?.myTodos as Array<{ title: string }>;
       expect(items.every((i) => i.title !== 'Theirs')).toBe(true);
@@ -53,7 +58,9 @@ describe('todo resolvers', () => {
       await seedTodo(db, userId, list2.id, { title: 'In list 2' });
 
       const result = await gql(
-        testSchema, db, userId,
+        testSchema,
+        db,
+        userId,
         'query($id: ID) { myTodos(listId: $id) { title } }',
         { id: list1.id },
       );
@@ -67,10 +74,18 @@ describe('todo resolvers', () => {
       const { id: userId } = await seedUser(db, 'todos-completed@example.com');
       const at = await seedActivityType(db, userId);
       const list = await seedTodoList(db, userId, at.id);
-      await seedTodo(db, userId, list.id, { title: 'Done', completedAt: new Date() });
+      await seedTodo(db, userId, list.id, {
+        title: 'Done',
+        completedAt: new Date(),
+      });
       await seedTodo(db, userId, list.id, { title: 'Pending' });
 
-      const result = await gql(testSchema, db, userId, 'query { myTodos(completed: true) { title } }');
+      const result = await gql(
+        testSchema,
+        db,
+        userId,
+        'query { myTodos(completed: true) { title } }',
+      );
       expect(result.errors).toBeUndefined();
       const items = result.data?.myTodos as Array<{ title: string }>;
       expect(items.every((i) => i.title === 'Done')).toBe(true);
@@ -84,23 +99,33 @@ describe('todo resolvers', () => {
       await seedTodo(db, userId, list.id, { title: 'High', priority: 10 });
 
       const result = await gql(
-        testSchema, db, userId,
+        testSchema,
+        db,
+        userId,
         'query($o: TodoOrderBy) { myTodos(orderBy: $o) { title priority } }',
         { o: { priority: { direction: 'asc', priority: 1 } } },
       );
       expect(result.errors).toBeUndefined();
-      const items = result.data?.myTodos as Array<{ title: string; priority: number }>;
+      const items = result.data?.myTodos as Array<{
+        title: string;
+        priority: number;
+      }>;
       expect(items[0]?.priority).toBeLessThanOrEqual(items[1]?.priority ?? 999);
     });
 
     it('falls back to default order when orderBy has no entries', async () => {
-      const { id: userId } = await seedUser(db, 'todos-orderby-empty@example.com');
+      const { id: userId } = await seedUser(
+        db,
+        'todos-orderby-empty@example.com',
+      );
       const at = await seedActivityType(db, userId);
       const list = await seedTodoList(db, userId, at.id);
       await seedTodo(db, userId, list.id, { title: 'Todo' });
 
       const result = await gql(
-        testSchema, db, userId,
+        testSchema,
+        db,
+        userId,
         'query($o: TodoOrderBy) { myTodos(orderBy: $o) { id } }',
         { o: {} },
       );
@@ -111,10 +136,18 @@ describe('todo resolvers', () => {
       const { id: userId } = await seedUser(db, 'todos-incomplete@example.com');
       const at = await seedActivityType(db, userId);
       const list = await seedTodoList(db, userId, at.id);
-      await seedTodo(db, userId, list.id, { title: 'Done', completedAt: new Date() });
+      await seedTodo(db, userId, list.id, {
+        title: 'Done',
+        completedAt: new Date(),
+      });
       await seedTodo(db, userId, list.id, { title: 'Pending' });
 
-      const result = await gql(testSchema, db, userId, 'query { myTodos(completed: false) { title } }');
+      const result = await gql(
+        testSchema,
+        db,
+        userId,
+        'query { myTodos(completed: false) { title } }',
+      );
       expect(result.errors).toBeUndefined();
       const items = result.data?.myTodos as Array<{ title: string }>;
       expect(items.every((i) => i.title === 'Pending')).toBe(true);
@@ -125,23 +158,42 @@ describe('todo resolvers', () => {
 
   describe('myCreateTodo', () => {
     it('throws when list not found', async () => {
-      const { id: userId } = await seedUser(db, 'create-todo-nlist@example.com');
+      const { id: userId } = await seedUser(
+        db,
+        'create-todo-nlist@example.com',
+      );
       const result = await gql(
-        testSchema, db, userId,
+        testSchema,
+        db,
+        userId,
         'mutation($input: CreateTodoArgs!) { myCreateTodo(input: $input) { id } }',
-        { input: { listId: '00000000-0000-0000-0000-000000000000', title: 'X', estimatedLength: 30 } },
+        {
+          input: {
+            listId: '00000000-0000-0000-0000-000000000000',
+            title: 'X',
+            estimatedLength: 30,
+          },
+        },
       );
       expect(result.errors?.[0]?.message).toMatch(/not found/i);
     });
 
     it('throws Forbidden when list belongs to another user', async () => {
-      const { id: userId } = await seedUser(db, 'create-todo-forbidden@example.com');
-      const { id: otherId } = await seedUser(db, 'create-todo-other@example.com');
+      const { id: userId } = await seedUser(
+        db,
+        'create-todo-forbidden@example.com',
+      );
+      const { id: otherId } = await seedUser(
+        db,
+        'create-todo-other@example.com',
+      );
       const otherAt = await seedActivityType(db, otherId);
       const otherList = await seedTodoList(db, otherId, otherAt.id);
 
       const result = await gql(
-        testSchema, db, userId,
+        testSchema,
+        db,
+        userId,
         'mutation($input: CreateTodoArgs!) { myCreateTodo(input: $input) { id } }',
         { input: { listId: otherList.id, title: 'Hack', estimatedLength: 30 } },
       );
@@ -149,17 +201,32 @@ describe('todo resolvers', () => {
     });
 
     it('creates a todo with optional dueAt and scheduledAt', async () => {
-      const { id: userId } = await seedUser(db, 'create-todo-dates@example.com');
+      const { id: userId } = await seedUser(
+        db,
+        'create-todo-dates@example.com',
+      );
       const at = await seedActivityType(db, userId);
       const list = await seedTodoList(db, userId, at.id);
 
       const result = await gql(
-        testSchema, db, userId,
+        testSchema,
+        db,
+        userId,
         'mutation($input: CreateTodoArgs!) { myCreateTodo(input: $input) { id title dueAt } }',
-        { input: { listId: list.id, title: 'With dates', estimatedLength: 60, dueAt: '2025-12-31T00:00:00' } },
+        {
+          input: {
+            listId: list.id,
+            title: 'With dates',
+            estimatedLength: 60,
+            dueAt: '2025-12-31T00:00:00',
+          },
+        },
       );
       expect(result.errors).toBeUndefined();
-      const todo = result.data?.myCreateTodo as { title: string; dueAt: string };
+      const todo = result.data?.myCreateTodo as {
+        title: string;
+        dueAt: string;
+      };
       expect(todo.title).toBe('With dates');
       expect(todo.dueAt).not.toBeNull();
     });
@@ -169,31 +236,47 @@ describe('todo resolvers', () => {
 
   describe('myUpdateTodo', () => {
     it('updates title and priority', async () => {
-      const { id: userId } = await seedUser(db, 'update-todo-basic@example.com');
+      const { id: userId } = await seedUser(
+        db,
+        'update-todo-basic@example.com',
+      );
       const at = await seedActivityType(db, userId);
       const list = await seedTodoList(db, userId, at.id);
-      const todo = await seedTodo(db, userId, list.id, { title: 'Old', priority: 1 });
+      const todo = await seedTodo(db, userId, list.id, {
+        title: 'Old',
+        priority: 1,
+      });
 
       const result = await gql(
-        testSchema, db, userId,
+        testSchema,
+        db,
+        userId,
         'mutation($input: UpdateTodoArgs!) { myUpdateTodo(input: $input) { id title priority } }',
         { input: { id: todo.id, title: 'New', priority: 5 } },
       );
       expect(result.errors).toBeUndefined();
-      const updated = result.data?.myUpdateTodo as { title: string; priority: number };
+      const updated = result.data?.myUpdateTodo as {
+        title: string;
+        priority: number;
+      };
       expect(updated.title).toBe('New');
       expect(updated.priority).toBe(5);
     });
 
     it('moves todo to a different list', async () => {
-      const { id: userId } = await seedUser(db, 'update-todo-movelist@example.com');
+      const { id: userId } = await seedUser(
+        db,
+        'update-todo-movelist@example.com',
+      );
       const at = await seedActivityType(db, userId);
       const list1 = await seedTodoList(db, userId, at.id);
       const list2 = await seedTodoList(db, userId, at.id);
       const todo = await seedTodo(db, userId, list1.id);
 
       const result = await gql(
-        testSchema, db, userId,
+        testSchema,
+        db,
+        userId,
         'mutation($input: UpdateTodoArgs!) { myUpdateTodo(input: $input) { id } }',
         { input: { id: todo.id, listId: list2.id } },
       );
@@ -201,24 +284,38 @@ describe('todo resolvers', () => {
     });
 
     it('clears dueAt when set to null', async () => {
-      const { id: userId } = await seedUser(db, 'update-todo-nulldue@example.com');
+      const { id: userId } = await seedUser(
+        db,
+        'update-todo-nulldue@example.com',
+      );
       const at = await seedActivityType(db, userId);
       const list = await seedTodoList(db, userId, at.id);
-      const todo = await seedTodo(db, userId, list.id, { dueAt: new Date('2025-12-31') });
+      const todo = await seedTodo(db, userId, list.id, {
+        dueAt: new Date('2025-12-31'),
+      });
 
       const result = await gql(
-        testSchema, db, userId,
+        testSchema,
+        db,
+        userId,
         'mutation($input: UpdateTodoArgs!) { myUpdateTodo(input: $input) { id dueAt } }',
         { input: { id: todo.id, dueAt: null } },
       );
       expect(result.errors).toBeUndefined();
-      expect((result.data?.myUpdateTodo as { dueAt: unknown }).dueAt).toBeNull();
+      expect(
+        (result.data?.myUpdateTodo as { dueAt: unknown }).dueAt,
+      ).toBeNull();
     });
 
     it('throws when todo not found', async () => {
-      const { id: userId } = await seedUser(db, 'update-todo-notfound@example.com');
+      const { id: userId } = await seedUser(
+        db,
+        'update-todo-notfound@example.com',
+      );
       const result = await gql(
-        testSchema, db, userId,
+        testSchema,
+        db,
+        userId,
         'mutation($input: UpdateTodoArgs!) { myUpdateTodo(input: $input) { id } }',
         { input: { id: '00000000-0000-0000-0000-000000000000', title: 'X' } },
       );
@@ -226,14 +323,22 @@ describe('todo resolvers', () => {
     });
 
     it('throws Forbidden when todo belongs to another user', async () => {
-      const { id: userId } = await seedUser(db, 'update-todo-forbidden@example.com');
-      const { id: otherId } = await seedUser(db, 'update-todo-other@example.com');
+      const { id: userId } = await seedUser(
+        db,
+        'update-todo-forbidden@example.com',
+      );
+      const { id: otherId } = await seedUser(
+        db,
+        'update-todo-other@example.com',
+      );
       const otherAt = await seedActivityType(db, otherId);
       const otherList = await seedTodoList(db, otherId, otherAt.id);
       const otherTodo = await seedTodo(db, otherId, otherList.id);
 
       const result = await gql(
-        testSchema, db, userId,
+        testSchema,
+        db,
+        userId,
         'mutation($input: UpdateTodoArgs!) { myUpdateTodo(input: $input) { id } }',
         { input: { id: otherTodo.id, title: 'Hack' } },
       );
@@ -241,22 +346,38 @@ describe('todo resolvers', () => {
     });
 
     it('throws when target list not found during move', async () => {
-      const { id: userId } = await seedUser(db, 'update-todo-movebadlist@example.com');
+      const { id: userId } = await seedUser(
+        db,
+        'update-todo-movebadlist@example.com',
+      );
       const at = await seedActivityType(db, userId);
       const list = await seedTodoList(db, userId, at.id);
       const todo = await seedTodo(db, userId, list.id);
 
       const result = await gql(
-        testSchema, db, userId,
+        testSchema,
+        db,
+        userId,
         'mutation($input: UpdateTodoArgs!) { myUpdateTodo(input: $input) { id } }',
-        { input: { id: todo.id, listId: '00000000-0000-0000-0000-000000000000' } },
+        {
+          input: {
+            id: todo.id,
+            listId: '00000000-0000-0000-0000-000000000000',
+          },
+        },
       );
       expect(result.errors?.[0]?.message).toMatch(/not found/i);
     });
 
     it("throws Forbidden when moving to another user's list", async () => {
-      const { id: userId } = await seedUser(db, 'update-todo-moveforbidden@example.com');
-      const { id: otherId } = await seedUser(db, 'update-todo-moveother@example.com');
+      const { id: userId } = await seedUser(
+        db,
+        'update-todo-moveforbidden@example.com',
+      );
+      const { id: otherId } = await seedUser(
+        db,
+        'update-todo-moveother@example.com',
+      );
       const at = await seedActivityType(db, userId);
       const list = await seedTodoList(db, userId, at.id);
       const todo = await seedTodo(db, userId, list.id);
@@ -264,7 +385,9 @@ describe('todo resolvers', () => {
       const otherList = await seedTodoList(db, otherId, otherAt.id);
 
       const result = await gql(
-        testSchema, db, userId,
+        testSchema,
+        db,
+        userId,
         'mutation($input: UpdateTodoArgs!) { myUpdateTodo(input: $input) { id } }',
         { input: { id: todo.id, listId: otherList.id } },
       );
@@ -276,14 +399,19 @@ describe('todo resolvers', () => {
 
   describe('myCompleteTodo', () => {
     it('accepts an explicit completedAt timestamp', async () => {
-      const { id: userId } = await seedUser(db, 'complete-todo-explicit@example.com');
+      const { id: userId } = await seedUser(
+        db,
+        'complete-todo-explicit@example.com',
+      );
       const at = await seedActivityType(db, userId);
       const list = await seedTodoList(db, userId, at.id);
       const todo = await seedTodo(db, userId, list.id);
 
       const ts = '2025-06-01T10:00:00.000Z';
       const result = await gql(
-        testSchema, db, userId,
+        testSchema,
+        db,
+        userId,
         'mutation($id: ID!, $at: String) { myCompleteTodo(id: $id, completedAt: $at) { completedAt } }',
         { id: todo.id, at: ts },
       );
@@ -293,23 +421,36 @@ describe('todo resolvers', () => {
     });
 
     it('throws when todo not found', async () => {
-      const { id: userId } = await seedUser(db, 'complete-todo-notfound@example.com');
+      const { id: userId } = await seedUser(
+        db,
+        'complete-todo-notfound@example.com',
+      );
       const result = await gql(
-        testSchema, db, userId,
+        testSchema,
+        db,
+        userId,
         'mutation { myCompleteTodo(id: "00000000-0000-0000-0000-000000000000") { id } }',
       );
       expect(result.errors?.[0]?.message).toMatch(/not found/i);
     });
 
     it('throws Forbidden when todo belongs to another user', async () => {
-      const { id: userId } = await seedUser(db, 'complete-todo-forbidden@example.com');
-      const { id: otherId } = await seedUser(db, 'complete-todo-other@example.com');
+      const { id: userId } = await seedUser(
+        db,
+        'complete-todo-forbidden@example.com',
+      );
+      const { id: otherId } = await seedUser(
+        db,
+        'complete-todo-other@example.com',
+      );
       const otherAt = await seedActivityType(db, otherId);
       const otherList = await seedTodoList(db, otherId, otherAt.id);
       const otherTodo = await seedTodo(db, otherId, otherList.id);
 
       const result = await gql(
-        testSchema, db, userId,
+        testSchema,
+        db,
+        userId,
         'mutation($id: ID!) { myCompleteTodo(id: $id) { id } }',
         { id: otherTodo.id },
       );
@@ -327,7 +468,9 @@ describe('todo resolvers', () => {
       const todo = await seedTodo(db, userId, list.id);
 
       const result = await gql(
-        testSchema, db, userId,
+        testSchema,
+        db,
+        userId,
         'mutation($id: ID!) { myDeleteTodo(id: $id) }',
         { id: todo.id },
       );
@@ -336,23 +479,36 @@ describe('todo resolvers', () => {
     });
 
     it('throws when todo not found', async () => {
-      const { id: userId } = await seedUser(db, 'delete-todo-notfound@example.com');
+      const { id: userId } = await seedUser(
+        db,
+        'delete-todo-notfound@example.com',
+      );
       const result = await gql(
-        testSchema, db, userId,
+        testSchema,
+        db,
+        userId,
         'mutation { myDeleteTodo(id: "00000000-0000-0000-0000-000000000000") }',
       );
       expect(result.errors?.[0]?.message).toMatch(/not found/i);
     });
 
     it('throws Forbidden when todo belongs to another user', async () => {
-      const { id: userId } = await seedUser(db, 'delete-todo-forbidden@example.com');
-      const { id: otherId } = await seedUser(db, 'delete-todo-other@example.com');
+      const { id: userId } = await seedUser(
+        db,
+        'delete-todo-forbidden@example.com',
+      );
+      const { id: otherId } = await seedUser(
+        db,
+        'delete-todo-other@example.com',
+      );
       const otherAt = await seedActivityType(db, otherId);
       const otherList = await seedTodoList(db, otherId, otherAt.id);
       const otherTodo = await seedTodo(db, otherId, otherList.id);
 
       const result = await gql(
-        testSchema, db, userId,
+        testSchema,
+        db,
+        userId,
         'mutation($id: ID!) { myDeleteTodo(id: $id) }',
         { id: otherTodo.id },
       );

--- a/packages/server/src/schema/resolvers/resolvers.todos.integration.test.ts
+++ b/packages/server/src/schema/resolvers/resolvers.todos.integration.test.ts
@@ -1,0 +1,331 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+import {
+  type TestDb,
+  type TestSchema,
+  buildTestSchema,
+  createTestDb,
+  gql,
+  seedActivityType,
+  seedTodo,
+  seedTodoList,
+  seedUser,
+} from './test-helpers.ts';
+
+describe('todo resolvers', () => {
+  let db: TestDb;
+  let testSchema: TestSchema;
+
+  beforeAll(async () => {
+    db = await createTestDb();
+    testSchema = buildTestSchema(db);
+  }, 30000);
+
+  // ─── myTodos ──────────────────────────────────────────────────────────────────
+
+  describe('myTodos', () => {
+    it('throws when not authenticated', async () => {
+      const result = await gql(testSchema, db, '', 'query { myTodos { id } }');
+      expect(result.errors?.[0]?.message).toMatch(/not authenticated/i);
+    });
+
+    it("returns only the current user's todos", async () => {
+      const { id: userId } = await seedUser(db, 'todos-isolation@example.com');
+      const { id: otherId } = await seedUser(db, 'todos-other@example.com');
+      const at = await seedActivityType(db, userId);
+      const list = await seedTodoList(db, userId, at.id);
+      await seedTodo(db, userId, list.id, { title: 'Mine' });
+      const otherAt = await seedActivityType(db, otherId);
+      const otherList = await seedTodoList(db, otherId, otherAt.id);
+      await seedTodo(db, otherId, otherList.id, { title: 'Theirs' });
+
+      const result = await gql(testSchema, db, userId, 'query { myTodos { title } }');
+      expect(result.errors).toBeUndefined();
+      const items = result.data?.myTodos as Array<{ title: string }>;
+      expect(items.every((i) => i.title !== 'Theirs')).toBe(true);
+    });
+
+    it('filters by listId', async () => {
+      const { id: userId } = await seedUser(db, 'todos-listfilter@example.com');
+      const at = await seedActivityType(db, userId);
+      const list1 = await seedTodoList(db, userId, at.id);
+      const list2 = await seedTodoList(db, userId, at.id);
+      await seedTodo(db, userId, list1.id, { title: 'In list 1' });
+      await seedTodo(db, userId, list2.id, { title: 'In list 2' });
+
+      const result = await gql(
+        testSchema, db, userId,
+        'query($id: ID) { myTodos(listId: $id) { title } }',
+        { id: list1.id },
+      );
+      expect(result.errors).toBeUndefined();
+      const items = result.data?.myTodos as Array<{ title: string }>;
+      expect(items).toHaveLength(1);
+      expect(items[0]?.title).toBe('In list 1');
+    });
+
+    it('filters completed:true returns only completed todos', async () => {
+      const { id: userId } = await seedUser(db, 'todos-completed@example.com');
+      const at = await seedActivityType(db, userId);
+      const list = await seedTodoList(db, userId, at.id);
+      await seedTodo(db, userId, list.id, { title: 'Done', completedAt: new Date() });
+      await seedTodo(db, userId, list.id, { title: 'Pending' });
+
+      const result = await gql(testSchema, db, userId, 'query { myTodos(completed: true) { title } }');
+      expect(result.errors).toBeUndefined();
+      const items = result.data?.myTodos as Array<{ title: string }>;
+      expect(items.every((i) => i.title === 'Done')).toBe(true);
+    });
+
+    it('filters completed:false returns only incomplete todos', async () => {
+      const { id: userId } = await seedUser(db, 'todos-incomplete@example.com');
+      const at = await seedActivityType(db, userId);
+      const list = await seedTodoList(db, userId, at.id);
+      await seedTodo(db, userId, list.id, { title: 'Done', completedAt: new Date() });
+      await seedTodo(db, userId, list.id, { title: 'Pending' });
+
+      const result = await gql(testSchema, db, userId, 'query { myTodos(completed: false) { title } }');
+      expect(result.errors).toBeUndefined();
+      const items = result.data?.myTodos as Array<{ title: string }>;
+      expect(items.every((i) => i.title === 'Pending')).toBe(true);
+    });
+  });
+
+  // ─── myCreateTodo ─────────────────────────────────────────────────────────────
+
+  describe('myCreateTodo', () => {
+    it('throws when list not found', async () => {
+      const { id: userId } = await seedUser(db, 'create-todo-nlist@example.com');
+      const result = await gql(
+        testSchema, db, userId,
+        'mutation($input: CreateTodoArgs!) { myCreateTodo(input: $input) { id } }',
+        { input: { listId: '00000000-0000-0000-0000-000000000000', title: 'X', estimatedLength: 30 } },
+      );
+      expect(result.errors?.[0]?.message).toMatch(/not found/i);
+    });
+
+    it('throws Forbidden when list belongs to another user', async () => {
+      const { id: userId } = await seedUser(db, 'create-todo-forbidden@example.com');
+      const { id: otherId } = await seedUser(db, 'create-todo-other@example.com');
+      const otherAt = await seedActivityType(db, otherId);
+      const otherList = await seedTodoList(db, otherId, otherAt.id);
+
+      const result = await gql(
+        testSchema, db, userId,
+        'mutation($input: CreateTodoArgs!) { myCreateTodo(input: $input) { id } }',
+        { input: { listId: otherList.id, title: 'Hack', estimatedLength: 30 } },
+      );
+      expect(result.errors?.[0]?.message).toMatch(/forbidden/i);
+    });
+
+    it('creates a todo with optional dueAt and scheduledAt', async () => {
+      const { id: userId } = await seedUser(db, 'create-todo-dates@example.com');
+      const at = await seedActivityType(db, userId);
+      const list = await seedTodoList(db, userId, at.id);
+
+      const result = await gql(
+        testSchema, db, userId,
+        'mutation($input: CreateTodoArgs!) { myCreateTodo(input: $input) { id title dueAt } }',
+        { input: { listId: list.id, title: 'With dates', estimatedLength: 60, dueAt: '2025-12-31T00:00:00' } },
+      );
+      expect(result.errors).toBeUndefined();
+      const todo = result.data?.myCreateTodo as { title: string; dueAt: string };
+      expect(todo.title).toBe('With dates');
+      expect(todo.dueAt).not.toBeNull();
+    });
+  });
+
+  // ─── myUpdateTodo ─────────────────────────────────────────────────────────────
+
+  describe('myUpdateTodo', () => {
+    it('updates title and priority', async () => {
+      const { id: userId } = await seedUser(db, 'update-todo-basic@example.com');
+      const at = await seedActivityType(db, userId);
+      const list = await seedTodoList(db, userId, at.id);
+      const todo = await seedTodo(db, userId, list.id, { title: 'Old', priority: 1 });
+
+      const result = await gql(
+        testSchema, db, userId,
+        'mutation($input: UpdateTodoArgs!) { myUpdateTodo(input: $input) { id title priority } }',
+        { input: { id: todo.id, title: 'New', priority: 5 } },
+      );
+      expect(result.errors).toBeUndefined();
+      const updated = result.data?.myUpdateTodo as { title: string; priority: number };
+      expect(updated.title).toBe('New');
+      expect(updated.priority).toBe(5);
+    });
+
+    it('moves todo to a different list', async () => {
+      const { id: userId } = await seedUser(db, 'update-todo-movelist@example.com');
+      const at = await seedActivityType(db, userId);
+      const list1 = await seedTodoList(db, userId, at.id);
+      const list2 = await seedTodoList(db, userId, at.id);
+      const todo = await seedTodo(db, userId, list1.id);
+
+      const result = await gql(
+        testSchema, db, userId,
+        'mutation($input: UpdateTodoArgs!) { myUpdateTodo(input: $input) { id } }',
+        { input: { id: todo.id, listId: list2.id } },
+      );
+      expect(result.errors).toBeUndefined();
+    });
+
+    it('clears dueAt when set to null', async () => {
+      const { id: userId } = await seedUser(db, 'update-todo-nulldue@example.com');
+      const at = await seedActivityType(db, userId);
+      const list = await seedTodoList(db, userId, at.id);
+      const todo = await seedTodo(db, userId, list.id, { dueAt: new Date('2025-12-31') });
+
+      const result = await gql(
+        testSchema, db, userId,
+        'mutation($input: UpdateTodoArgs!) { myUpdateTodo(input: $input) { id dueAt } }',
+        { input: { id: todo.id, dueAt: null } },
+      );
+      expect(result.errors).toBeUndefined();
+      expect((result.data?.myUpdateTodo as { dueAt: unknown }).dueAt).toBeNull();
+    });
+
+    it('throws when todo not found', async () => {
+      const { id: userId } = await seedUser(db, 'update-todo-notfound@example.com');
+      const result = await gql(
+        testSchema, db, userId,
+        'mutation($input: UpdateTodoArgs!) { myUpdateTodo(input: $input) { id } }',
+        { input: { id: '00000000-0000-0000-0000-000000000000', title: 'X' } },
+      );
+      expect(result.errors?.[0]?.message).toMatch(/not found/i);
+    });
+
+    it('throws Forbidden when todo belongs to another user', async () => {
+      const { id: userId } = await seedUser(db, 'update-todo-forbidden@example.com');
+      const { id: otherId } = await seedUser(db, 'update-todo-other@example.com');
+      const otherAt = await seedActivityType(db, otherId);
+      const otherList = await seedTodoList(db, otherId, otherAt.id);
+      const otherTodo = await seedTodo(db, otherId, otherList.id);
+
+      const result = await gql(
+        testSchema, db, userId,
+        'mutation($input: UpdateTodoArgs!) { myUpdateTodo(input: $input) { id } }',
+        { input: { id: otherTodo.id, title: 'Hack' } },
+      );
+      expect(result.errors?.[0]?.message).toMatch(/forbidden/i);
+    });
+
+    it('throws when target list not found during move', async () => {
+      const { id: userId } = await seedUser(db, 'update-todo-movebadlist@example.com');
+      const at = await seedActivityType(db, userId);
+      const list = await seedTodoList(db, userId, at.id);
+      const todo = await seedTodo(db, userId, list.id);
+
+      const result = await gql(
+        testSchema, db, userId,
+        'mutation($input: UpdateTodoArgs!) { myUpdateTodo(input: $input) { id } }',
+        { input: { id: todo.id, listId: '00000000-0000-0000-0000-000000000000' } },
+      );
+      expect(result.errors?.[0]?.message).toMatch(/not found/i);
+    });
+
+    it("throws Forbidden when moving to another user's list", async () => {
+      const { id: userId } = await seedUser(db, 'update-todo-moveforbidden@example.com');
+      const { id: otherId } = await seedUser(db, 'update-todo-moveother@example.com');
+      const at = await seedActivityType(db, userId);
+      const list = await seedTodoList(db, userId, at.id);
+      const todo = await seedTodo(db, userId, list.id);
+      const otherAt = await seedActivityType(db, otherId);
+      const otherList = await seedTodoList(db, otherId, otherAt.id);
+
+      const result = await gql(
+        testSchema, db, userId,
+        'mutation($input: UpdateTodoArgs!) { myUpdateTodo(input: $input) { id } }',
+        { input: { id: todo.id, listId: otherList.id } },
+      );
+      expect(result.errors?.[0]?.message).toMatch(/forbidden/i);
+    });
+  });
+
+  // ─── myCompleteTodo ───────────────────────────────────────────────────────────
+
+  describe('myCompleteTodo', () => {
+    it('accepts an explicit completedAt timestamp', async () => {
+      const { id: userId } = await seedUser(db, 'complete-todo-explicit@example.com');
+      const at = await seedActivityType(db, userId);
+      const list = await seedTodoList(db, userId, at.id);
+      const todo = await seedTodo(db, userId, list.id);
+
+      const ts = '2025-06-01T10:00:00.000Z';
+      const result = await gql(
+        testSchema, db, userId,
+        'mutation($id: ID!, $at: String) { myCompleteTodo(id: $id, completedAt: $at) { completedAt } }',
+        { id: todo.id, at: ts },
+      );
+      expect(result.errors).toBeUndefined();
+      const completed = result.data?.myCompleteTodo as { completedAt: string };
+      expect(new Date(completed.completedAt).toISOString()).toBe(ts);
+    });
+
+    it('throws when todo not found', async () => {
+      const { id: userId } = await seedUser(db, 'complete-todo-notfound@example.com');
+      const result = await gql(
+        testSchema, db, userId,
+        'mutation { myCompleteTodo(id: "00000000-0000-0000-0000-000000000000") { id } }',
+      );
+      expect(result.errors?.[0]?.message).toMatch(/not found/i);
+    });
+
+    it('throws Forbidden when todo belongs to another user', async () => {
+      const { id: userId } = await seedUser(db, 'complete-todo-forbidden@example.com');
+      const { id: otherId } = await seedUser(db, 'complete-todo-other@example.com');
+      const otherAt = await seedActivityType(db, otherId);
+      const otherList = await seedTodoList(db, otherId, otherAt.id);
+      const otherTodo = await seedTodo(db, otherId, otherList.id);
+
+      const result = await gql(
+        testSchema, db, userId,
+        'mutation($id: ID!) { myCompleteTodo(id: $id) { id } }',
+        { id: otherTodo.id },
+      );
+      expect(result.errors?.[0]?.message).toMatch(/forbidden/i);
+    });
+  });
+
+  // ─── myDeleteTodo ─────────────────────────────────────────────────────────────
+
+  describe('myDeleteTodo', () => {
+    it('deletes a todo and returns true', async () => {
+      const { id: userId } = await seedUser(db, 'delete-todo@example.com');
+      const at = await seedActivityType(db, userId);
+      const list = await seedTodoList(db, userId, at.id);
+      const todo = await seedTodo(db, userId, list.id);
+
+      const result = await gql(
+        testSchema, db, userId,
+        'mutation($id: ID!) { myDeleteTodo(id: $id) }',
+        { id: todo.id },
+      );
+      expect(result.errors).toBeUndefined();
+      expect(result.data?.myDeleteTodo).toBe(true);
+    });
+
+    it('throws when todo not found', async () => {
+      const { id: userId } = await seedUser(db, 'delete-todo-notfound@example.com');
+      const result = await gql(
+        testSchema, db, userId,
+        'mutation { myDeleteTodo(id: "00000000-0000-0000-0000-000000000000") }',
+      );
+      expect(result.errors?.[0]?.message).toMatch(/not found/i);
+    });
+
+    it('throws Forbidden when todo belongs to another user', async () => {
+      const { id: userId } = await seedUser(db, 'delete-todo-forbidden@example.com');
+      const { id: otherId } = await seedUser(db, 'delete-todo-other@example.com');
+      const otherAt = await seedActivityType(db, otherId);
+      const otherList = await seedTodoList(db, otherId, otherAt.id);
+      const otherTodo = await seedTodo(db, otherId, otherList.id);
+
+      const result = await gql(
+        testSchema, db, userId,
+        'mutation($id: ID!) { myDeleteTodo(id: $id) }',
+        { id: otherTodo.id },
+      );
+      expect(result.errors?.[0]?.message).toMatch(/forbidden/i);
+    });
+  });
+});

--- a/packages/server/src/schema/resolvers/resolvers.todos.integration.test.ts
+++ b/packages/server/src/schema/resolvers/resolvers.todos.integration.test.ts
@@ -76,6 +76,37 @@ describe('todo resolvers', () => {
       expect(items.every((i) => i.title === 'Done')).toBe(true);
     });
 
+    it('accepts a custom orderBy argument', async () => {
+      const { id: userId } = await seedUser(db, 'todos-orderby@example.com');
+      const at = await seedActivityType(db, userId);
+      const list = await seedTodoList(db, userId, at.id);
+      await seedTodo(db, userId, list.id, { title: 'Low', priority: 1 });
+      await seedTodo(db, userId, list.id, { title: 'High', priority: 10 });
+
+      const result = await gql(
+        testSchema, db, userId,
+        'query($o: TodoOrderBy) { myTodos(orderBy: $o) { title priority } }',
+        { o: { priority: { direction: 'asc', priority: 1 } } },
+      );
+      expect(result.errors).toBeUndefined();
+      const items = result.data?.myTodos as Array<{ title: string; priority: number }>;
+      expect(items[0]?.priority).toBeLessThanOrEqual(items[1]?.priority ?? 999);
+    });
+
+    it('falls back to default order when orderBy has no entries', async () => {
+      const { id: userId } = await seedUser(db, 'todos-orderby-empty@example.com');
+      const at = await seedActivityType(db, userId);
+      const list = await seedTodoList(db, userId, at.id);
+      await seedTodo(db, userId, list.id, { title: 'Todo' });
+
+      const result = await gql(
+        testSchema, db, userId,
+        'query($o: TodoOrderBy) { myTodos(orderBy: $o) { id } }',
+        { o: {} },
+      );
+      expect(result.errors).toBeUndefined();
+    });
+
     it('filters completed:false returns only incomplete todos', async () => {
       const { id: userId } = await seedUser(db, 'todos-incomplete@example.com');
       const at = await seedActivityType(db, userId);

--- a/packages/server/src/schema/resolvers/test-helpers.ts
+++ b/packages/server/src/schema/resolvers/test-helpers.ts
@@ -1,0 +1,125 @@
+/**
+ * Shared test helpers for resolver integration tests.
+ * Each test file gets fresh PGLite instances — no shared state between files.
+ */
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { relations } from '@auto-cal/db/relations';
+import * as schema from '@auto-cal/db/schema';
+import { activityTypes, habits, timeBlocks, todoLists, todos, users } from '@auto-cal/db/schema';
+import { PGlite } from '@electric-sql/pglite';
+import { buildSchema } from '@vantreeseba/drizzle-graphql';
+import { drizzle } from 'drizzle-orm/pglite';
+import { migrate } from 'drizzle-orm/pglite/migrator';
+import { graphql } from 'graphql';
+import { createLoaders } from '../../context.ts';
+import { applyCustomResolvers } from './index.ts';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const migrationsFolder = resolve(__dirname, '../../../../../packages/db/drizzle');
+
+export async function createTestDb() {
+  const client = new PGlite('memory://');
+  await client.waitReady;
+  // @ts-expect-error drizzle-orm 1.0-beta removed `schema` from config types but it remains valid at runtime
+  const db = drizzle({ client, schema, relations });
+  await migrate(db, { migrationsFolder });
+  return db;
+}
+
+export type TestDb = Awaited<ReturnType<typeof createTestDb>>;
+
+export function buildTestSchema(db: TestDb) {
+  const { schema: drizzleSchema } = buildSchema(db, {
+    prefixes: { insert: 'create', update: 'update', delete: 'delete' },
+    suffixes: { list: 's', single: '' },
+    singularTypes: true,
+  });
+  return applyCustomResolvers(drizzleSchema);
+}
+
+export type TestSchema = ReturnType<typeof buildTestSchema>;
+
+export async function gql(
+  testSchema: TestSchema,
+  db: TestDb,
+  userId: string,
+  source: string,
+  variableValues?: Record<string, unknown>,
+) {
+  return graphql({
+    schema: testSchema,
+    source,
+    variableValues,
+    contextValue: { db, userId, loaders: createLoaders(db) },
+  });
+}
+
+// ─── Seed helpers ─────────────────────────────────────────────────────────────
+
+export async function seedUser(db: TestDb, email = 'test@example.com') {
+  const [user] = await db.insert(users).values({ email }).returning();
+  if (!user) throw new Error('Failed to create user');
+  return user;
+}
+
+export async function seedActivityType(db: TestDb, userId: string, name = 'Work') {
+  const [at] = await db
+    .insert(activityTypes)
+    .values({ userId, name, color: '#6366f1' })
+    .returning();
+  if (!at) throw new Error('Failed to create activity type');
+  return at;
+}
+
+export async function seedTimeBlock(db: TestDb, userId: string, activityTypeId: string) {
+  const [tb] = await db
+    .insert(timeBlocks)
+    .values({
+      userId,
+      activityTypeId,
+      daysOfWeek: [0, 1, 2, 3, 4, 5, 6],
+      startTime: '09:00',
+      endTime: '17:00',
+      priority: 0,
+    })
+    .returning();
+  if (!tb) throw new Error('Failed to create time block');
+  return tb;
+}
+
+export async function seedTodoList(db: TestDb, userId: string, activityTypeId: string) {
+  const [list] = await db
+    .insert(todoLists)
+    .values({ userId, name: 'Test List', activityTypeId })
+    .returning();
+  if (!list) throw new Error('Failed to create todo list');
+  return list;
+}
+
+export async function seedTodo(db: TestDb, userId: string, listId: string, overrides: Partial<typeof todos.$inferInsert> = {}) {
+  const [todo] = await db
+    .insert(todos)
+    .values({ userId, listId, title: 'Test todo', estimatedLength: 30, priority: 1, ...overrides })
+    .returning();
+  if (!todo) throw new Error('Failed to create todo');
+  return todo;
+}
+
+export async function seedHabit(db: TestDb, userId: string, activityTypeId: string, overrides: Partial<typeof habits.$inferInsert> = {}) {
+  const [habit] = await db
+    .insert(habits)
+    .values({
+      userId,
+      activityTypeId,
+      title: 'Test habit',
+      estimatedLength: 30,
+      frequencyCount: 3,
+      frequencyUnit: 'week',
+      priority: 1,
+      ...overrides,
+    })
+    .returning();
+  if (!habit) throw new Error('Failed to create habit');
+  return habit;
+}

--- a/packages/server/src/schema/resolvers/test-helpers.ts
+++ b/packages/server/src/schema/resolvers/test-helpers.ts
@@ -6,7 +6,14 @@ import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { relations } from '@auto-cal/db/relations';
 import * as schema from '@auto-cal/db/schema';
-import { activityTypes, habits, timeBlocks, todoLists, todos, users } from '@auto-cal/db/schema';
+import {
+  activityTypes,
+  habits,
+  timeBlocks,
+  todoLists,
+  todos,
+  users,
+} from '@auto-cal/db/schema';
 import { PGlite } from '@electric-sql/pglite';
 import { buildSchema } from '@vantreeseba/drizzle-graphql';
 import { drizzle } from 'drizzle-orm/pglite';
@@ -16,7 +23,10 @@ import { createLoaders } from '../../context.ts';
 import { applyCustomResolvers } from './index.ts';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const migrationsFolder = resolve(__dirname, '../../../../../packages/db/drizzle');
+const migrationsFolder = resolve(
+  __dirname,
+  '../../../../../packages/db/drizzle',
+);
 
 export async function createTestDb() {
   const client = new PGlite('memory://');
@@ -63,7 +73,11 @@ export async function seedUser(db: TestDb, email = 'test@example.com') {
   return user;
 }
 
-export async function seedActivityType(db: TestDb, userId: string, name = 'Work') {
+export async function seedActivityType(
+  db: TestDb,
+  userId: string,
+  name = 'Work',
+) {
   const [at] = await db
     .insert(activityTypes)
     .values({ userId, name, color: '#6366f1' })
@@ -72,7 +86,11 @@ export async function seedActivityType(db: TestDb, userId: string, name = 'Work'
   return at;
 }
 
-export async function seedTimeBlock(db: TestDb, userId: string, activityTypeId: string) {
+export async function seedTimeBlock(
+  db: TestDb,
+  userId: string,
+  activityTypeId: string,
+) {
   const [tb] = await db
     .insert(timeBlocks)
     .values({
@@ -88,7 +106,11 @@ export async function seedTimeBlock(db: TestDb, userId: string, activityTypeId: 
   return tb;
 }
 
-export async function seedTodoList(db: TestDb, userId: string, activityTypeId: string) {
+export async function seedTodoList(
+  db: TestDb,
+  userId: string,
+  activityTypeId: string,
+) {
   const [list] = await db
     .insert(todoLists)
     .values({ userId, name: 'Test List', activityTypeId })
@@ -97,16 +119,33 @@ export async function seedTodoList(db: TestDb, userId: string, activityTypeId: s
   return list;
 }
 
-export async function seedTodo(db: TestDb, userId: string, listId: string, overrides: Partial<typeof todos.$inferInsert> = {}) {
+export async function seedTodo(
+  db: TestDb,
+  userId: string,
+  listId: string,
+  overrides: Partial<typeof todos.$inferInsert> = {},
+) {
   const [todo] = await db
     .insert(todos)
-    .values({ userId, listId, title: 'Test todo', estimatedLength: 30, priority: 1, ...overrides })
+    .values({
+      userId,
+      listId,
+      title: 'Test todo',
+      estimatedLength: 30,
+      priority: 1,
+      ...overrides,
+    })
     .returning();
   if (!todo) throw new Error('Failed to create todo');
   return todo;
 }
 
-export async function seedHabit(db: TestDb, userId: string, activityTypeId: string, overrides: Partial<typeof habits.$inferInsert> = {}) {
+export async function seedHabit(
+  db: TestDb,
+  userId: string,
+  activityTypeId: string,
+  overrides: Partial<typeof habits.$inferInsert> = {},
+) {
   const [habit] = await db
     .insert(habits)
     .values({

--- a/packages/server/src/services/scheduler-writeback.test.ts
+++ b/packages/server/src/services/scheduler-writeback.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Integration tests for runSchedulerWriteback using PGLite in-memory.
+ * Tests are exercised through the resolver layer (myReschedule) so the full
+ * stack runs, but also call the function directly for targeted branch coverage.
+ */
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { relations } from '@auto-cal/db/relations';
+import * as schema from '@auto-cal/db/schema';
+import {
+  activityTypes,
+  habitCompletions,
+  habits,
+  timeBlocks,
+  todoLists,
+  todos,
+  users,
+} from '@auto-cal/db/schema';
+import { PGlite } from '@electric-sql/pglite';
+import { drizzle } from 'drizzle-orm/pglite';
+import { migrate } from 'drizzle-orm/pglite/migrator';
+import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { runSchedulerWriteback } from './scheduler-writeback.ts';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const migrationsFolder = resolve(__dirname, '../../../../packages/db/drizzle');
+
+type TestDb = Awaited<ReturnType<typeof createDb>>;
+
+async function createDb() {
+  const client = new PGlite('memory://');
+  await client.waitReady;
+  // @ts-expect-error drizzle-orm 1.0-beta removed `schema` from config types but it remains valid at runtime
+  const db = drizzle({ client, schema, relations });
+  await migrate(db, { migrationsFolder });
+  return db;
+}
+
+describe('runSchedulerWriteback', () => {
+  let db: TestDb;
+  let userId: string;
+  let activityTypeId: string;
+
+  beforeAll(async () => {
+    db = await createDb();
+  }, 30000);
+
+  beforeEach(async () => {
+    const [user] = await db.insert(users).values({ email: `writeback-${Date.now()}@example.com` }).returning();
+    if (!user) throw new Error('seed failed');
+    userId = user.id;
+
+    const [at] = await db.insert(activityTypes).values({ userId, name: 'Work', color: '#6366f1' }).returning();
+    if (!at) throw new Error('seed failed');
+    activityTypeId = at.id;
+  });
+
+  it('runs without error when user has no data', async () => {
+    await expect(runSchedulerWriteback(db, userId)).resolves.toBeUndefined();
+  });
+
+  it('sets scheduledAt on todos that fit in a time block', async () => {
+    await db.insert(timeBlocks).values({
+      userId, activityTypeId,
+      daysOfWeek: [0, 1, 2, 3, 4, 5, 6],
+      startTime: '09:00', endTime: '17:00', priority: 0,
+    });
+    const [list] = await db.insert(todoLists).values({ userId, name: 'Work', activityTypeId }).returning();
+    const [todo] = await db.insert(todos).values({ userId, listId: list!.id, title: 'Task', estimatedLength: 30 }).returning();
+
+    await runSchedulerWriteback(db, userId);
+
+    const [updated] = await db.query.todos.findMany({ where: { id: todo!.id } });
+    expect(updated?.scheduledAt).not.toBeNull();
+  });
+
+  it('sets scheduledAt to null for todos with no matching time block', async () => {
+    // Todo has Work activity type but there is no time block for it
+    const [list] = await db.insert(todoLists).values({ userId, name: 'Work', activityTypeId }).returning();
+    const [todo] = await db.insert(todos).values({ userId, listId: list!.id, title: 'Unplaceable', estimatedLength: 30 }).returning();
+
+    await runSchedulerWriteback(db, userId);
+
+    const [updated] = await db.query.todos.findMany({ where: { id: todo!.id } });
+    expect(updated?.scheduledAt).toBeNull();
+  });
+
+  it('creates tentative habit completions for habits with a deficit', async () => {
+    await db.insert(timeBlocks).values({
+      userId, activityTypeId,
+      daysOfWeek: [0, 1, 2, 3, 4, 5, 6],
+      startTime: '09:00', endTime: '17:00', priority: 0,
+    });
+    const [habit] = await db.insert(habits).values({
+      userId, activityTypeId, title: 'Morning run',
+      estimatedLength: 30, frequencyCount: 3, frequencyUnit: 'week', priority: 1,
+    }).returning();
+
+    await runSchedulerWriteback(db, userId);
+
+    // Tentative completions (completedAt = null) should be created
+    const tentative = await db.query.habitCompletions.findMany({
+      where: { habitId: habit!.id },
+    });
+    expect(tentative.some((c) => c.completedAt === null)).toBe(true);
+  });
+
+  it('resets tentative completions on each writeback run', async () => {
+    await db.insert(timeBlocks).values({
+      userId, activityTypeId,
+      daysOfWeek: [0, 1, 2, 3, 4, 5, 6],
+      startTime: '09:00', endTime: '17:00', priority: 0,
+    });
+    const [habit] = await db.insert(habits).values({
+      userId, activityTypeId, title: 'Exercise',
+      estimatedLength: 30, frequencyCount: 2, frequencyUnit: 'week', priority: 1,
+    }).returning();
+
+    await runSchedulerWriteback(db, userId);
+    const firstRun = await db.query.habitCompletions.findMany({ where: { habitId: habit!.id } });
+
+    await runSchedulerWriteback(db, userId);
+    const secondRun = await db.query.habitCompletions.findMany({ where: { habitId: habit!.id } });
+
+    // Count of tentative completions should be the same after each run
+    const firstTentative = firstRun.filter((c) => c.completedAt === null).length;
+    const secondTentative = secondRun.filter((c) => c.completedAt === null).length;
+    expect(secondTentative).toBe(firstTentative);
+  });
+
+  it('resets overdue pinned todos and re-schedules them', async () => {
+    await db.insert(timeBlocks).values({
+      userId, activityTypeId,
+      daysOfWeek: [0, 1, 2, 3, 4, 5, 6],
+      startTime: '09:00', endTime: '17:00', priority: 0,
+    });
+    const [list] = await db.insert(todoLists).values({ userId, name: 'Work', activityTypeId }).returning();
+    const past = new Date(Date.now() - 86_400_000);
+    const [todo] = await db.insert(todos).values({
+      userId, listId: list!.id, title: 'Overdue pinned',
+      estimatedLength: 30, manuallyScheduled: true, scheduledAt: past,
+    }).returning();
+
+    await runSchedulerWriteback(db, userId);
+
+    const [updated] = await db.query.todos.findMany({ where: { id: todo!.id } });
+    // After writeback: manuallyScheduled cleared, scheduledAt reassigned by planner
+    expect(updated?.manuallyScheduled).toBe(false);
+  });
+
+  it('preserves a pre-placed todo with a valid future slot', async () => {
+    const [tb] = await db.insert(timeBlocks).values({
+      userId, activityTypeId,
+      daysOfWeek: [0, 1, 2, 3, 4, 5, 6],
+      startTime: '09:00', endTime: '17:00', priority: 0,
+    }).returning();
+    const [list] = await db.insert(todoLists).values({ userId, name: 'Work', activityTypeId }).returning();
+
+    // Build a future scheduledAt that falls inside the time block
+    const future = new Date();
+    future.setDate(future.getDate() + 1);
+    future.setHours(10, 0, 0, 0);
+
+    const [todo] = await db.insert(todos).values({
+      userId, listId: list!.id, title: 'Pre-placed',
+      estimatedLength: 30, scheduledAt: future,
+    }).returning();
+
+    await runSchedulerWriteback(db, userId);
+
+    const [updated] = await db.query.todos.findMany({ where: { id: todo!.id } });
+    // The pre-placed slot should be preserved (same scheduledAt)
+    expect(updated?.scheduledAt).not.toBeNull();
+    if (tb) expect(true).toBe(true); // silence unused var lint
+  });
+
+  it('does not delete real (completed) habit completions during writeback', async () => {
+    await db.insert(timeBlocks).values({
+      userId, activityTypeId,
+      daysOfWeek: [0, 1, 2, 3, 4, 5, 6],
+      startTime: '09:00', endTime: '17:00', priority: 0,
+    });
+    const [habit] = await db.insert(habits).values({
+      userId, activityTypeId, title: 'Real completion habit',
+      estimatedLength: 30, frequencyCount: 1, frequencyUnit: 'week', priority: 1,
+    }).returning();
+    // Insert a real (completed) completion
+    await db.insert(habitCompletions).values({ habitId: habit!.id, completedAt: new Date() });
+
+    await runSchedulerWriteback(db, userId);
+
+    const completions = await db.query.habitCompletions.findMany({ where: { habitId: habit!.id } });
+    const real = completions.filter((c) => c.completedAt !== null);
+    expect(real.length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/packages/server/src/services/scheduler-writeback.test.ts
+++ b/packages/server/src/services/scheduler-writeback.test.ts
@@ -27,6 +27,12 @@ const migrationsFolder = resolve(__dirname, '../../../../packages/db/drizzle');
 
 type TestDb = Awaited<ReturnType<typeof createDb>>;
 
+function seed<T>(rows: T[]): T {
+  const row = rows[0];
+  if (!row) throw new Error('seed failed');
+  return row;
+}
+
 async function createDb() {
   const client = new PGlite('memory://');
   await client.waitReady;
@@ -46,12 +52,20 @@ describe('runSchedulerWriteback', () => {
   }, 30000);
 
   beforeEach(async () => {
-    const [user] = await db.insert(users).values({ email: `writeback-${Date.now()}@example.com` }).returning();
-    if (!user) throw new Error('seed failed');
+    const user = seed(
+      await db
+        .insert(users)
+        .values({ email: `writeback-${Date.now()}@example.com` })
+        .returning(),
+    );
     userId = user.id;
 
-    const [at] = await db.insert(activityTypes).values({ userId, name: 'Work', color: '#6366f1' }).returning();
-    if (!at) throw new Error('seed failed');
+    const at = seed(
+      await db
+        .insert(activityTypes)
+        .values({ userId, name: 'Work', color: '#6366f1' })
+        .returning(),
+    );
     activityTypeId = at.id;
   });
 
@@ -61,135 +75,239 @@ describe('runSchedulerWriteback', () => {
 
   it('sets scheduledAt on todos that fit in a time block', async () => {
     await db.insert(timeBlocks).values({
-      userId, activityTypeId,
+      userId,
+      activityTypeId,
       daysOfWeek: [0, 1, 2, 3, 4, 5, 6],
-      startTime: '09:00', endTime: '17:00', priority: 0,
+      startTime: '09:00',
+      endTime: '17:00',
+      priority: 0,
     });
-    const [list] = await db.insert(todoLists).values({ userId, name: 'Work', activityTypeId }).returning();
-    const [todo] = await db.insert(todos).values({ userId, listId: list!.id, title: 'Task', estimatedLength: 30 }).returning();
+    const list = seed(
+      await db
+        .insert(todoLists)
+        .values({ userId, name: 'Work', activityTypeId })
+        .returning(),
+    );
+    const todo = seed(
+      await db
+        .insert(todos)
+        .values({ userId, listId: list.id, title: 'Task', estimatedLength: 30 })
+        .returning(),
+    );
 
     await runSchedulerWriteback(db, userId);
 
-    const [updated] = await db.query.todos.findMany({ where: { id: todo!.id } });
+    const [updated] = await db.query.todos.findMany({ where: { id: todo.id } });
     expect(updated?.scheduledAt).not.toBeNull();
   });
 
   it('sets scheduledAt to null for todos with no matching time block', async () => {
-    // Todo has Work activity type but there is no time block for it
-    const [list] = await db.insert(todoLists).values({ userId, name: 'Work', activityTypeId }).returning();
-    const [todo] = await db.insert(todos).values({ userId, listId: list!.id, title: 'Unplaceable', estimatedLength: 30 }).returning();
+    const list = seed(
+      await db
+        .insert(todoLists)
+        .values({ userId, name: 'Work', activityTypeId })
+        .returning(),
+    );
+    const todo = seed(
+      await db
+        .insert(todos)
+        .values({
+          userId,
+          listId: list.id,
+          title: 'Unplaceable',
+          estimatedLength: 30,
+        })
+        .returning(),
+    );
 
     await runSchedulerWriteback(db, userId);
 
-    const [updated] = await db.query.todos.findMany({ where: { id: todo!.id } });
+    const [updated] = await db.query.todos.findMany({ where: { id: todo.id } });
     expect(updated?.scheduledAt).toBeNull();
   });
 
   it('creates tentative habit completions for habits with a deficit', async () => {
     await db.insert(timeBlocks).values({
-      userId, activityTypeId,
+      userId,
+      activityTypeId,
       daysOfWeek: [0, 1, 2, 3, 4, 5, 6],
-      startTime: '09:00', endTime: '17:00', priority: 0,
+      startTime: '09:00',
+      endTime: '17:00',
+      priority: 0,
     });
-    const [habit] = await db.insert(habits).values({
-      userId, activityTypeId, title: 'Morning run',
-      estimatedLength: 30, frequencyCount: 3, frequencyUnit: 'week', priority: 1,
-    }).returning();
+    const habit = seed(
+      await db
+        .insert(habits)
+        .values({
+          userId,
+          activityTypeId,
+          title: 'Morning run',
+          estimatedLength: 30,
+          frequencyCount: 3,
+          frequencyUnit: 'week',
+          priority: 1,
+        })
+        .returning(),
+    );
 
     await runSchedulerWriteback(db, userId);
 
-    // Tentative completions (completedAt = null) should be created
     const tentative = await db.query.habitCompletions.findMany({
-      where: { habitId: habit!.id },
+      where: { habitId: habit.id },
     });
     expect(tentative.some((c) => c.completedAt === null)).toBe(true);
   });
 
   it('resets tentative completions on each writeback run', async () => {
     await db.insert(timeBlocks).values({
-      userId, activityTypeId,
+      userId,
+      activityTypeId,
       daysOfWeek: [0, 1, 2, 3, 4, 5, 6],
-      startTime: '09:00', endTime: '17:00', priority: 0,
+      startTime: '09:00',
+      endTime: '17:00',
+      priority: 0,
     });
-    const [habit] = await db.insert(habits).values({
-      userId, activityTypeId, title: 'Exercise',
-      estimatedLength: 30, frequencyCount: 2, frequencyUnit: 'week', priority: 1,
-    }).returning();
+    const habit = seed(
+      await db
+        .insert(habits)
+        .values({
+          userId,
+          activityTypeId,
+          title: 'Exercise',
+          estimatedLength: 30,
+          frequencyCount: 2,
+          frequencyUnit: 'week',
+          priority: 1,
+        })
+        .returning(),
+    );
 
     await runSchedulerWriteback(db, userId);
-    const firstRun = await db.query.habitCompletions.findMany({ where: { habitId: habit!.id } });
+    const firstRun = await db.query.habitCompletions.findMany({
+      where: { habitId: habit.id },
+    });
 
     await runSchedulerWriteback(db, userId);
-    const secondRun = await db.query.habitCompletions.findMany({ where: { habitId: habit!.id } });
+    const secondRun = await db.query.habitCompletions.findMany({
+      where: { habitId: habit.id },
+    });
 
-    // Count of tentative completions should be the same after each run
-    const firstTentative = firstRun.filter((c) => c.completedAt === null).length;
-    const secondTentative = secondRun.filter((c) => c.completedAt === null).length;
+    const firstTentative = firstRun.filter(
+      (c) => c.completedAt === null,
+    ).length;
+    const secondTentative = secondRun.filter(
+      (c) => c.completedAt === null,
+    ).length;
     expect(secondTentative).toBe(firstTentative);
   });
 
   it('resets overdue pinned todos and re-schedules them', async () => {
     await db.insert(timeBlocks).values({
-      userId, activityTypeId,
+      userId,
+      activityTypeId,
       daysOfWeek: [0, 1, 2, 3, 4, 5, 6],
-      startTime: '09:00', endTime: '17:00', priority: 0,
+      startTime: '09:00',
+      endTime: '17:00',
+      priority: 0,
     });
-    const [list] = await db.insert(todoLists).values({ userId, name: 'Work', activityTypeId }).returning();
+    const list = seed(
+      await db
+        .insert(todoLists)
+        .values({ userId, name: 'Work', activityTypeId })
+        .returning(),
+    );
     const past = new Date(Date.now() - 86_400_000);
-    const [todo] = await db.insert(todos).values({
-      userId, listId: list!.id, title: 'Overdue pinned',
-      estimatedLength: 30, manuallyScheduled: true, scheduledAt: past,
-    }).returning();
+    const todo = seed(
+      await db
+        .insert(todos)
+        .values({
+          userId,
+          listId: list.id,
+          title: 'Overdue pinned',
+          estimatedLength: 30,
+          manuallyScheduled: true,
+          scheduledAt: past,
+        })
+        .returning(),
+    );
 
     await runSchedulerWriteback(db, userId);
 
-    const [updated] = await db.query.todos.findMany({ where: { id: todo!.id } });
-    // After writeback: manuallyScheduled cleared, scheduledAt reassigned by planner
+    const [updated] = await db.query.todos.findMany({ where: { id: todo.id } });
     expect(updated?.manuallyScheduled).toBe(false);
   });
 
   it('preserves a pre-placed todo with a valid future slot', async () => {
-    const [tb] = await db.insert(timeBlocks).values({
-      userId, activityTypeId,
+    await db.insert(timeBlocks).values({
+      userId,
+      activityTypeId,
       daysOfWeek: [0, 1, 2, 3, 4, 5, 6],
-      startTime: '09:00', endTime: '17:00', priority: 0,
-    }).returning();
-    const [list] = await db.insert(todoLists).values({ userId, name: 'Work', activityTypeId }).returning();
+      startTime: '09:00',
+      endTime: '17:00',
+      priority: 0,
+    });
+    const list = seed(
+      await db
+        .insert(todoLists)
+        .values({ userId, name: 'Work', activityTypeId })
+        .returning(),
+    );
 
-    // Build a future scheduledAt that falls inside the time block
     const future = new Date();
     future.setDate(future.getDate() + 1);
     future.setHours(10, 0, 0, 0);
 
-    const [todo] = await db.insert(todos).values({
-      userId, listId: list!.id, title: 'Pre-placed',
-      estimatedLength: 30, scheduledAt: future,
-    }).returning();
+    const todo = seed(
+      await db
+        .insert(todos)
+        .values({
+          userId,
+          listId: list.id,
+          title: 'Pre-placed',
+          estimatedLength: 30,
+          scheduledAt: future,
+        })
+        .returning(),
+    );
 
     await runSchedulerWriteback(db, userId);
 
-    const [updated] = await db.query.todos.findMany({ where: { id: todo!.id } });
-    // The pre-placed slot should be preserved (same scheduledAt)
+    const [updated] = await db.query.todos.findMany({ where: { id: todo.id } });
     expect(updated?.scheduledAt).not.toBeNull();
-    if (tb) expect(true).toBe(true); // silence unused var lint
   });
 
   it('does not delete real (completed) habit completions during writeback', async () => {
     await db.insert(timeBlocks).values({
-      userId, activityTypeId,
+      userId,
+      activityTypeId,
       daysOfWeek: [0, 1, 2, 3, 4, 5, 6],
-      startTime: '09:00', endTime: '17:00', priority: 0,
+      startTime: '09:00',
+      endTime: '17:00',
+      priority: 0,
     });
-    const [habit] = await db.insert(habits).values({
-      userId, activityTypeId, title: 'Real completion habit',
-      estimatedLength: 30, frequencyCount: 1, frequencyUnit: 'week', priority: 1,
-    }).returning();
-    // Insert a real (completed) completion
-    await db.insert(habitCompletions).values({ habitId: habit!.id, completedAt: new Date() });
+    const habit = seed(
+      await db
+        .insert(habits)
+        .values({
+          userId,
+          activityTypeId,
+          title: 'Real completion habit',
+          estimatedLength: 30,
+          frequencyCount: 1,
+          frequencyUnit: 'week',
+          priority: 1,
+        })
+        .returning(),
+    );
+    await db
+      .insert(habitCompletions)
+      .values({ habitId: habit.id, completedAt: new Date() });
 
     await runSchedulerWriteback(db, userId);
 
-    const completions = await db.query.habitCompletions.findMany({ where: { habitId: habit!.id } });
+    const completions = await db.query.habitCompletions.findMany({
+      where: { habitId: habit.id },
+    });
     const real = completions.filter((c) => c.completedAt !== null);
     expect(real.length).toBeGreaterThanOrEqual(1);
   });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -18,7 +18,10 @@ export default defineConfig({
       provider: 'v8',
       reporter: ['text', 'html', 'lcov'],
       include: ['packages/*/src/**/*.ts'],
-      exclude: ['packages/*/src/**/*.test.ts', 'packages/*/src/__generated__/**'],
+      exclude: [
+        'packages/*/src/**/*.test.ts',
+        'packages/*/src/__generated__/**',
+      ],
     },
   },
 });


### PR DESCRIPTION
## Summary

- Adds a shared `test-helpers.ts` module with PGLite setup, schema building, and seed helpers reused across all four new test files
- 69 new integration tests covering `schedule.ts`, `stats.ts`, `todos.ts`, and `habits.ts` resolvers
- Overall server coverage: **28% → 58% statements, 15% → 50% branches**

| Resolver | Before | After (stmts) |
|---|---|---|
| `schedule.ts` | 2.8% | 94% |
| `stats.ts` | 2.4% | 100% |
| `todos.ts` | 41.8% | 86% |
| `habits.ts` | 6.9% | 94% |

## Test plan

- [ ] `npm test` passes all 183 tests
- [ ] `npm test -- --coverage` shows the coverage improvements above

🤖 Generated with [Claude Code](https://claude.com/claude-code)