### PR TITLE
feat(subscriptions): live-update todos and dashboard via WebSocket

### DIFF
--- a/packages/client/app/(app)/dashboard.tsx
+++ b/packages/client/app/(app)/dashboard.tsx
@@ -2,7 +2,7 @@ import { graphql } from '@/__generated__/index.js';
 import { CalendarView } from '@/components/domain/dashboard/CalendarView';
 import { ScheduleView } from '@/components/domain/dashboard/ScheduleView';
 import { WeekNavigator } from '@/components/domain/dashboard/WeekNavigator';
-import { useMutation, useQuery } from '@apollo/client/react';
+import { useMutation, useQuery, useSubscription } from '@apollo/client/react';
 import { addDays, addMonths, addWeeks, format, startOfMonth } from 'date-fns';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { useEffect } from 'react';
@@ -29,6 +29,16 @@ const MY_SCHEDULE = graphql(`
 const UPDATE_PROFILE = graphql(`
   mutation UpdateProfile($timezone: String!) {
     myUpdateProfile(timezone: $timezone)
+  }
+`);
+
+// Reuse the same subscription from the todo-lists page
+const TODO_UPDATED_SUB = graphql(`
+  subscription DashboardTodoUpdated {
+    myTodosUpdated {
+      type
+      deletedId
+    }
   }
 `);
 
@@ -163,10 +173,21 @@ export default function DashboardPage() {
   });
 
   const weekStart = toMonday(date);
-  const { data: scheduleData } = useQuery(MY_SCHEDULE, {
-    variables: {
-      weekStart: format(weekStart, 'yyyy-MM-dd'),
-      timezone: clientTimezone,
+  const { data: scheduleData, refetch: refetchSchedule } = useQuery(
+    MY_SCHEDULE,
+    {
+      variables: {
+        weekStart: format(weekStart, 'yyyy-MM-dd'),
+        timezone: clientTimezone,
+      },
+    },
+  );
+
+  // Refetch the schedule whenever any todo changes — the schedule is a
+  // server-computed view derived from todos, so we can't update it locally.
+  useSubscription(TODO_UPDATED_SUB, {
+    onData: () => {
+      refetchSchedule().catch(console.error);
     },
   });
 

--- a/packages/client/app/(app)/todo-lists.tsx
+++ b/packages/client/app/(app)/todo-lists.tsx
@@ -1,8 +1,11 @@
-import type { Todo_TodoListFragment } from '@/__generated__/graphql.js';
+import type {
+  GetTodoListsPageQuery,
+  Todo_TodoListFragment,
+} from '@/__generated__/graphql.js';
 import { graphql } from '@/__generated__/index.js';
 import { TodoListList } from '@/components/domain/todo-list/TodoListList';
 import { useQuery } from '@apollo/client/react';
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 
 const GET_TODO_LISTS_PAGE = graphql(`
   query GetTodoListsPage {
@@ -15,10 +18,114 @@ const GET_TODO_LISTS_PAGE = graphql(`
   }
 `);
 
+const TODO_UPDATED_SUB = graphql(`
+  subscription TodoUpdated {
+    myTodosUpdated {
+      type
+      deletedId
+      todo {
+        ...Todo_TodoList
+      }
+    }
+  }
+`);
+
+const TODO_LIST_UPDATED_SUB = graphql(`
+  subscription TodoListUpdated {
+    myTodoListsUpdated {
+      type
+      deletedId
+      todoList {
+        ...TodoList_TodoListList
+      }
+    }
+  }
+`);
+
 export default function TodoListsPage() {
-  const { data, loading, error } = useQuery(GET_TODO_LISTS_PAGE, {
-    fetchPolicy: 'cache-and-network',
-  });
+  const { data, loading, error, subscribeToMore } = useQuery(
+    GET_TODO_LISTS_PAGE,
+    { fetchPolicy: 'cache-and-network' },
+  );
+
+  // Subscribe to todo events and merge into the cached query result.
+  useEffect(() => {
+    const unsubTodos = subscribeToMore({
+      document: TODO_UPDATED_SUB,
+      updateQuery(prev, { subscriptionData }) {
+        const event = subscriptionData.data?.myTodosUpdated;
+        if (!event) return prev as GetTodoListsPageQuery;
+
+        const todos = (prev.myTodos ?? []) as GetTodoListsPageQuery['myTodos'];
+
+        if (event.type === 'deleted') {
+          return {
+            ...prev,
+            myTodos: todos.filter((t) => t.id !== event.deletedId),
+          } as GetTodoListsPageQuery;
+        }
+
+        if (!event.todo) return prev as GetTodoListsPageQuery;
+        const incoming = event.todo as GetTodoListsPageQuery['myTodos'][number];
+
+        if (event.type === 'created') {
+          // Avoid duplicates (optimistic update may have already added it)
+          const exists = todos.some((t) => t.id === incoming.id);
+          return {
+            ...prev,
+            myTodos: exists ? todos : [...todos, incoming],
+          } as GetTodoListsPageQuery;
+        }
+
+        // updated
+        return {
+          ...prev,
+          myTodos: todos.map((t) => (t.id === incoming.id ? incoming : t)),
+        } as GetTodoListsPageQuery;
+      },
+    });
+
+    const unsubLists = subscribeToMore({
+      document: TODO_LIST_UPDATED_SUB,
+      updateQuery(prev, { subscriptionData }) {
+        const event = subscriptionData.data?.myTodoListsUpdated;
+        if (!event) return prev as GetTodoListsPageQuery;
+
+        const lists = (prev.myTodoLists ??
+          []) as GetTodoListsPageQuery['myTodoLists'];
+
+        if (event.type === 'deleted') {
+          return {
+            ...prev,
+            myTodoLists: lists.filter((l) => l.id !== event.deletedId),
+          } as GetTodoListsPageQuery;
+        }
+
+        if (!event.todoList) return prev as GetTodoListsPageQuery;
+        const incoming =
+          event.todoList as GetTodoListsPageQuery['myTodoLists'][number];
+
+        if (event.type === 'created') {
+          const exists = lists.some((l) => l.id === incoming.id);
+          return {
+            ...prev,
+            myTodoLists: exists ? lists : [...lists, incoming],
+          } as GetTodoListsPageQuery;
+        }
+
+        // updated
+        return {
+          ...prev,
+          myTodoLists: lists.map((l) => (l.id === incoming.id ? incoming : l)),
+        } as GetTodoListsPageQuery;
+      },
+    });
+
+    return () => {
+      unsubTodos();
+      unsubLists();
+    };
+  }, [subscribeToMore]);
 
   const todosByListId = useMemo(() => {
     const map = new Map<string, Todo_TodoListFragment[]>();

--- a/packages/client/src/apollo-client.ts
+++ b/packages/client/src/apollo-client.ts
@@ -6,6 +6,9 @@ import {
 } from '@apollo/client';
 import { CombinedGraphQLErrors } from '@apollo/client/errors';
 import { ErrorLink } from '@apollo/client/link/error';
+import { GraphQLWsLink } from '@apollo/client/link/subscriptions';
+import { getMainDefinition } from '@apollo/client/utilities';
+import { createClient } from 'graphql-ws';
 import { Platform } from 'react-native';
 import { storage } from './storage';
 
@@ -13,6 +16,29 @@ import { storage } from './storage';
 // In production the variable is unset, so the URL is relative (/graphql) and
 // resolves to the same Express server that serves the static bundle.
 const API_URL = process.env.EXPO_PUBLIC_API_URL ?? '';
+
+function buildWsUrl(): string {
+  if (API_URL) {
+    // e.g. http://localhost:3001 → ws://localhost:3001/graphql
+    return `${API_URL.replace(/^http/, 'ws')}/graphql`;
+  }
+  if (Platform.OS === 'web' && typeof window !== 'undefined') {
+    const proto = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+    return `${proto}//${window.location.host}/graphql`;
+  }
+  // Fallback for native dev without explicit API_URL
+  return 'ws://localhost:3001/graphql';
+}
+
+const wsLink = new GraphQLWsLink(
+  createClient({
+    url: buildWsUrl(),
+    connectionParams: () => {
+      const token = storage.getItem('auth_token');
+      return token ? { authorization: `Bearer ${token}` } : {};
+    },
+  }),
+);
 
 const httpLink = new HttpLink({
   uri: `${API_URL}/graphql`,
@@ -23,6 +49,18 @@ const httpLink = new HttpLink({
     return fetch(uri as RequestInfo, { ...(options as RequestInit), headers });
   },
 });
+
+// Route subscription operations to the WebSocket link; everything else to HTTP.
+const splitLink = ApolloLink.split(
+  ({ query }) => {
+    const def = getMainDefinition(query);
+    return (
+      def.kind === 'OperationDefinition' && def.operation === 'subscription'
+    );
+  },
+  wsLink,
+  httpLink,
+);
 
 const errorLink = new ErrorLink(({ error }) => {
   if (CombinedGraphQLErrors.is(error)) {
@@ -38,7 +76,7 @@ const errorLink = new ErrorLink(({ error }) => {
 });
 
 export const apolloClient = new ApolloClient({
-  link: ApolloLink.from([errorLink, httpLink]),
+  link: ApolloLink.from([errorLink, splitLink]),
   cache: new InMemoryCache(),
   defaultOptions: {
     watchQuery: { fetchPolicy: 'cache-and-network' },


### PR DESCRIPTION
## Summary

- Adds `myTodosUpdated` and `myTodoListsUpdated` GraphQL subscriptions to the todo-lists page so the UI reflects creates, updates, and deletes without a manual refresh
- Dashboard subscribes to `myTodosUpdated` and refetches the schedule whenever any todo changes (the schedule is server-computed and can't be updated locally)
- Apollo `subscribeToMore` merges subscription events directly into the cached query, avoiding duplicate network fetches

## Test plan

- [ ] Create/update/complete/delete a todo in one browser tab — verify the todo-lists page in another tab updates in real time
- [ ] Toggle a todo complete — verify the dashboard schedule updates automatically
- [ ] Open multiple tabs; confirm no duplicate entries appear when a new todo is created
- [ ] Disconnect WebSocket (e.g. kill server briefly); reconnect and verify state is consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)