### PR TITLE
feat(server): add GraphQL subscriptions for todo and todo-list mutations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,6 @@
       "workspaces": [
         "packages/*"
       ],
-      "dependencies": {
-        "@vantreeseba/graphql-mocks": "^1.0.5"
-      },
       "devDependencies": {
         "@0no-co/graphqlsp": "^1.15.4",
         "@biomejs/biome": "^1.9.4",
@@ -23,6 +20,7 @@
         "@graphql-codegen/schema-ast": "^6.0.0",
         "@graphql-codegen/typescript": "^6.0.0",
         "@graphql-codegen/typescript-resolvers": "^6.0.0",
+        "@vantreeseba/graphql-mocks": "^1.0.5",
         "@vitest/coverage-v8": "^4.1.6",
         "concurrently": "^9.1.2",
         "esbuild": "^0.28.0",
@@ -1564,6 +1562,7 @@
       "version": "10.4.0",
       "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-10.4.0.tgz",
       "integrity": "sha512-sDBWI3yLy8EcDzgobvJTWq1MJYzAkQdpjXuPukga9wXonhpMRvd1Izuo2Qgwey2OiEoRIBr35RMU9HJRoOHzpw==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -5036,6 +5035,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@vantreeseba/graphql-mocks/-/graphql-mocks-1.0.5.tgz",
       "integrity": "sha512-ZxTfcz1gQi9A9FW37p0ro6CjUJoTyXhwCDuV9x5mq2pb6+kIjN42Q9O1yx8N6Grs0hfcBKwDMrH2PW37+Ca+/A==",
+      "dev": true,
       "peerDependencies": {
         "@faker-js/faker": ">=9",
         "graphql": ">=16",
@@ -7972,6 +7972,15 @@
         "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
       }
     },
+    "node_modules/graphql-subscriptions": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/graphql-subscriptions/-/graphql-subscriptions-3.0.0.tgz",
+      "integrity": "sha512-kZCdevgmzDjGAOqH7GlDmQXYAkuHoKpMlJrqF40HMPhUhM5ZWSFSxCwD/nSi6AkaijmMfsFhoJRGJ27UseCvRA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "graphql": "^15.7.2 || ^16.0.0"
+      }
+    },
     "node_modules/graphql-tag": {
       "version": "2.12.6",
       "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.6.tgz",
@@ -7991,7 +8000,6 @@
       "version": "6.0.8",
       "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-6.0.8.tgz",
       "integrity": "sha512-m3EOaNsUBXwAnkBWbzPfe0Nq8pXUfxsWnolC54sru3FzHvhTZL0Ouf/BoQsaGAXqM+YPerXOJ47BUnmgmoupCw==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=20"
@@ -11869,10 +11877,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
-      "devOptional": true,
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -12094,16 +12101,20 @@
         "drizzle-orm": "~1.0.0-rc.2",
         "express": "^4.21.2",
         "graphql": "^16.9.0",
+        "graphql-subscriptions": "^3.0.0",
+        "graphql-ws": "^6.0.8",
         "ical-generator": "^10.2.0",
         "jose": "^5.10.0",
         "pluralize": "^8.0.0",
+        "ws": "^8.20.1",
         "zod": "^3.24.1"
       },
       "devDependencies": {
         "@types/cors": "^2.8.17",
         "@types/express": "^5.0.0",
         "@types/node": "^25.6.0",
-        "@types/pluralize": "^0.0.33"
+        "@types/pluralize": "^0.0.33",
+        "@types/ws": "^8.18.1"
       }
     }
   }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -19,16 +19,20 @@
     "drizzle-orm": "~1.0.0-rc.2",
     "express": "^4.21.2",
     "graphql": "^16.9.0",
+    "graphql-subscriptions": "^3.0.0",
+    "graphql-ws": "^6.0.8",
     "ical-generator": "^10.2.0",
     "jose": "^5.10.0",
     "pluralize": "^8.0.0",
+    "ws": "^8.20.1",
     "zod": "^3.24.1"
   },
   "devDependencies": {
     "@types/cors": "^2.8.17",
     "@types/express": "^5.0.0",
     "@types/node": "^25.6.0",
-    "@types/pluralize": "^0.0.33"
+    "@types/pluralize": "^0.0.33",
+    "@types/ws": "^8.18.1"
   },
   "resolutions": {
     "graphql": "16.10.0"

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,6 +1,8 @@
 import fs from 'node:fs';
+import http from 'node:http';
 import path from 'node:path';
 import { ApolloServer } from '@apollo/server';
+import { ApolloServerPluginDrainHttpServer } from '@apollo/server/plugin/drainHttpServer';
 import { expressMiddleware } from '@as-integrations/express4';
 import { db } from '@auto-cal/db';
 import { apiKeys } from '@auto-cal/db/schema';
@@ -8,6 +10,8 @@ import { seedDemoData, seedDemoUser } from '@auto-cal/db/seed';
 import cors from 'cors';
 import { eq } from 'drizzle-orm';
 import express from 'express';
+import { useServer } from 'graphql-ws/use/ws';
+import { WebSocketServer } from 'ws';
 import { hashApiKey, isApiKey } from './api-keys.ts';
 import { verifyToken } from './auth.ts';
 import { createLoaders } from './context.ts';
@@ -15,9 +19,80 @@ import type { Context } from './context.ts';
 import { icalHandler } from './ical-route.ts';
 import { schema } from './schema/index.ts';
 
-const app = express();
+async function buildContext(rawToken?: string): Promise<Context> {
+  const loaders = createLoaders(db);
+  if (!rawToken) return { db, loaders };
 
-const server = new ApolloServer<Context>({ schema });
+  const payload = await verifyToken(rawToken);
+  if (payload?.sub) return { db, userId: payload.sub, loaders };
+
+  if (isApiKey(rawToken)) {
+    const hash = hashApiKey(rawToken);
+    const now = new Date();
+    const key = await db.query.apiKeys.findFirst({
+      where: {
+        keyHash: hash,
+        revokedAt: { isNull: true },
+      },
+    });
+    if (
+      key &&
+      (key.expiresAt === null ||
+        key.expiresAt === undefined ||
+        key.expiresAt > now)
+    ) {
+      db.update(apiKeys)
+        .set({ lastUsedAt: now })
+        .where(eq(apiKeys.id, key.id))
+        .catch(console.error);
+      return {
+        db,
+        userId: key.userId,
+        apiKey: { id: key.id, scopes: key.scopes },
+        loaders,
+      };
+    }
+  }
+
+  if (
+    process.env.NODE_ENV !== 'production' &&
+    /^[0-9a-f-]{36}$/i.test(rawToken)
+  )
+    return { db, userId: rawToken, loaders };
+
+  return { db, loaders };
+}
+
+const app = express();
+const httpServer = http.createServer(app);
+
+const wsServer = new WebSocketServer({ server: httpServer, path: '/graphql' });
+const serverCleanup = useServer(
+  {
+    schema,
+    context: (ctx) => {
+      const raw = ctx.connectionParams?.authorization as string | undefined;
+      return buildContext(raw);
+    },
+  },
+  wsServer,
+);
+
+const server = new ApolloServer<Context>({
+  schema,
+  plugins: [
+    ApolloServerPluginDrainHttpServer({ httpServer }),
+    {
+      async serverWillStart() {
+        return {
+          async drainServer() {
+            await serverCleanup.dispose();
+          },
+        };
+      },
+    },
+  ],
+});
 
 await server.start();
 await seedDemoUser();
@@ -42,54 +117,7 @@ app.use(
       const rawToken = authHeader?.startsWith('Bearer ')
         ? authHeader.slice(7)
         : undefined;
-
-      const loaders = createLoaders(db);
-
-      if (!rawToken) return { db, loaders };
-
-      // Try JWT verification first
-      const payload = await verifyToken(rawToken);
-      if (payload?.sub) return { db, userId: payload.sub, loaders };
-
-      // Try API key auth
-      if (isApiKey(rawToken)) {
-        const hash = hashApiKey(rawToken);
-        const now = new Date();
-        const key = await db.query.apiKeys.findFirst({
-          where: {
-            keyHash: hash,
-            revokedAt: { isNull: true },
-          },
-        });
-        if (
-          key &&
-          (key.expiresAt === null ||
-            key.expiresAt === undefined ||
-            key.expiresAt > now)
-        ) {
-          // Fire-and-forget lastUsedAt update
-          db.update(apiKeys)
-            .set({ lastUsedAt: now })
-            .where(eq(apiKeys.id, key.id))
-            .catch(console.error);
-          return {
-            db,
-            userId: key.userId,
-            apiKey: { id: key.id, scopes: key.scopes },
-            loaders,
-          };
-        }
-      }
-
-      // Dev-only: accept raw UUID as Bearer token for the demo user.
-      // In production, only JWTs and API keys (acal_ prefix) are valid.
-      if (
-        process.env.NODE_ENV !== 'production' &&
-        /^[0-9a-f-]{36}$/i.test(rawToken)
-      )
-        return { db, userId: rawToken, loaders };
-
-      return { db, loaders };
+      return buildContext(rawToken);
     },
   }),
 );
@@ -104,7 +132,7 @@ if (clientDistExists) {
 
 const PORT = Number(process.env.PORT ?? 4000);
 
-app.listen(PORT, '0.0.0.0', () => {
+httpServer.listen(PORT, '0.0.0.0', () => {
   console.log(`Server ready at http://0.0.0.0:${PORT}/graphql`);
   if (clientDistExists) {
     console.log(`Serving client from ${clientDist}`);

--- a/packages/server/src/pubsub.ts
+++ b/packages/server/src/pubsub.ts
@@ -1,0 +1,3 @@
+import { PubSub } from 'graphql-subscriptions';
+
+export const pubsub = new PubSub();

--- a/packages/server/src/schema/resolvers/index.ts
+++ b/packages/server/src/schema/resolvers/index.ts
@@ -15,6 +15,7 @@ import { applyHabitResolvers } from './habits.ts';
 import { applyProfileResolvers } from './profile.ts';
 import { applyScheduleResolvers } from './schedule.ts';
 import { applyStatsResolvers } from './stats.ts';
+import { applySubscriptionResolvers } from './subscriptions.ts';
 import { applyTimeBlockResolvers } from './time-blocks.ts';
 import { applyTodoListResolvers } from './todo-lists.ts';
 import { applyTodoResolvers } from './todos.ts';
@@ -215,6 +216,29 @@ const extensionSDL = `
     expiresAt: String
   }
 
+  enum TodoEventType {
+    created
+    updated
+    deleted
+  }
+
+  type TodoListEvent {
+    type: TodoEventType!
+    todoList: TodoList
+    deletedId: ID
+  }
+
+  type TodoEvent {
+    type: TodoEventType!
+    todo: Todo
+    deletedId: ID
+  }
+
+  type Subscription {
+    myTodoListsUpdated: TodoListEvent!
+    myTodosUpdated: TodoEvent!
+  }
+
   extend type Todo {
     activityType: ActivityType
   }
@@ -277,8 +301,12 @@ export function applyCustomResolvers(schema: GraphQLSchema): GraphQLSchema {
 
   const queryType = extended.getType('Query') as GraphQLObjectType;
   const mutationType = extended.getType('Mutation') as GraphQLObjectType;
+  const subscriptionType = extended.getType(
+    'Subscription',
+  ) as GraphQLObjectType;
   const queryFields = queryType.getFields();
   const mutationFields = mutationType.getFields();
+  const subscriptionFields = subscriptionType.getFields();
 
   applyProfileResolvers(queryFields, mutationFields);
   applyActivityTypeResolvers(queryFields, mutationFields);
@@ -290,6 +318,7 @@ export function applyCustomResolvers(schema: GraphQLSchema): GraphQLSchema {
   applyScheduleResolvers(queryFields, mutationFields);
   applyAuthResolvers(mutationFields);
   applyApiKeyResolvers(queryFields, mutationFields);
+  applySubscriptionResolvers(subscriptionFields);
 
   // Field resolvers: activityType on Habit and TimeBlock load directly from
   // their activityTypeId. Todo.activityType derives from its list.

--- a/packages/server/src/schema/resolvers/subscriptions.ts
+++ b/packages/server/src/schema/resolvers/subscriptions.ts
@@ -1,0 +1,37 @@
+import type { GraphQLObjectType } from 'graphql';
+import type { Context } from '../../context.ts';
+import { pubsub } from '../../pubsub.ts';
+
+type Fields = ReturnType<GraphQLObjectType['getFields']>;
+
+export const TODO_EVENT = (userId: string) => `TODO_EVENT:${userId}`;
+export const TODO_LIST_EVENT = (userId: string) => `TODO_LIST_EVENT:${userId}`;
+
+export function applySubscriptionResolvers(subscriptionFields: Fields): void {
+  // biome-ignore lint/style/noNonNullAssertion: field is defined in SDL above
+  subscriptionFields.myTodosUpdated!.subscribe = (
+    _parent,
+    _args,
+    context: Context,
+  ) => {
+    if (!context.userId) throw new Error('Not authenticated');
+    return pubsub.asyncIterableIterator(TODO_EVENT(context.userId));
+  };
+
+  // biome-ignore lint/style/noNonNullAssertion: field is defined in SDL above
+  subscriptionFields.myTodosUpdated!.resolve = (payload: unknown) => payload;
+
+  // biome-ignore lint/style/noNonNullAssertion: field is defined in SDL above
+  subscriptionFields.myTodoListsUpdated!.subscribe = (
+    _parent,
+    _args,
+    context: Context,
+  ) => {
+    if (!context.userId) throw new Error('Not authenticated');
+    return pubsub.asyncIterableIterator(TODO_LIST_EVENT(context.userId));
+  };
+
+  // biome-ignore lint/style/noNonNullAssertion: field is defined in SDL above
+  subscriptionFields.myTodoListsUpdated!.resolve = (payload: unknown) =>
+    payload;
+}

--- a/packages/server/src/schema/resolvers/todo-lists.ts
+++ b/packages/server/src/schema/resolvers/todo-lists.ts
@@ -2,7 +2,9 @@ import { todoLists } from '@auto-cal/db/schema';
 import { eq } from 'drizzle-orm';
 import type { GraphQLObjectType } from 'graphql';
 import type { Context } from '../../context.ts';
+import { pubsub } from '../../pubsub.ts';
 import { CreateTodoListInput, UpdateTodoListInput } from '../validators.ts';
+import { TODO_LIST_EVENT } from './subscriptions.ts';
 
 type Fields = ReturnType<GraphQLObjectType['getFields']>;
 
@@ -55,6 +57,12 @@ export function applyTodoListResolvers(
       })
       .returning();
     if (!list) throw new Error('Failed to create todo list');
+    pubsub
+      .publish(TODO_LIST_EVENT(context.userId), {
+        type: 'created',
+        todoList: list,
+      })
+      .catch(console.error);
     return list;
   };
 
@@ -103,6 +111,12 @@ export function applyTodoListResolvers(
       .where(eq(todoLists.id, input.id))
       .returning();
     if (!updated) throw new Error(`Failed to update todo list ${input.id}`);
+    pubsub
+      .publish(TODO_LIST_EVENT(context.userId), {
+        type: 'updated',
+        todoList: updated,
+      })
+      .catch(console.error);
     return updated;
   };
 
@@ -131,6 +145,12 @@ export function applyTodoListResolvers(
     }
 
     await context.db.delete(todoLists).where(eq(todoLists.id, args.id));
+    pubsub
+      .publish(TODO_LIST_EVENT(context.userId), {
+        type: 'deleted',
+        deletedId: args.id,
+      })
+      .catch(console.error);
     return true;
   };
 }

--- a/packages/server/src/schema/resolvers/todos.ts
+++ b/packages/server/src/schema/resolvers/todos.ts
@@ -3,8 +3,10 @@ import { eq } from 'drizzle-orm';
 import type { GraphQLObjectType } from 'graphql';
 import type { InnerOrder, TodoOrderBy } from '../../__generated__/resolvers.ts';
 import type { Context } from '../../context.ts';
+import { pubsub } from '../../pubsub.ts';
 import { runSchedulerWriteback } from '../../services/scheduler-writeback.ts';
 import { CreateTodoInput, UpdateTodoInput } from '../validators.ts';
+import { TODO_EVENT } from './subscriptions.ts';
 
 type Fields = ReturnType<GraphQLObjectType['getFields']>;
 
@@ -79,6 +81,9 @@ export function applyTodoResolvers(
       .returning();
     if (!todo) throw new Error('Failed to create todo');
     runSchedulerWriteback(context.db, context.userId).catch(console.error);
+    pubsub
+      .publish(TODO_EVENT(context.userId), { type: 'created', todo })
+      .catch(console.error);
     return todo;
   };
 
@@ -137,6 +142,9 @@ export function applyTodoResolvers(
       .returning();
     if (!updated) throw new Error(`Failed to update todo ${input.id}`);
     runSchedulerWriteback(context.db, context.userId).catch(console.error);
+    pubsub
+      .publish(TODO_EVENT(context.userId), { type: 'updated', todo: updated })
+      .catch(console.error);
     return updated;
   };
 
@@ -170,6 +178,9 @@ export function applyTodoResolvers(
       .returning();
     if (!completed) throw new Error(`Failed to complete todo ${args.id}`);
     runSchedulerWriteback(context.db, context.userId).catch(console.error);
+    pubsub
+      .publish(TODO_EVENT(context.userId), { type: 'updated', todo: completed })
+      .catch(console.error);
     return completed;
   };
 
@@ -187,6 +198,12 @@ export function applyTodoResolvers(
     if (existing.userId !== context.userId) throw new Error('Forbidden');
     await context.db.delete(todos).where(eq(todos.id, args.id));
     runSchedulerWriteback(context.db, context.userId).catch(console.error);
+    pubsub
+      .publish(TODO_EVENT(context.userId), {
+        type: 'deleted',
+        deletedId: args.id,
+      })
+      .catch(console.error);
     return true;
   };
 }


### PR DESCRIPTION
## Summary

- Adds `graphql-subscriptions` PubSub singleton (`pubsub.ts`) shared across all resolvers
- Introduces `myTodosUpdated` and `myTodoListsUpdated` GraphQL subscriptions, each firing a typed event (`TodoEvent` / `TodoListEvent`) with a `TodoEventType` enum (`created | updated | deleted`)
- Publishes events fire-and-forget from all todo and todo-list create, update, complete, and delete mutations
- Wires a `WebSocketServer` via `graphql-ws` onto the HTTP server at `/graphql`; adds graceful drain via `ApolloServerPluginDrainHttpServer`
- Extracts a shared `buildContext` helper (JWT → API key → dev UUID fallback) used by both HTTP and WebSocket auth

## Event shape

```graphql
type TodoEvent      { type: TodoEventType!  todo: Todo        deletedId: ID }
type TodoListEvent  { type: TodoEventType!  todoList: TodoList deletedId: ID }
```

For `created`/`updated` the full object is populated; for `deleted` only `deletedId` is set.

## Client connection

Connect via WebSocket to `ws://<host>:<port>/graphql` with `connectionParams: { authorization: "<token>" }`.

## Test plan

- [ ] `npm test` — all 253 tests pass
- [ ] `npm run typecheck` — clean
- [ ] `npm run lint` — clean
- [ ] Manual: start server, subscribe to `myTodosUpdated`, create/update/delete a todo, verify events arrive over WS

🤖 Generated with [Claude Code](https://claude.com/claude-code)