### PR TITLE
feat(habits): auto-generate pomodoros

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5206,6 +5206,35 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-switch": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-switch/-/react-switch-1.2.6.tgz",
+      "integrity": "sha512-bByzr1+ep1zk4VubeEVViV592vu2lHE2BZY5OnzehZqOOgogN80+mNtCqPkhn2gklJqOpxWgPoYTSnhBCqpOXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-tabs": {
       "version": "1.1.13",
       "license": "MIT",
@@ -13076,6 +13105,18 @@
         }
       }
     },
+    "node_modules/react-dom": {
+      "version": "19.2.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
+      "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.0"
+      }
+    },
     "node_modules/react-fast-compare": {
       "version": "3.2.2",
       "license": "MIT"
@@ -15668,6 +15709,7 @@
         "@radix-ui/react-popover": "^1.1.15",
         "@radix-ui/react-select": "^2.1.4",
         "@radix-ui/react-slot": "^1.1.1",
+        "@radix-ui/react-switch": "^1.2.6",
         "@radix-ui/react-tabs": "^1.1.1",
         "@radix-ui/react-tooltip": "^1.2.8",
         "@react-native-async-storage/async-storage": "2.2.0",
@@ -15795,16 +15837,6 @@
       },
       "peerDependencies": {
         "react-native": "^0.0.0-0 || >=0.65 <1.0"
-      }
-    },
-    "packages/client/node_modules/react-dom": {
-      "version": "19.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "scheduler": "^0.27.0"
-      },
-      "peerDependencies": {
-        "react": "^19.2.0"
       }
     },
     "packages/client/node_modules/react-native-is-edge-to-edge": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "db:migrate": "npm run db:migrate -w @auto-cal/db",
     "db:seed": "npm run db:seed -w @auto-cal/db",
     "db:studio": "npm run db:studio -w @auto-cal/db",
+    "db:clean": "rm -rf pgdata",
     "generate:schema": "node --experimental-strip-types packages/server/generate_schema.ts",
     "codegen": "npm run generate:schema && npm run codegen:server && npm run codegen:client",
     "codegen:client": "graphql-codegen --config codegen.ts",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -18,6 +18,7 @@
     "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-select": "^2.1.4",
     "@radix-ui/react-slot": "^1.1.1",
+    "@radix-ui/react-switch": "^1.2.6",
     "@radix-ui/react-tabs": "^1.1.1",
     "@radix-ui/react-tooltip": "^1.2.8",
     "@react-native-async-storage/async-storage": "2.2.0",

--- a/packages/client/src/__generated__/graphql.ts
+++ b/packages/client/src/__generated__/graphql.ts
@@ -1,0 +1,541 @@
+/* eslint-disable */
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> = T | { [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never };
+import { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';
+export type CompleteHabitArgs = {
+  completedAt?: string | null | undefined;
+  habitId: string | number;
+  scheduledAt?: string | null | undefined;
+};
+
+export type CreateActivityTypeArgs = {
+  color?: string | null | undefined;
+  name: string;
+};
+
+export type CreateHabitArgs = {
+  activityTypeId: string | number;
+  description?: string | null | undefined;
+  estimatedLength?: number | null | undefined;
+  frequencyCount: number;
+  frequencyUnit: string;
+  minTimeBetweenInstances?: number | null | undefined;
+  pomodoroEnabled?: boolean | null | undefined;
+  pomodoroLongBreakLength?: number | null | undefined;
+  pomodoroShortBreakLength?: number | null | undefined;
+  pomodoroUnitLength?: number | null | undefined;
+  pomodoroUnitsBeforeLongBreak?: number | null | undefined;
+  priority?: number | null | undefined;
+  title: string;
+};
+
+export type CreateTimeBlockArgs = {
+  activityTypeId: string | number;
+  daysOfWeek: Array<number>;
+  endTime: string;
+  priority?: number | null | undefined;
+  startTime: string;
+};
+
+export type CreateTodoArgs = {
+  description?: string | null | undefined;
+  dueAt?: string | null | undefined;
+  estimatedLength?: number | null | undefined;
+  listId: string | number;
+  priority?: number | null | undefined;
+  scheduledAt?: string | null | undefined;
+  title: string;
+};
+
+export type CreateTodoListArgs = {
+  activityTypeId: string | number;
+  defaultEstimatedLength?: number | null | undefined;
+  defaultPriority?: number | null | undefined;
+  description?: string | null | undefined;
+  name: string;
+};
+
+export type MyCreateApiKeyInput = {
+  expiresAt?: string | null | undefined;
+  name: string;
+  scopes: Array<string>;
+};
+
+export type ScheduledItemKind =
+  | 'habit'
+  | 'pomodoro'
+  | 'todo';
+
+export type UpdateActivityTypeArgs = {
+  color?: string | null | undefined;
+  id: string | number;
+  name?: string | null | undefined;
+};
+
+export type UpdateHabitArgs = {
+  activityTypeId?: string | number | null | undefined;
+  description?: string | null | undefined;
+  estimatedLength?: number | null | undefined;
+  frequencyCount?: number | null | undefined;
+  frequencyUnit?: string | null | undefined;
+  id: string | number;
+  minTimeBetweenInstances?: number | null | undefined;
+  pomodoroEnabled?: boolean | null | undefined;
+  pomodoroLongBreakLength?: number | null | undefined;
+  pomodoroShortBreakLength?: number | null | undefined;
+  pomodoroUnitLength?: number | null | undefined;
+  pomodoroUnitsBeforeLongBreak?: number | null | undefined;
+  priority?: number | null | undefined;
+  title?: string | null | undefined;
+};
+
+export type UpdateTimeBlockArgs = {
+  activityTypeId?: string | number | null | undefined;
+  daysOfWeek?: Array<number> | null | undefined;
+  endTime?: string | null | undefined;
+  id: string | number;
+  priority?: number | null | undefined;
+  startTime?: string | null | undefined;
+};
+
+export type UpdateTodoArgs = {
+  completedAt?: string | null | undefined;
+  description?: string | null | undefined;
+  dueAt?: string | null | undefined;
+  estimatedLength?: number | null | undefined;
+  id: string | number;
+  listId?: string | number | null | undefined;
+  manuallyScheduled?: boolean | null | undefined;
+  priority?: number | null | undefined;
+  scheduledAt?: string | null | undefined;
+  title?: string | null | undefined;
+};
+
+export type UpdateTodoListArgs = {
+  activityTypeId?: string | number | null | undefined;
+  defaultEstimatedLength?: number | null | undefined;
+  defaultPriority?: number | null | undefined;
+  description?: string | null | undefined;
+  id: string | number;
+  name?: string | null | undefined;
+};
+
+export type GetMyActivityTypesQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type GetMyActivityTypesQuery = { myActivityTypes: Array<{ id: string, name: string, color: string }> };
+
+export type GetActivityTypeStatsQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type GetActivityTypeStatsQuery = { activityTypeStats: Array<{ activityTypeId: string, totalTodos: number, completedTodos: number, totalHabits: number }> };
+
+export type GetCalendarDataQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type GetCalendarDataQuery = { myTimeBlocks: Array<{ id: string, daysOfWeek: Array<number>, startTime: string, endTime: string, activityType: { id: string, name: string, color: string } | null }> };
+
+export type MyScheduleQueryVariables = Exact<{
+  weekStart?: string | null | undefined;
+  timezone?: string | null | undefined;
+}>;
+
+
+export type MyScheduleQuery = { mySchedule: Array<{ id: string, kind: ScheduledItemKind, title: string, isScheduled: boolean, isOverdue: boolean, scheduledStart: string | null, scheduledEnd: string | null, completedAt: string | null, priority: number, estimatedLength: number, activityType: { id: string, name: string, color: string } | null }> };
+
+export type UpdateProfileMutationVariables = Exact<{
+  timezone: string;
+}>;
+
+
+export type UpdateProfileMutation = { myUpdateProfile: boolean };
+
+export type GetMyHabitsQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type GetMyHabitsQuery = { myHabits: Array<{ id: string, title: string, description: string | null, priority: number, estimatedLength: number, frequencyCount: number, frequencyUnit: string, minTimeBetweenInstances: number | null, pomodoroEnabled: boolean, pomodoroUnitLength: number | null, pomodoroShortBreakLength: number | null, pomodoroUnitsBeforeLongBreak: number | null, pomodoroLongBreakLength: number | null, createdAt: unknown, activityType: { id: string, name: string, color: string } | null }> };
+
+export type CheckOnboardedQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type CheckOnboardedQuery = { myActivityTypes: Array<{ id: string }> };
+
+export type GetMyStatsQueryVariables = Exact<{
+  startDate?: string | null | undefined;
+  endDate?: string | null | undefined;
+}>;
+
+
+export type GetMyStatsQuery = { myStats: { weightedScore: number | null, habitScore: number | null, todoScore: number | null, habits: Array<{ habitId: string, title: string, completionRate: number, completions: number, target: number, frequencyUnit: string, frequencyCount: number, activityType: { id: string, color: string } | null }>, todos: { total: number, completed: number, overdue: number, completionRate: number } } };
+
+export type GetActivityTypeStatsWithRangeQueryVariables = Exact<{
+  startDate?: string | null | undefined;
+  endDate?: string | null | undefined;
+}>;
+
+
+export type GetActivityTypeStatsWithRangeQuery = { activityTypeStats: Array<{ activityTypeId: string, activityTypeName: string, totalTodos: number, completedTodos: number, totalHabits: number }>, myActivityTypes: Array<{ id: string, name: string, color: string }> };
+
+export type GetMyTimeBlocksQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type GetMyTimeBlocksQuery = { myTimeBlocks: Array<{ id: string, daysOfWeek: Array<number>, startTime: string, endTime: string, priority: number, createdAt: unknown, activityType: { id: string, name: string, color: string } | null }> };
+
+export type GetTodoListsPageQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type GetTodoListsPageQuery = { myTodoLists: Array<{ id: string, name: string, description: string | null, defaultPriority: number, defaultEstimatedLength: number, activityType: { id: string, name: string, color: string } | null }>, myTodos: Array<{ id: string, title: string, description: string | null, priority: number, estimatedLength: number, dueAt: unknown, scheduledAt: unknown, completedAt: unknown, createdAt: unknown, list: { id: string, name: string } | null, activityType: { id: string, name: string, color: string } | null }> };
+
+export type RequestMagicLinkMutationVariables = Exact<{
+  email: string;
+}>;
+
+
+export type RequestMagicLinkMutation = { requestMagicLink: { ok: boolean, magicLink: string | null } };
+
+export type VerifyMagicLinkMutationVariables = Exact<{
+  token: string;
+}>;
+
+
+export type VerifyMagicLinkMutation = { verifyMagicLink: { token: string, userId: string } };
+
+export type CompleteTodoFromDialogMutationVariables = Exact<{
+  id: string | number;
+  completedAt?: string | null | undefined;
+}>;
+
+
+export type CompleteTodoFromDialogMutation = { myCompleteTodo: { id: string, completedAt: unknown, scheduledAt: unknown } };
+
+export type CompleteHabitFromDialogMutationVariables = Exact<{
+  input: CompleteHabitArgs;
+}>;
+
+
+export type CompleteHabitFromDialogMutation = { myCompleteHabit: { id: string, completedAt: unknown, scheduledAt: unknown } };
+
+export type CreateActivityTypeMutationVariables = Exact<{
+  input: CreateActivityTypeArgs;
+}>;
+
+
+export type CreateActivityTypeMutation = { myCreateActivityType: { id: string, name: string, color: string } };
+
+export type UpdateActivityTypeMutationVariables = Exact<{
+  input: UpdateActivityTypeArgs;
+}>;
+
+
+export type UpdateActivityTypeMutation = { myUpdateActivityType: { id: string, name: string, color: string } };
+
+export type DeleteActivityTypeMutationVariables = Exact<{
+  id: string | number;
+}>;
+
+
+export type DeleteActivityTypeMutation = { myDeleteActivityType: boolean };
+
+export type ActivityType_ActivityTypeListFragment = { id: string, name: string, color: string };
+
+export type GetActivityTypesForSelectQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type GetActivityTypesForSelectQuery = { myActivityTypes: Array<{ id: string, name: string, color: string }> };
+
+export type TimeBlock_CalendarViewFragment = { id: string, daysOfWeek: Array<number>, startTime: string, endTime: string, activityType: { id: string, name: string, color: string } | null };
+
+export type ScheduledItem_CalendarViewFragment = { kind: ScheduledItemKind, id: string, title: string, isScheduled: boolean, isOverdue: boolean, scheduledStart: string | null, scheduledEnd: string | null, completedAt: string | null, activityType: { id: string, name: string, color: string } | null };
+
+export type PinTodoMutationVariables = Exact<{
+  input: UpdateTodoArgs;
+}>;
+
+
+export type PinTodoMutation = { myUpdateTodo: { id: string, scheduledAt: unknown, manuallyScheduled: boolean } };
+
+export type CompleteHabitFromCalendarMutationVariables = Exact<{
+  input: CompleteHabitArgs;
+}>;
+
+
+export type CompleteHabitFromCalendarMutation = { myCompleteHabit: { __typename: 'HabitCompletion', id: string, completedAt: unknown } };
+
+export type CompleteTodoFromCalendarMutationVariables = Exact<{
+  id: string | number;
+}>;
+
+
+export type CompleteTodoFromCalendarMutation = { myCompleteTodo: { __typename: 'Todo', id: string, completedAt: unknown } };
+
+export type ScheduledItem_ScheduleViewFragment = { kind: ScheduledItemKind, id: string, title: string, priority: number, estimatedLength: number, isScheduled: boolean, scheduledStart: string | null, scheduledEnd: string | null, activityType: { id: string, name: string, color: string } | null };
+
+export type CompleteHabitFromScheduleMutationVariables = Exact<{
+  input: CompleteHabitArgs;
+}>;
+
+
+export type CompleteHabitFromScheduleMutation = { myCompleteHabit: { __typename: 'HabitCompletion', id: string, completedAt: unknown } };
+
+export type CompleteTodoFromScheduleMutationVariables = Exact<{
+  id: string | number;
+}>;
+
+
+export type CompleteTodoFromScheduleMutation = { myCompleteTodo: { __typename: 'Todo', id: string, completedAt: unknown } };
+
+export type GetHabitDetailQueryVariables = Exact<{
+  habitId: string | number;
+  periods?: number | null | undefined;
+}>;
+
+
+export type GetHabitDetailQuery = { myHabitDetail: { habitId: string, title: string, description: string | null, priority: number, estimatedLength: number, frequencyCount: number, frequencyUnit: string, totalCompletions: number, allTimeRate: number, activityType: { id: string, name: string, color: string } | null, periods: Array<{ label: string, periodStart: string, periodEnd: string, completions: number, target: number, rate: number }> } };
+
+export type CreateHabitMutationVariables = Exact<{
+  input: CreateHabitArgs;
+}>;
+
+
+export type CreateHabitMutation = { myCreateHabit: { id: string, title: string, description: string | null, priority: number, estimatedLength: number, frequencyCount: number, frequencyUnit: string, pomodoroEnabled: boolean, pomodoroUnitLength: number | null, pomodoroShortBreakLength: number | null, pomodoroUnitsBeforeLongBreak: number | null, pomodoroLongBreakLength: number | null, activityType: { id: string, name: string, color: string } | null } };
+
+export type UpdateHabitMutationVariables = Exact<{
+  input: UpdateHabitArgs;
+}>;
+
+
+export type UpdateHabitMutation = { myUpdateHabit: { id: string, title: string, description: string | null, priority: number, estimatedLength: number, frequencyCount: number, frequencyUnit: string, pomodoroEnabled: boolean, pomodoroUnitLength: number | null, pomodoroShortBreakLength: number | null, pomodoroUnitsBeforeLongBreak: number | null, pomodoroLongBreakLength: number | null, activityType: { id: string, name: string, color: string } | null } };
+
+export type UpdateHabitEstimatedLengthMutationVariables = Exact<{
+  input: UpdateHabitArgs;
+}>;
+
+
+export type UpdateHabitEstimatedLengthMutation = { myUpdateHabit: { id: string, estimatedLength: number } };
+
+export type Habit_HabitListFragment = { id: string, title: string, description: string | null, priority: number, estimatedLength: number, frequencyCount: number, frequencyUnit: string, minTimeBetweenInstances: number | null, pomodoroEnabled: boolean, pomodoroUnitLength: number | null, pomodoroShortBreakLength: number | null, pomodoroUnitsBeforeLongBreak: number | null, pomodoroLongBreakLength: number | null, createdAt: unknown, activityType: { id: string, name: string, color: string } | null };
+
+export type GetActivityTypesForOnboardingQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type GetActivityTypesForOnboardingQuery = { myActivityTypes: Array<{ id: string, name: string, color: string }> };
+
+export type CreateActivityTypeOnboardingMutationVariables = Exact<{
+  input: CreateActivityTypeArgs;
+}>;
+
+
+export type CreateActivityTypeOnboardingMutation = { myCreateActivityType: { id: string, name: string, color: string } };
+
+export type GetMyHabitsForOnboardingQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type GetMyHabitsForOnboardingQuery = { myHabits: Array<{ id: string, title: string, frequencyCount: number, frequencyUnit: string, activityType: { id: string, name: string, color: string } | null }> };
+
+export type CreateHabitOnboardingMutationVariables = Exact<{
+  input: CreateHabitArgs;
+}>;
+
+
+export type CreateHabitOnboardingMutation = { myCreateHabit: { id: string, title: string } };
+
+export type GetMyTimeblocksForOnboardingQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type GetMyTimeblocksForOnboardingQuery = { myTimeBlocks: Array<{ id: string, daysOfWeek: Array<number>, startTime: string, endTime: string, activityType: { id: string, name: string, color: string } | null }> };
+
+export type CreateTimeBlockOnboardingMutationVariables = Exact<{
+  input: CreateTimeBlockArgs;
+}>;
+
+
+export type CreateTimeBlockOnboardingMutation = { myCreateTimeBlock: { id: string, daysOfWeek: Array<number>, startTime: string, endTime: string } };
+
+export type GetMyTodosForOnboardingQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type GetMyTodosForOnboardingQuery = { myTodos: Array<{ id: string, title: string, priority: number, list: { id: string, name: string } | null, activityType: { id: string, name: string, color: string } | null }> };
+
+export type CreateTodoOnboardingMutationVariables = Exact<{
+  input: CreateTodoArgs;
+}>;
+
+
+export type CreateTodoOnboardingMutation = { myCreateTodo: { id: string, title: string } };
+
+export type MyApiKeysQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type MyApiKeysQuery = { myApiKeys: Array<{ id: string, name: string, keyPrefix: string, scopes: Array<string>, lastUsedAt: unknown, expiresAt: unknown, createdAt: unknown }> };
+
+export type MyRevokeApiKeyMutationVariables = Exact<{
+  id: string | number;
+}>;
+
+
+export type MyRevokeApiKeyMutation = { myRevokeApiKey: boolean };
+
+export type MyCreateApiKeyMutationVariables = Exact<{
+  input: MyCreateApiKeyInput;
+}>;
+
+
+export type MyCreateApiKeyMutation = { myCreateApiKey: { token: string, apiKey: { id: string, name: string, keyPrefix: string, scopes: Array<string>, createdAt: unknown } } };
+
+export type CreateTimeBlockMutationVariables = Exact<{
+  input: CreateTimeBlockArgs;
+}>;
+
+
+export type CreateTimeBlockMutation = { myCreateTimeBlock: { id: string, daysOfWeek: Array<number>, startTime: string, endTime: string, activityType: { id: string, name: string, color: string } | null } };
+
+export type UpdateTimeBlockMutationVariables = Exact<{
+  input: UpdateTimeBlockArgs;
+}>;
+
+
+export type UpdateTimeBlockMutation = { myUpdateTimeBlock: { id: string, daysOfWeek: Array<number>, startTime: string, endTime: string, activityType: { id: string, name: string, color: string } | null } };
+
+export type TimeBlock_TimeBlockListFragment = { id: string, daysOfWeek: Array<number>, startTime: string, endTime: string, priority: number, createdAt: unknown, activityType: { id: string, name: string, color: string } | null };
+
+export type QuickCreateTodoMutationVariables = Exact<{
+  input: CreateTodoArgs;
+}>;
+
+
+export type QuickCreateTodoMutation = { myCreateTodo: { id: string, title: string } };
+
+export type CreateTodoListMutationVariables = Exact<{
+  input: CreateTodoListArgs;
+}>;
+
+
+export type CreateTodoListMutation = { myCreateTodoList: { id: string, name: string, description: string | null, defaultPriority: number, defaultEstimatedLength: number, activityType: { id: string, name: string, color: string } | null } };
+
+export type UpdateTodoListMutationVariables = Exact<{
+  input: UpdateTodoListArgs;
+}>;
+
+
+export type UpdateTodoListMutation = { myUpdateTodoList: { id: string, name: string, description: string | null, defaultPriority: number, defaultEstimatedLength: number, activityType: { id: string, name: string, color: string } | null } };
+
+export type DeleteTodoListMutationVariables = Exact<{
+  id: string | number;
+}>;
+
+
+export type DeleteTodoListMutation = { myDeleteTodoList: boolean };
+
+export type TodoList_TodoListListFragment = { id: string, name: string, description: string | null, defaultPriority: number, defaultEstimatedLength: number, activityType: { id: string, name: string, color: string } | null };
+
+export type GetTodoListsForSelectQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type GetTodoListsForSelectQuery = { myTodoLists: Array<{ id: string, name: string, defaultPriority: number, defaultEstimatedLength: number, activityType: { id: string, name: string, color: string } | null }> };
+
+export type CreateTodoMutationVariables = Exact<{
+  input: CreateTodoArgs;
+}>;
+
+
+export type CreateTodoMutation = { myCreateTodo: { id: string, title: string, description: string | null, priority: number, estimatedLength: number, dueAt: unknown, scheduledAt: unknown, completedAt: unknown, list: { id: string, name: string } | null, activityType: { id: string, name: string, color: string } | null } };
+
+export type UpdateTodoMutationVariables = Exact<{
+  input: UpdateTodoArgs;
+}>;
+
+
+export type UpdateTodoMutation = { myUpdateTodo: { id: string, title: string, description: string | null, priority: number, estimatedLength: number, dueAt: unknown, scheduledAt: unknown, completedAt: unknown, list: { id: string, name: string } | null, activityType: { id: string, name: string, color: string } | null } };
+
+export type CompleteTodoFromFormMutationVariables = Exact<{
+  id: string | number;
+}>;
+
+
+export type CompleteTodoFromFormMutation = { myCompleteTodo: { id: string, completedAt: unknown } };
+
+export type Todo_TodoListFragment = { id: string, title: string, description: string | null, priority: number, estimatedLength: number, dueAt: unknown, scheduledAt: unknown, completedAt: unknown, createdAt: unknown, list: { id: string, name: string } | null, activityType: { id: string, name: string, color: string } | null };
+
+export type UpdateTodoEstimatedLengthMutationVariables = Exact<{
+  input: UpdateTodoArgs;
+}>;
+
+
+export type UpdateTodoEstimatedLengthMutation = { myUpdateTodo: { id: string, estimatedLength: number } };
+
+export type UncompleteTodoMutationVariables = Exact<{
+  id: string | number;
+}>;
+
+
+export type UncompleteTodoMutation = { myUpdateTodo: { id: string, completedAt: unknown } };
+
+export type DeleteTodoMutationVariables = Exact<{
+  id: string | number;
+}>;
+
+
+export type DeleteTodoMutation = { myDeleteTodo: boolean };
+
+export const ActivityType_ActivityTypeListFragmentDoc = {"kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"ActivityType_ActivityTypeList"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"ActivityType"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"color"}}]}}]} as unknown as DocumentNode<ActivityType_ActivityTypeListFragment, unknown>;
+export const TimeBlock_CalendarViewFragmentDoc = {"kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"TimeBlock_CalendarView"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"TimeBlock"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"daysOfWeek"}},{"kind":"Field","name":{"kind":"Name","value":"startTime"}},{"kind":"Field","name":{"kind":"Name","value":"endTime"}},{"kind":"Field","name":{"kind":"Name","value":"activityType"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"color"}}]}}]}}]} as unknown as DocumentNode<TimeBlock_CalendarViewFragment, unknown>;
+export const ScheduledItem_CalendarViewFragmentDoc = {"kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"ScheduledItem_CalendarView"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"ScheduledItem"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"kind"}},{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"title"}},{"kind":"Field","name":{"kind":"Name","value":"isScheduled"}},{"kind":"Field","name":{"kind":"Name","value":"isOverdue"}},{"kind":"Field","name":{"kind":"Name","value":"scheduledStart"}},{"kind":"Field","name":{"kind":"Name","value":"scheduledEnd"}},{"kind":"Field","name":{"kind":"Name","value":"completedAt"}},{"kind":"Field","name":{"kind":"Name","value":"activityType"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"color"}}]}}]}}]} as unknown as DocumentNode<ScheduledItem_CalendarViewFragment, unknown>;
+export const ScheduledItem_ScheduleViewFragmentDoc = {"kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"ScheduledItem_ScheduleView"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"ScheduledItem"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"kind"}},{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"title"}},{"kind":"Field","name":{"kind":"Name","value":"priority"}},{"kind":"Field","name":{"kind":"Name","value":"estimatedLength"}},{"kind":"Field","name":{"kind":"Name","value":"isScheduled"}},{"kind":"Field","name":{"kind":"Name","value":"scheduledStart"}},{"kind":"Field","name":{"kind":"Name","value":"scheduledEnd"}},{"kind":"Field","name":{"kind":"Name","value":"activityType"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"color"}}]}}]}}]} as unknown as DocumentNode<ScheduledItem_ScheduleViewFragment, unknown>;
+export const Habit_HabitListFragmentDoc = {"kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"Habit_HabitList"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Habit"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"title"}},{"kind":"Field","name":{"kind":"Name","value":"description"}},{"kind":"Field","name":{"kind":"Name","value":"priority"}},{"kind":"Field","name":{"kind":"Name","value":"estimatedLength"}},{"kind":"Field","name":{"kind":"Name","value":"activityType"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"color"}}]}},{"kind":"Field","name":{"kind":"Name","value":"frequencyCount"}},{"kind":"Field","name":{"kind":"Name","value":"frequencyUnit"}},{"kind":"Field","name":{"kind":"Name","value":"minTimeBetweenInstances"}},{"kind":"Field","name":{"kind":"Name","value":"pomodoroEnabled"}},{"kind":"Field","name":{"kind":"Name","value":"pomodoroUnitLength"}},{"kind":"Field","name":{"kind":"Name","value":"pomodoroShortBreakLength"}},{"kind":"Field","name":{"kind":"Name","value":"pomodoroUnitsBeforeLongBreak"}},{"kind":"Field","name":{"kind":"Name","value":"pomodoroLongBreakLength"}},{"kind":"Field","name":{"kind":"Name","value":"createdAt"}}]}}]} as unknown as DocumentNode<Habit_HabitListFragment, unknown>;
+export const TimeBlock_TimeBlockListFragmentDoc = {"kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"TimeBlock_TimeBlockList"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"TimeBlock"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"activityType"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"color"}}]}},{"kind":"Field","name":{"kind":"Name","value":"daysOfWeek"}},{"kind":"Field","name":{"kind":"Name","value":"startTime"}},{"kind":"Field","name":{"kind":"Name","value":"endTime"}},{"kind":"Field","name":{"kind":"Name","value":"priority"}},{"kind":"Field","name":{"kind":"Name","value":"createdAt"}}]}}]} as unknown as DocumentNode<TimeBlock_TimeBlockListFragment, unknown>;
+export const TodoList_TodoListListFragmentDoc = {"kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"TodoList_TodoListList"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"TodoList"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"description"}},{"kind":"Field","name":{"kind":"Name","value":"defaultPriority"}},{"kind":"Field","name":{"kind":"Name","value":"defaultEstimatedLength"}},{"kind":"Field","name":{"kind":"Name","value":"activityType"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"color"}}]}}]}}]} as unknown as DocumentNode<TodoList_TodoListListFragment, unknown>;
+export const Todo_TodoListFragmentDoc = {"kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"Todo_TodoList"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Todo"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"title"}},{"kind":"Field","name":{"kind":"Name","value":"description"}},{"kind":"Field","name":{"kind":"Name","value":"priority"}},{"kind":"Field","name":{"kind":"Name","value":"estimatedLength"}},{"kind":"Field","name":{"kind":"Name","value":"list"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}}]}},{"kind":"Field","name":{"kind":"Name","value":"activityType"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"color"}}]}},{"kind":"Field","name":{"kind":"Name","value":"dueAt"}},{"kind":"Field","name":{"kind":"Name","value":"scheduledAt"}},{"kind":"Field","name":{"kind":"Name","value":"completedAt"}},{"kind":"Field","name":{"kind":"Name","value":"createdAt"}}]}}]} as unknown as DocumentNode<Todo_TodoListFragment, unknown>;
+export const GetMyActivityTypesDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetMyActivityTypes"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"myActivityTypes"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"ActivityType_ActivityTypeList"}}]}}]}},{"kind":"FragmentDefinition","name":{"kind":"Name","value":"ActivityType_ActivityTypeList"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"ActivityType"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"color"}}]}}]} as unknown as DocumentNode<GetMyActivityTypesQuery, GetMyActivityTypesQueryVariables>;
+export const GetActivityTypeStatsDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetActivityTypeStats"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"activityTypeStats"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"activityTypeId"}},{"kind":"Field","name":{"kind":"Name","value":"totalTodos"}},{"kind":"Field","name":{"kind":"Name","value":"completedTodos"}},{"kind":"Field","name":{"kind":"Name","value":"totalHabits"}}]}}]}}]} as unknown as DocumentNode<GetActivityTypeStatsQuery, GetActivityTypeStatsQueryVariables>;
+export const GetCalendarDataDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetCalendarData"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"myTimeBlocks"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"FragmentSpread","name":{"kind":"Name","value":"TimeBlock_CalendarView"}}]}}]}},{"kind":"FragmentDefinition","name":{"kind":"Name","value":"TimeBlock_CalendarView"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"TimeBlock"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"daysOfWeek"}},{"kind":"Field","name":{"kind":"Name","value":"startTime"}},{"kind":"Field","name":{"kind":"Name","value":"endTime"}},{"kind":"Field","name":{"kind":"Name","value":"activityType"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"color"}}]}}]}}]} as unknown as DocumentNode<GetCalendarDataQuery, GetCalendarDataQueryVariables>;
+export const MyScheduleDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"MySchedule"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"weekStart"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"timezone"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"mySchedule"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"weekStart"},"value":{"kind":"Variable","name":{"kind":"Name","value":"weekStart"}}},{"kind":"Argument","name":{"kind":"Name","value":"timezone"},"value":{"kind":"Variable","name":{"kind":"Name","value":"timezone"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"FragmentSpread","name":{"kind":"Name","value":"ScheduledItem_CalendarView"}},{"kind":"FragmentSpread","name":{"kind":"Name","value":"ScheduledItem_ScheduleView"}}]}}]}},{"kind":"FragmentDefinition","name":{"kind":"Name","value":"ScheduledItem_CalendarView"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"ScheduledItem"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"kind"}},{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"title"}},{"kind":"Field","name":{"kind":"Name","value":"isScheduled"}},{"kind":"Field","name":{"kind":"Name","value":"isOverdue"}},{"kind":"Field","name":{"kind":"Name","value":"scheduledStart"}},{"kind":"Field","name":{"kind":"Name","value":"scheduledEnd"}},{"kind":"Field","name":{"kind":"Name","value":"completedAt"}},{"kind":"Field","name":{"kind":"Name","value":"activityType"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"color"}}]}}]}},{"kind":"FragmentDefinition","name":{"kind":"Name","value":"ScheduledItem_ScheduleView"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"ScheduledItem"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"kind"}},{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"title"}},{"kind":"Field","name":{"kind":"Name","value":"priority"}},{"kind":"Field","name":{"kind":"Name","value":"estimatedLength"}},{"kind":"Field","name":{"kind":"Name","value":"isScheduled"}},{"kind":"Field","name":{"kind":"Name","value":"scheduledStart"}},{"kind":"Field","name":{"kind":"Name","value":"scheduledEnd"}},{"kind":"Field","name":{"kind":"Name","value":"activityType"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"color"}}]}}]}}]} as unknown as DocumentNode<MyScheduleQuery, MyScheduleQueryVariables>;
+export const UpdateProfileDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"UpdateProfile"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"timezone"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"myUpdateProfile"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"timezone"},"value":{"kind":"Variable","name":{"kind":"Name","value":"timezone"}}}]}]}}]} as unknown as DocumentNode<UpdateProfileMutation, UpdateProfileMutationVariables>;
+export const GetMyHabitsDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetMyHabits"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"myHabits"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"Habit_HabitList"}}]}}]}},{"kind":"FragmentDefinition","name":{"kind":"Name","value":"Habit_HabitList"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Habit"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"title"}},{"kind":"Field","name":{"kind":"Name","value":"description"}},{"kind":"Field","name":{"kind":"Name","value":"priority"}},{"kind":"Field","name":{"kind":"Name","value":"estimatedLength"}},{"kind":"Field","name":{"kind":"Name","value":"activityType"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"color"}}]}},{"kind":"Field","name":{"kind":"Name","value":"frequencyCount"}},{"kind":"Field","name":{"kind":"Name","value":"frequencyUnit"}},{"kind":"Field","name":{"kind":"Name","value":"minTimeBetweenInstances"}},{"kind":"Field","name":{"kind":"Name","value":"pomodoroEnabled"}},{"kind":"Field","name":{"kind":"Name","value":"pomodoroUnitLength"}},{"kind":"Field","name":{"kind":"Name","value":"pomodoroShortBreakLength"}},{"kind":"Field","name":{"kind":"Name","value":"pomodoroUnitsBeforeLongBreak"}},{"kind":"Field","name":{"kind":"Name","value":"pomodoroLongBreakLength"}},{"kind":"Field","name":{"kind":"Name","value":"createdAt"}}]}}]} as unknown as DocumentNode<GetMyHabitsQuery, GetMyHabitsQueryVariables>;
+export const CheckOnboardedDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"CheckOnboarded"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"myActivityTypes"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}}]}}]}}]} as unknown as DocumentNode<CheckOnboardedQuery, CheckOnboardedQueryVariables>;
+export const GetMyStatsDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetMyStats"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"startDate"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"endDate"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"myStats"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"startDate"},"value":{"kind":"Variable","name":{"kind":"Name","value":"startDate"}}},{"kind":"Argument","name":{"kind":"Name","value":"endDate"},"value":{"kind":"Variable","name":{"kind":"Name","value":"endDate"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"weightedScore"}},{"kind":"Field","name":{"kind":"Name","value":"habitScore"}},{"kind":"Field","name":{"kind":"Name","value":"todoScore"}},{"kind":"Field","name":{"kind":"Name","value":"habits"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"habitId"}},{"kind":"Field","name":{"kind":"Name","value":"title"}},{"kind":"Field","name":{"kind":"Name","value":"completionRate"}},{"kind":"Field","name":{"kind":"Name","value":"completions"}},{"kind":"Field","name":{"kind":"Name","value":"target"}},{"kind":"Field","name":{"kind":"Name","value":"frequencyUnit"}},{"kind":"Field","name":{"kind":"Name","value":"frequencyCount"}},{"kind":"Field","name":{"kind":"Name","value":"activityType"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"color"}}]}}]}},{"kind":"Field","name":{"kind":"Name","value":"todos"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"total"}},{"kind":"Field","name":{"kind":"Name","value":"completed"}},{"kind":"Field","name":{"kind":"Name","value":"overdue"}},{"kind":"Field","name":{"kind":"Name","value":"completionRate"}}]}}]}}]}}]} as unknown as DocumentNode<GetMyStatsQuery, GetMyStatsQueryVariables>;
+export const GetActivityTypeStatsWithRangeDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetActivityTypeStatsWithRange"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"startDate"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"endDate"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"activityTypeStats"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"startDate"},"value":{"kind":"Variable","name":{"kind":"Name","value":"startDate"}}},{"kind":"Argument","name":{"kind":"Name","value":"endDate"},"value":{"kind":"Variable","name":{"kind":"Name","value":"endDate"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"activityTypeId"}},{"kind":"Field","name":{"kind":"Name","value":"activityTypeName"}},{"kind":"Field","name":{"kind":"Name","value":"totalTodos"}},{"kind":"Field","name":{"kind":"Name","value":"completedTodos"}},{"kind":"Field","name":{"kind":"Name","value":"totalHabits"}}]}},{"kind":"Field","name":{"kind":"Name","value":"myActivityTypes"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"color"}}]}}]}}]} as unknown as DocumentNode<GetActivityTypeStatsWithRangeQuery, GetActivityTypeStatsWithRangeQueryVariables>;
+export const GetMyTimeBlocksDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetMyTimeBlocks"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"myTimeBlocks"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"TimeBlock_TimeBlockList"}}]}}]}},{"kind":"FragmentDefinition","name":{"kind":"Name","value":"TimeBlock_TimeBlockList"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"TimeBlock"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"activityType"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"color"}}]}},{"kind":"Field","name":{"kind":"Name","value":"daysOfWeek"}},{"kind":"Field","name":{"kind":"Name","value":"startTime"}},{"kind":"Field","name":{"kind":"Name","value":"endTime"}},{"kind":"Field","name":{"kind":"Name","value":"priority"}},{"kind":"Field","name":{"kind":"Name","value":"createdAt"}}]}}]} as unknown as DocumentNode<GetMyTimeBlocksQuery, GetMyTimeBlocksQueryVariables>;
+export const GetTodoListsPageDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetTodoListsPage"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"myTodoLists"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"TodoList_TodoListList"}}]}},{"kind":"Field","name":{"kind":"Name","value":"myTodos"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"Todo_TodoList"}}]}}]}},{"kind":"FragmentDefinition","name":{"kind":"Name","value":"TodoList_TodoListList"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"TodoList"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"description"}},{"kind":"Field","name":{"kind":"Name","value":"defaultPriority"}},{"kind":"Field","name":{"kind":"Name","value":"defaultEstimatedLength"}},{"kind":"Field","name":{"kind":"Name","value":"activityType"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"color"}}]}}]}},{"kind":"FragmentDefinition","name":{"kind":"Name","value":"Todo_TodoList"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Todo"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"title"}},{"kind":"Field","name":{"kind":"Name","value":"description"}},{"kind":"Field","name":{"kind":"Name","value":"priority"}},{"kind":"Field","name":{"kind":"Name","value":"estimatedLength"}},{"kind":"Field","name":{"kind":"Name","value":"list"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}}]}},{"kind":"Field","name":{"kind":"Name","value":"activityType"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"color"}}]}},{"kind":"Field","name":{"kind":"Name","value":"dueAt"}},{"kind":"Field","name":{"kind":"Name","value":"scheduledAt"}},{"kind":"Field","name":{"kind":"Name","value":"completedAt"}},{"kind":"Field","name":{"kind":"Name","value":"createdAt"}}]}}]} as unknown as DocumentNode<GetTodoListsPageQuery, GetTodoListsPageQueryVariables>;
+export const RequestMagicLinkDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"RequestMagicLink"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"email"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"requestMagicLink"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"email"},"value":{"kind":"Variable","name":{"kind":"Name","value":"email"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"ok"}},{"kind":"Field","name":{"kind":"Name","value":"magicLink"}}]}}]}}]} as unknown as DocumentNode<RequestMagicLinkMutation, RequestMagicLinkMutationVariables>;
+export const VerifyMagicLinkDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"VerifyMagicLink"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"token"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"verifyMagicLink"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"token"},"value":{"kind":"Variable","name":{"kind":"Name","value":"token"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"token"}},{"kind":"Field","name":{"kind":"Name","value":"userId"}}]}}]}}]} as unknown as DocumentNode<VerifyMagicLinkMutation, VerifyMagicLinkMutationVariables>;
+export const CompleteTodoFromDialogDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"CompleteTodoFromDialog"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"id"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"ID"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"completedAt"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"myCompleteTodo"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"id"}}},{"kind":"Argument","name":{"kind":"Name","value":"completedAt"},"value":{"kind":"Variable","name":{"kind":"Name","value":"completedAt"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"completedAt"}},{"kind":"Field","name":{"kind":"Name","value":"scheduledAt"}}]}}]}}]} as unknown as DocumentNode<CompleteTodoFromDialogMutation, CompleteTodoFromDialogMutationVariables>;
+export const CompleteHabitFromDialogDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"CompleteHabitFromDialog"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"input"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"CompleteHabitArgs"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"myCompleteHabit"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"input"},"value":{"kind":"Variable","name":{"kind":"Name","value":"input"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"completedAt"}},{"kind":"Field","name":{"kind":"Name","value":"scheduledAt"}}]}}]}}]} as unknown as DocumentNode<CompleteHabitFromDialogMutation, CompleteHabitFromDialogMutationVariables>;
+export const CreateActivityTypeDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"CreateActivityType"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"input"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"CreateActivityTypeArgs"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"myCreateActivityType"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"input"},"value":{"kind":"Variable","name":{"kind":"Name","value":"input"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"color"}}]}}]}}]} as unknown as DocumentNode<CreateActivityTypeMutation, CreateActivityTypeMutationVariables>;
+export const UpdateActivityTypeDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"UpdateActivityType"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"input"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"UpdateActivityTypeArgs"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"myUpdateActivityType"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"input"},"value":{"kind":"Variable","name":{"kind":"Name","value":"input"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"color"}}]}}]}}]} as unknown as DocumentNode<UpdateActivityTypeMutation, UpdateActivityTypeMutationVariables>;
+export const DeleteActivityTypeDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"DeleteActivityType"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"id"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"ID"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"myDeleteActivityType"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"id"}}}]}]}}]} as unknown as DocumentNode<DeleteActivityTypeMutation, DeleteActivityTypeMutationVariables>;
+export const GetActivityTypesForSelectDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetActivityTypesForSelect"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"myActivityTypes"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"color"}}]}}]}}]} as unknown as DocumentNode<GetActivityTypesForSelectQuery, GetActivityTypesForSelectQueryVariables>;
+export const PinTodoDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"PinTodo"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"input"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"UpdateTodoArgs"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"myUpdateTodo"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"input"},"value":{"kind":"Variable","name":{"kind":"Name","value":"input"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"scheduledAt"}},{"kind":"Field","name":{"kind":"Name","value":"manuallyScheduled"}}]}}]}}]} as unknown as DocumentNode<PinTodoMutation, PinTodoMutationVariables>;
+export const CompleteHabitFromCalendarDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"CompleteHabitFromCalendar"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"input"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"CompleteHabitArgs"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"myCompleteHabit"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"input"},"value":{"kind":"Variable","name":{"kind":"Name","value":"input"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"__typename"}},{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"completedAt"}}]}}]}}]} as unknown as DocumentNode<CompleteHabitFromCalendarMutation, CompleteHabitFromCalendarMutationVariables>;
+export const CompleteTodoFromCalendarDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"CompleteTodoFromCalendar"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"id"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"ID"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"myCompleteTodo"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"id"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"__typename"}},{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"completedAt"}}]}}]}}]} as unknown as DocumentNode<CompleteTodoFromCalendarMutation, CompleteTodoFromCalendarMutationVariables>;
+export const CompleteHabitFromScheduleDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"CompleteHabitFromSchedule"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"input"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"CompleteHabitArgs"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"myCompleteHabit"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"input"},"value":{"kind":"Variable","name":{"kind":"Name","value":"input"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"__typename"}},{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"completedAt"}}]}}]}}]} as unknown as DocumentNode<CompleteHabitFromScheduleMutation, CompleteHabitFromScheduleMutationVariables>;
+export const CompleteTodoFromScheduleDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"CompleteTodoFromSchedule"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"id"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"ID"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"myCompleteTodo"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"id"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"__typename"}},{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"completedAt"}}]}}]}}]} as unknown as DocumentNode<CompleteTodoFromScheduleMutation, CompleteTodoFromScheduleMutationVariables>;
+export const GetHabitDetailDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetHabitDetail"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"habitId"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"ID"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"periods"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"Int"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"myHabitDetail"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"habitId"},"value":{"kind":"Variable","name":{"kind":"Name","value":"habitId"}}},{"kind":"Argument","name":{"kind":"Name","value":"periods"},"value":{"kind":"Variable","name":{"kind":"Name","value":"periods"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"habitId"}},{"kind":"Field","name":{"kind":"Name","value":"title"}},{"kind":"Field","name":{"kind":"Name","value":"description"}},{"kind":"Field","name":{"kind":"Name","value":"priority"}},{"kind":"Field","name":{"kind":"Name","value":"estimatedLength"}},{"kind":"Field","name":{"kind":"Name","value":"frequencyCount"}},{"kind":"Field","name":{"kind":"Name","value":"frequencyUnit"}},{"kind":"Field","name":{"kind":"Name","value":"totalCompletions"}},{"kind":"Field","name":{"kind":"Name","value":"allTimeRate"}},{"kind":"Field","name":{"kind":"Name","value":"activityType"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"color"}}]}},{"kind":"Field","name":{"kind":"Name","value":"periods"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"label"}},{"kind":"Field","name":{"kind":"Name","value":"periodStart"}},{"kind":"Field","name":{"kind":"Name","value":"periodEnd"}},{"kind":"Field","name":{"kind":"Name","value":"completions"}},{"kind":"Field","name":{"kind":"Name","value":"target"}},{"kind":"Field","name":{"kind":"Name","value":"rate"}}]}}]}}]}}]} as unknown as DocumentNode<GetHabitDetailQuery, GetHabitDetailQueryVariables>;
+export const CreateHabitDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"CreateHabit"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"input"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"CreateHabitArgs"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"myCreateHabit"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"input"},"value":{"kind":"Variable","name":{"kind":"Name","value":"input"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"title"}},{"kind":"Field","name":{"kind":"Name","value":"description"}},{"kind":"Field","name":{"kind":"Name","value":"activityType"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"color"}}]}},{"kind":"Field","name":{"kind":"Name","value":"priority"}},{"kind":"Field","name":{"kind":"Name","value":"estimatedLength"}},{"kind":"Field","name":{"kind":"Name","value":"frequencyCount"}},{"kind":"Field","name":{"kind":"Name","value":"frequencyUnit"}},{"kind":"Field","name":{"kind":"Name","value":"pomodoroEnabled"}},{"kind":"Field","name":{"kind":"Name","value":"pomodoroUnitLength"}},{"kind":"Field","name":{"kind":"Name","value":"pomodoroShortBreakLength"}},{"kind":"Field","name":{"kind":"Name","value":"pomodoroUnitsBeforeLongBreak"}},{"kind":"Field","name":{"kind":"Name","value":"pomodoroLongBreakLength"}}]}}]}}]} as unknown as DocumentNode<CreateHabitMutation, CreateHabitMutationVariables>;
+export const UpdateHabitDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"UpdateHabit"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"input"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"UpdateHabitArgs"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"myUpdateHabit"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"input"},"value":{"kind":"Variable","name":{"kind":"Name","value":"input"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"title"}},{"kind":"Field","name":{"kind":"Name","value":"description"}},{"kind":"Field","name":{"kind":"Name","value":"activityType"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"color"}}]}},{"kind":"Field","name":{"kind":"Name","value":"priority"}},{"kind":"Field","name":{"kind":"Name","value":"estimatedLength"}},{"kind":"Field","name":{"kind":"Name","value":"frequencyCount"}},{"kind":"Field","name":{"kind":"Name","value":"frequencyUnit"}},{"kind":"Field","name":{"kind":"Name","value":"pomodoroEnabled"}},{"kind":"Field","name":{"kind":"Name","value":"pomodoroUnitLength"}},{"kind":"Field","name":{"kind":"Name","value":"pomodoroShortBreakLength"}},{"kind":"Field","name":{"kind":"Name","value":"pomodoroUnitsBeforeLongBreak"}},{"kind":"Field","name":{"kind":"Name","value":"pomodoroLongBreakLength"}}]}}]}}]} as unknown as DocumentNode<UpdateHabitMutation, UpdateHabitMutationVariables>;
+export const UpdateHabitEstimatedLengthDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"UpdateHabitEstimatedLength"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"input"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"UpdateHabitArgs"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"myUpdateHabit"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"input"},"value":{"kind":"Variable","name":{"kind":"Name","value":"input"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"estimatedLength"}}]}}]}}]} as unknown as DocumentNode<UpdateHabitEstimatedLengthMutation, UpdateHabitEstimatedLengthMutationVariables>;
+export const GetActivityTypesForOnboardingDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetActivityTypesForOnboarding"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"myActivityTypes"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"color"}}]}}]}}]} as unknown as DocumentNode<GetActivityTypesForOnboardingQuery, GetActivityTypesForOnboardingQueryVariables>;
+export const CreateActivityTypeOnboardingDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"CreateActivityTypeOnboarding"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"input"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"CreateActivityTypeArgs"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"myCreateActivityType"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"input"},"value":{"kind":"Variable","name":{"kind":"Name","value":"input"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"color"}}]}}]}}]} as unknown as DocumentNode<CreateActivityTypeOnboardingMutation, CreateActivityTypeOnboardingMutationVariables>;
+export const GetMyHabitsForOnboardingDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetMyHabitsForOnboarding"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"myHabits"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"title"}},{"kind":"Field","name":{"kind":"Name","value":"frequencyCount"}},{"kind":"Field","name":{"kind":"Name","value":"frequencyUnit"}},{"kind":"Field","name":{"kind":"Name","value":"activityType"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"color"}}]}}]}}]}}]} as unknown as DocumentNode<GetMyHabitsForOnboardingQuery, GetMyHabitsForOnboardingQueryVariables>;
+export const CreateHabitOnboardingDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"CreateHabitOnboarding"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"input"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"CreateHabitArgs"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"myCreateHabit"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"input"},"value":{"kind":"Variable","name":{"kind":"Name","value":"input"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"title"}}]}}]}}]} as unknown as DocumentNode<CreateHabitOnboardingMutation, CreateHabitOnboardingMutationVariables>;
+export const GetMyTimeblocksForOnboardingDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetMyTimeblocksForOnboarding"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"myTimeBlocks"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"activityType"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"color"}}]}},{"kind":"Field","name":{"kind":"Name","value":"daysOfWeek"}},{"kind":"Field","name":{"kind":"Name","value":"startTime"}},{"kind":"Field","name":{"kind":"Name","value":"endTime"}}]}}]}}]} as unknown as DocumentNode<GetMyTimeblocksForOnboardingQuery, GetMyTimeblocksForOnboardingQueryVariables>;
+export const CreateTimeBlockOnboardingDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"CreateTimeBlockOnboarding"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"input"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"CreateTimeBlockArgs"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"myCreateTimeBlock"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"input"},"value":{"kind":"Variable","name":{"kind":"Name","value":"input"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"daysOfWeek"}},{"kind":"Field","name":{"kind":"Name","value":"startTime"}},{"kind":"Field","name":{"kind":"Name","value":"endTime"}}]}}]}}]} as unknown as DocumentNode<CreateTimeBlockOnboardingMutation, CreateTimeBlockOnboardingMutationVariables>;
+export const GetMyTodosForOnboardingDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetMyTodosForOnboarding"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"myTodos"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"title"}},{"kind":"Field","name":{"kind":"Name","value":"priority"}},{"kind":"Field","name":{"kind":"Name","value":"list"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}}]}},{"kind":"Field","name":{"kind":"Name","value":"activityType"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"color"}}]}}]}}]}}]} as unknown as DocumentNode<GetMyTodosForOnboardingQuery, GetMyTodosForOnboardingQueryVariables>;
+export const CreateTodoOnboardingDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"CreateTodoOnboarding"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"input"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"CreateTodoArgs"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"myCreateTodo"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"input"},"value":{"kind":"Variable","name":{"kind":"Name","value":"input"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"title"}}]}}]}}]} as unknown as DocumentNode<CreateTodoOnboardingMutation, CreateTodoOnboardingMutationVariables>;
+export const MyApiKeysDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"MyApiKeys"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"myApiKeys"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"keyPrefix"}},{"kind":"Field","name":{"kind":"Name","value":"scopes"}},{"kind":"Field","name":{"kind":"Name","value":"lastUsedAt"}},{"kind":"Field","name":{"kind":"Name","value":"expiresAt"}},{"kind":"Field","name":{"kind":"Name","value":"createdAt"}}]}}]}}]} as unknown as DocumentNode<MyApiKeysQuery, MyApiKeysQueryVariables>;
+export const MyRevokeApiKeyDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"MyRevokeApiKey"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"id"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"ID"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"myRevokeApiKey"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"id"}}}]}]}}]} as unknown as DocumentNode<MyRevokeApiKeyMutation, MyRevokeApiKeyMutationVariables>;
+export const MyCreateApiKeyDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"MyCreateApiKey"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"input"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"MyCreateApiKeyInput"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"myCreateApiKey"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"input"},"value":{"kind":"Variable","name":{"kind":"Name","value":"input"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"apiKey"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"keyPrefix"}},{"kind":"Field","name":{"kind":"Name","value":"scopes"}},{"kind":"Field","name":{"kind":"Name","value":"createdAt"}}]}},{"kind":"Field","name":{"kind":"Name","value":"token"}}]}}]}}]} as unknown as DocumentNode<MyCreateApiKeyMutation, MyCreateApiKeyMutationVariables>;
+export const CreateTimeBlockDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"CreateTimeBlock"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"input"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"CreateTimeBlockArgs"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"myCreateTimeBlock"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"input"},"value":{"kind":"Variable","name":{"kind":"Name","value":"input"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"activityType"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"color"}}]}},{"kind":"Field","name":{"kind":"Name","value":"daysOfWeek"}},{"kind":"Field","name":{"kind":"Name","value":"startTime"}},{"kind":"Field","name":{"kind":"Name","value":"endTime"}}]}}]}}]} as unknown as DocumentNode<CreateTimeBlockMutation, CreateTimeBlockMutationVariables>;
+export const UpdateTimeBlockDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"UpdateTimeBlock"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"input"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"UpdateTimeBlockArgs"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"myUpdateTimeBlock"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"input"},"value":{"kind":"Variable","name":{"kind":"Name","value":"input"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"activityType"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"color"}}]}},{"kind":"Field","name":{"kind":"Name","value":"daysOfWeek"}},{"kind":"Field","name":{"kind":"Name","value":"startTime"}},{"kind":"Field","name":{"kind":"Name","value":"endTime"}}]}}]}}]} as unknown as DocumentNode<UpdateTimeBlockMutation, UpdateTimeBlockMutationVariables>;
+export const QuickCreateTodoDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"QuickCreateTodo"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"input"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"CreateTodoArgs"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"myCreateTodo"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"input"},"value":{"kind":"Variable","name":{"kind":"Name","value":"input"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"title"}}]}}]}}]} as unknown as DocumentNode<QuickCreateTodoMutation, QuickCreateTodoMutationVariables>;
+export const CreateTodoListDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"CreateTodoList"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"input"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"CreateTodoListArgs"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"myCreateTodoList"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"input"},"value":{"kind":"Variable","name":{"kind":"Name","value":"input"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"description"}},{"kind":"Field","name":{"kind":"Name","value":"defaultPriority"}},{"kind":"Field","name":{"kind":"Name","value":"defaultEstimatedLength"}},{"kind":"Field","name":{"kind":"Name","value":"activityType"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"color"}}]}}]}}]}}]} as unknown as DocumentNode<CreateTodoListMutation, CreateTodoListMutationVariables>;
+export const UpdateTodoListDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"UpdateTodoList"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"input"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"UpdateTodoListArgs"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"myUpdateTodoList"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"input"},"value":{"kind":"Variable","name":{"kind":"Name","value":"input"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"description"}},{"kind":"Field","name":{"kind":"Name","value":"defaultPriority"}},{"kind":"Field","name":{"kind":"Name","value":"defaultEstimatedLength"}},{"kind":"Field","name":{"kind":"Name","value":"activityType"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"color"}}]}}]}}]}}]} as unknown as DocumentNode<UpdateTodoListMutation, UpdateTodoListMutationVariables>;
+export const DeleteTodoListDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"DeleteTodoList"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"id"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"ID"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"myDeleteTodoList"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"id"}}}]}]}}]} as unknown as DocumentNode<DeleteTodoListMutation, DeleteTodoListMutationVariables>;
+export const GetTodoListsForSelectDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetTodoListsForSelect"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"myTodoLists"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"defaultPriority"}},{"kind":"Field","name":{"kind":"Name","value":"defaultEstimatedLength"}},{"kind":"Field","name":{"kind":"Name","value":"activityType"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"color"}}]}}]}}]}}]} as unknown as DocumentNode<GetTodoListsForSelectQuery, GetTodoListsForSelectQueryVariables>;
+export const CreateTodoDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"CreateTodo"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"input"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"CreateTodoArgs"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"myCreateTodo"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"input"},"value":{"kind":"Variable","name":{"kind":"Name","value":"input"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"title"}},{"kind":"Field","name":{"kind":"Name","value":"description"}},{"kind":"Field","name":{"kind":"Name","value":"list"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}}]}},{"kind":"Field","name":{"kind":"Name","value":"activityType"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"color"}}]}},{"kind":"Field","name":{"kind":"Name","value":"priority"}},{"kind":"Field","name":{"kind":"Name","value":"estimatedLength"}},{"kind":"Field","name":{"kind":"Name","value":"dueAt"}},{"kind":"Field","name":{"kind":"Name","value":"scheduledAt"}},{"kind":"Field","name":{"kind":"Name","value":"completedAt"}}]}}]}}]} as unknown as DocumentNode<CreateTodoMutation, CreateTodoMutationVariables>;
+export const UpdateTodoDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"UpdateTodo"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"input"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"UpdateTodoArgs"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"myUpdateTodo"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"input"},"value":{"kind":"Variable","name":{"kind":"Name","value":"input"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"title"}},{"kind":"Field","name":{"kind":"Name","value":"description"}},{"kind":"Field","name":{"kind":"Name","value":"list"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}}]}},{"kind":"Field","name":{"kind":"Name","value":"activityType"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"color"}}]}},{"kind":"Field","name":{"kind":"Name","value":"priority"}},{"kind":"Field","name":{"kind":"Name","value":"estimatedLength"}},{"kind":"Field","name":{"kind":"Name","value":"dueAt"}},{"kind":"Field","name":{"kind":"Name","value":"scheduledAt"}},{"kind":"Field","name":{"kind":"Name","value":"completedAt"}}]}}]}}]} as unknown as DocumentNode<UpdateTodoMutation, UpdateTodoMutationVariables>;
+export const CompleteTodoFromFormDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"CompleteTodoFromForm"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"id"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"ID"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"myCompleteTodo"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"id"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"completedAt"}}]}}]}}]} as unknown as DocumentNode<CompleteTodoFromFormMutation, CompleteTodoFromFormMutationVariables>;
+export const UpdateTodoEstimatedLengthDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"UpdateTodoEstimatedLength"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"input"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"UpdateTodoArgs"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"myUpdateTodo"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"input"},"value":{"kind":"Variable","name":{"kind":"Name","value":"input"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"estimatedLength"}}]}}]}}]} as unknown as DocumentNode<UpdateTodoEstimatedLengthMutation, UpdateTodoEstimatedLengthMutationVariables>;
+export const UncompleteTodoDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"UncompleteTodo"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"id"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"ID"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"myUpdateTodo"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"input"},"value":{"kind":"ObjectValue","fields":[{"kind":"ObjectField","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"id"}}},{"kind":"ObjectField","name":{"kind":"Name","value":"completedAt"},"value":{"kind":"NullValue"}}]}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"completedAt"}}]}}]}}]} as unknown as DocumentNode<UncompleteTodoMutation, UncompleteTodoMutationVariables>;
+export const DeleteTodoDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"DeleteTodo"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"id"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"ID"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"myDeleteTodo"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"id"}}}]}]}}]} as unknown as DocumentNode<DeleteTodoMutation, DeleteTodoMutationVariables>;

--- a/packages/client/src/__generated__/index.ts
+++ b/packages/client/src/__generated__/index.ts
@@ -1,0 +1,1 @@
+export * from "./gql";

--- a/packages/client/src/components/domain/habit/HabitForm.tsx
+++ b/packages/client/src/components/domain/habit/HabitForm.tsx
@@ -323,65 +323,13 @@ export function HabitForm({ habit, open, onOpenChange }: HabitFormProps) {
               )}
             </form.AppField>
 
-            {/* Priority + Duration — two columns */}
-            <div className="grid grid-cols-2 gap-4">
-              {/* Priority */}
-              <form.AppField name="priority">
-                {(field) => (
-                  <field.SelectField
-                    label="Priority"
-                    options={PRIORITY_OPTIONS}
-                    placeholder="Select priority"
-                  />
-                )}
-              </form.AppField>
-
-              {/* Estimated Length */}
-              <form.AppField name="estimatedLength">
-                {(field) => (
-                  <field.SelectField
-                    label="Duration"
-                    options={DURATION_OPTIONS}
-                    placeholder="Select duration"
-                  />
-                )}
-              </form.AppField>
-            </div>
-
-            {/* Frequency — count + unit side by side */}
-            <div className="grid grid-cols-2 gap-4">
-              {/* Frequency Count */}
-              <form.AppField name="frequencyCount">
-                {(field) => (
-                  <field.InputField
-                    label="Times"
-                    type="number"
-                    min={1}
-                    max={30}
-                  />
-                )}
-              </form.AppField>
-
-              {/* Frequency Unit */}
-              <form.AppField name="frequencyUnit">
-                {(field) => (
-                  <field.SelectField
-                    label="Frequency"
-                    options={FREQUENCY_UNIT_OPTIONS}
-                    placeholder="Select frequency"
-                  />
-                )}
-              </form.AppField>
-            </div>
-
-            {/* Minimum time between instances */}
-            <form.AppField name="minTimeBetweenInstances">
+            {/* Priority — always visible */}
+            <form.AppField name="priority">
               {(field) => (
-                <field.InputField
-                  label="Min hours between sessions (optional)"
-                  type="number"
-                  min={0}
-                  placeholder="e.g. 24"
+                <field.SelectField
+                  label="Priority"
+                  options={PRIORITY_OPTIONS}
+                  placeholder="Select priority"
                 />
               )}
             </form.AppField>
@@ -410,7 +358,7 @@ export function HabitForm({ habit, open, onOpenChange }: HabitFormProps) {
               )}
             </form.AppField>
 
-            {/* Pomodoro config — only shown when enabled */}
+            {/* Scheduling fields (hidden when pomodoro mode is on) or pomodoro config */}
             <form.Subscribe selector={(s) => s.values.pomodoroEnabled}>
               {(pomodoroEnabled) =>
                 pomodoroEnabled ? (
@@ -465,7 +413,56 @@ export function HabitForm({ habit, open, onOpenChange }: HabitFormProps) {
                       </form.AppField>
                     </div>
                   </div>
-                ) : null
+                ) : (
+                  <div className="space-y-4">
+                    {/* Duration */}
+                    <form.AppField name="estimatedLength">
+                      {(field) => (
+                        <field.SelectField
+                          label="Duration"
+                          options={DURATION_OPTIONS}
+                          placeholder="Select duration"
+                        />
+                      )}
+                    </form.AppField>
+
+                    {/* Frequency — count + unit side by side */}
+                    <div className="grid grid-cols-2 gap-4">
+                      <form.AppField name="frequencyCount">
+                        {(field) => (
+                          <field.InputField
+                            label="Times"
+                            type="number"
+                            min={1}
+                            max={30}
+                          />
+                        )}
+                      </form.AppField>
+
+                      <form.AppField name="frequencyUnit">
+                        {(field) => (
+                          <field.SelectField
+                            label="Frequency"
+                            options={FREQUENCY_UNIT_OPTIONS}
+                            placeholder="Select frequency"
+                          />
+                        )}
+                      </form.AppField>
+                    </div>
+
+                    {/* Minimum time between instances */}
+                    <form.AppField name="minTimeBetweenInstances">
+                      {(field) => (
+                        <field.InputField
+                          label="Min hours between sessions (optional)"
+                          type="number"
+                          min={0}
+                          placeholder="e.g. 24"
+                        />
+                      )}
+                    </form.AppField>
+                  </div>
+                )
               }
             </form.Subscribe>
 

--- a/packages/client/src/components/domain/habit/HabitForm.tsx
+++ b/packages/client/src/components/domain/habit/HabitForm.tsx
@@ -17,6 +17,8 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog';
 import { FieldWrapper, Form } from '@/components/ui/form';
+import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
 import { useAppForm } from '@/hooks/form-hook';
 import { useMutation } from '@apollo/client/react';
 import { useEffect } from 'react';
@@ -39,6 +41,11 @@ const CREATE_HABIT = graphql(`
       estimatedLength
       frequencyCount
       frequencyUnit
+      pomodoroEnabled
+      pomodoroUnitLength
+      pomodoroShortBreakLength
+      pomodoroUnitsBeforeLongBreak
+      pomodoroLongBreakLength
     }
   }
 `);
@@ -58,6 +65,11 @@ const UPDATE_HABIT = graphql(`
       estimatedLength
       frequencyCount
       frequencyUnit
+      pomodoroEnabled
+      pomodoroUnitLength
+      pomodoroShortBreakLength
+      pomodoroUnitsBeforeLongBreak
+      pomodoroLongBreakLength
     }
   }
 `);
@@ -89,20 +101,50 @@ const FREQUENCY_UNIT_OPTIONS = [
 
 // ─── Validation Schema ──────────────────────────────────────────────────────
 
-const habitSchema = z.object({
-  title: z.string().min(1, 'Title is required').max(200, 'Max 200 characters'),
-  description: z.string().max(2000, 'Max 2000 characters'),
-  activityTypeId: z.string().uuid('Activity type is required'),
-  priority: z.string().min(1, 'Priority is required'),
-  estimatedLength: z.string().min(1, 'Duration is required'),
-  frequencyCount: z
-    .number()
-    .int()
-    .min(1, 'Must be at least 1')
-    .max(30, 'Max 30'),
-  frequencyUnit: z.string().min(1, 'Frequency unit is required'),
-  minTimeBetweenInstances: z.number().int().min(0).nullable(),
+const pomodoroConfig = z.object({
+  pomodoroUnitLength: z.number().int().min(1).max(120),
+  pomodoroShortBreakLength: z.number().int().min(1).max(60),
+  pomodoroUnitsBeforeLongBreak: z.number().int().min(1).max(20),
+  pomodoroLongBreakLength: z.number().int().min(1).max(120),
 });
+
+const habitSchema = z
+  .object({
+    title: z
+      .string()
+      .min(1, 'Title is required')
+      .max(200, 'Max 200 characters'),
+    description: z.string().max(2000, 'Max 2000 characters'),
+    activityTypeId: z.string().uuid('Activity type is required'),
+    priority: z.string().min(1, 'Priority is required'),
+    estimatedLength: z.string().min(1, 'Duration is required'),
+    frequencyCount: z
+      .number()
+      .int()
+      .min(1, 'Must be at least 1')
+      .max(30, 'Max 30'),
+    frequencyUnit: z.string().min(1, 'Frequency unit is required'),
+    minTimeBetweenInstances: z.number().int().min(0).nullable(),
+    pomodoroEnabled: z.boolean(),
+    pomodoroUnitLength: z.number().int().min(1).max(120).nullable(),
+    pomodoroShortBreakLength: z.number().int().min(1).max(60).nullable(),
+    pomodoroUnitsBeforeLongBreak: z.number().int().min(1).max(20).nullable(),
+    pomodoroLongBreakLength: z.number().int().min(1).max(120).nullable(),
+  })
+  .superRefine((data, ctx) => {
+    if (!data.pomodoroEnabled) return;
+    const result = pomodoroConfig.safeParse({
+      pomodoroUnitLength: data.pomodoroUnitLength,
+      pomodoroShortBreakLength: data.pomodoroShortBreakLength,
+      pomodoroUnitsBeforeLongBreak: data.pomodoroUnitsBeforeLongBreak,
+      pomodoroLongBreakLength: data.pomodoroLongBreakLength,
+    });
+    if (!result.success) {
+      for (const issue of result.error.issues) {
+        ctx.addIssue({ ...issue, path: issue.path });
+      }
+    }
+  });
 
 type HabitFormValues = z.infer<typeof habitSchema>;
 
@@ -133,21 +175,45 @@ export function HabitForm({ habit, open, onOpenChange }: HabitFormProps) {
     refetchQueries: ['GetMyHabits'],
   });
 
+  const defaultValues: HabitFormValues = {
+    title: habit?.title ?? '',
+    description: habit?.description ?? '',
+    activityTypeId: habit?.activityType?.id ?? '',
+    priority: String(habit?.priority ?? 0),
+    estimatedLength: String(habit?.estimatedLength ?? 30),
+    frequencyCount: habit?.frequencyCount ?? 1,
+    frequencyUnit: habit?.frequencyUnit ?? 'week',
+    minTimeBetweenInstances: habit?.minTimeBetweenInstances ?? null,
+    pomodoroEnabled: habit?.pomodoroEnabled ?? false,
+    pomodoroUnitLength: habit?.pomodoroUnitLength ?? 25,
+    pomodoroShortBreakLength: habit?.pomodoroShortBreakLength ?? 5,
+    pomodoroUnitsBeforeLongBreak: habit?.pomodoroUnitsBeforeLongBreak ?? 4,
+    pomodoroLongBreakLength: habit?.pomodoroLongBreakLength ?? 15,
+  };
+
   const form = useAppForm({
-    defaultValues: {
-      title: habit?.title ?? '',
-      description: habit?.description ?? '',
-      activityTypeId: habit?.activityType?.id ?? '',
-      priority: String(habit?.priority ?? 0),
-      estimatedLength: String(habit?.estimatedLength ?? 30),
-      frequencyCount: habit?.frequencyCount ?? 1,
-      frequencyUnit: habit?.frequencyUnit ?? 'week',
-      minTimeBetweenInstances: habit?.minTimeBetweenInstances ?? null,
-    } as HabitFormValues,
+    defaultValues,
     validators: {
       onChange: habitSchema,
     },
     onSubmit: async ({ value }) => {
+      const pomodoroFields = value.pomodoroEnabled
+        ? {
+            pomodoroEnabled: true,
+            pomodoroUnitLength: value.pomodoroUnitLength ?? 25,
+            pomodoroShortBreakLength: value.pomodoroShortBreakLength ?? 5,
+            pomodoroUnitsBeforeLongBreak:
+              value.pomodoroUnitsBeforeLongBreak ?? 4,
+            pomodoroLongBreakLength: value.pomodoroLongBreakLength ?? 15,
+          }
+        : {
+            pomodoroEnabled: false,
+            pomodoroUnitLength: null,
+            pomodoroShortBreakLength: null,
+            pomodoroUnitsBeforeLongBreak: null,
+            pomodoroLongBreakLength: null,
+          };
+
       if (isEdit && habit) {
         await updateHabit({
           variables: {
@@ -161,6 +227,7 @@ export function HabitForm({ habit, open, onOpenChange }: HabitFormProps) {
               frequencyCount: value.frequencyCount,
               frequencyUnit: value.frequencyUnit,
               minTimeBetweenInstances: value.minTimeBetweenInstances,
+              ...pomodoroFields,
             },
           },
         });
@@ -176,6 +243,7 @@ export function HabitForm({ habit, open, onOpenChange }: HabitFormProps) {
               frequencyCount: value.frequencyCount,
               frequencyUnit: value.frequencyUnit,
               minTimeBetweenInstances: value.minTimeBetweenInstances,
+              ...pomodoroFields,
             },
           },
         });
@@ -196,6 +264,11 @@ export function HabitForm({ habit, open, onOpenChange }: HabitFormProps) {
         frequencyCount: habit?.frequencyCount ?? 1,
         frequencyUnit: habit?.frequencyUnit ?? 'week',
         minTimeBetweenInstances: habit?.minTimeBetweenInstances ?? null,
+        pomodoroEnabled: habit?.pomodoroEnabled ?? false,
+        pomodoroUnitLength: habit?.pomodoroUnitLength ?? 25,
+        pomodoroShortBreakLength: habit?.pomodoroShortBreakLength ?? 5,
+        pomodoroUnitsBeforeLongBreak: habit?.pomodoroUnitsBeforeLongBreak ?? 4,
+        pomodoroLongBreakLength: habit?.pomodoroLongBreakLength ?? 15,
       });
     }
   }, [open, habit?.id]);
@@ -312,6 +385,89 @@ export function HabitForm({ habit, open, onOpenChange }: HabitFormProps) {
                 />
               )}
             </form.AppField>
+
+            {/* Pomodoro toggle */}
+            <form.AppField name="pomodoroEnabled">
+              {(field) => (
+                <div className="flex items-center justify-between rounded-lg border p-3">
+                  <div>
+                    <Label
+                      htmlFor="pomodoro-toggle"
+                      className="text-sm font-medium"
+                    >
+                      Auto-generate pomodoros
+                    </Label>
+                    <p className="text-xs text-muted-foreground">
+                      Fill remaining time with timed work units
+                    </p>
+                  </div>
+                  <Switch
+                    id="pomodoro-toggle"
+                    checked={field.state.value}
+                    onCheckedChange={(checked) => field.handleChange(checked)}
+                  />
+                </div>
+              )}
+            </form.AppField>
+
+            {/* Pomodoro config — only shown when enabled */}
+            <form.Subscribe selector={(s) => s.values.pomodoroEnabled}>
+              {(pomodoroEnabled) =>
+                pomodoroEnabled ? (
+                  <div className="space-y-3 rounded-lg border p-3">
+                    <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                      Pomodoro Settings
+                    </p>
+
+                    <div className="grid grid-cols-2 gap-3">
+                      <form.AppField name="pomodoroUnitLength">
+                        {(field) => (
+                          <field.InputField
+                            label="Unit length (min)"
+                            type="number"
+                            min={1}
+                            max={120}
+                          />
+                        )}
+                      </form.AppField>
+
+                      <form.AppField name="pomodoroShortBreakLength">
+                        {(field) => (
+                          <field.InputField
+                            label="Short break (min)"
+                            type="number"
+                            min={1}
+                            max={60}
+                          />
+                        )}
+                      </form.AppField>
+
+                      <form.AppField name="pomodoroUnitsBeforeLongBreak">
+                        {(field) => (
+                          <field.InputField
+                            label="Units before long break"
+                            type="number"
+                            min={1}
+                            max={20}
+                          />
+                        )}
+                      </form.AppField>
+
+                      <form.AppField name="pomodoroLongBreakLength">
+                        {(field) => (
+                          <field.InputField
+                            label="Long break (min)"
+                            type="number"
+                            min={1}
+                            max={120}
+                          />
+                        )}
+                      </form.AppField>
+                    </div>
+                  </div>
+                ) : null
+              }
+            </form.Subscribe>
 
             <DialogFooter>
               <form.Subscribe

--- a/packages/client/src/components/domain/habit/HabitList.tsx
+++ b/packages/client/src/components/domain/habit/HabitList.tsx
@@ -21,6 +21,11 @@ export const HABIT_LIST_FRAGMENT = graphql(`
     frequencyCount
     frequencyUnit
     minTimeBetweenInstances
+    pomodoroEnabled
+    pomodoroUnitLength
+    pomodoroShortBreakLength
+    pomodoroUnitsBeforeLongBreak
+    pomodoroLongBreakLength
     createdAt
   }
 `);

--- a/packages/client/src/components/ui/switch.tsx
+++ b/packages/client/src/components/ui/switch.tsx
@@ -1,0 +1,26 @@
+import { cn } from '@/lib/utils';
+import * as SwitchPrimitive from '@radix-ui/react-switch';
+import type * as React from 'react';
+
+function Switch({
+  className,
+  ...props
+}: React.ComponentProps<typeof SwitchPrimitive.Root>) {
+  return (
+    <SwitchPrimitive.Root
+      className={cn(
+        'peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent shadow-xs transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input',
+        className,
+      )}
+      {...props}
+    >
+      <SwitchPrimitive.Thumb
+        className={cn(
+          'pointer-events-none block h-4 w-4 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0',
+        )}
+      />
+    </SwitchPrimitive.Root>
+  );
+}
+
+export { Switch };

--- a/packages/db/drizzle/20260528041948_past_mordo/migration.sql
+++ b/packages/db/drizzle/20260528041948_past_mordo/migration.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "habits" ADD COLUMN "pomodoro_enabled" boolean DEFAULT false NOT NULL;--> statement-breakpoint
+ALTER TABLE "habits" ADD COLUMN "pomodoro_unit_length" integer;--> statement-breakpoint
+ALTER TABLE "habits" ADD COLUMN "pomodoro_short_break_length" integer;--> statement-breakpoint
+ALTER TABLE "habits" ADD COLUMN "pomodoro_units_before_long_break" integer;--> statement-breakpoint
+ALTER TABLE "habits" ADD COLUMN "pomodoro_long_break_length" integer;

--- a/packages/db/drizzle/20260528041948_past_mordo/snapshot.json
+++ b/packages/db/drizzle/20260528041948_past_mordo/snapshot.json
@@ -1,0 +1,1310 @@
+{
+  "version": "8",
+  "dialect": "postgres",
+  "id": "0570a84a-5303-4111-a9d5-a8848444fb58",
+  "prevIds": [
+    "d4528e12-2138-403c-a691-63a390eaef3f"
+  ],
+  "ddl": [
+    {
+      "isRlsEnabled": false,
+      "name": "users",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "activity_types",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "todo_lists",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "todos",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "habits",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "time_blocks",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "habit_completions",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "api_keys",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "email",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'UTC'",
+      "generated": null,
+      "identity": null,
+      "name": "timezone",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "activity_types"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "activity_types"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "activity_types"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'#6366f1'",
+      "generated": null,
+      "identity": null,
+      "name": "color",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "activity_types"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "activity_types"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "activity_types"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "todo_lists"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "todo_lists"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "todo_lists"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "description",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "todo_lists"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "activity_type_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "todo_lists"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "default_priority",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "todo_lists"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "default_estimated_length",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "todo_lists"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "todo_lists"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "todo_lists"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "todos"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "todos"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "list_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "todos"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "title",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "todos"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "description",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "todos"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "priority",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "todos"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "estimated_length",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "todos"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "due_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "todos"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "scheduled_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "todos"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "completed_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "todos"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "manually_scheduled",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "todos"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "todos"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "todos"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "habits"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "habits"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "title",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "habits"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "description",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "habits"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "priority",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "habits"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "estimated_length",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "habits"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "activity_type_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "habits"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "frequency_count",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "habits"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "frequency_unit",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "habits"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "min_time_between_instances",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "habits"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "pomodoro_enabled",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "habits"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "pomodoro_unit_length",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "habits"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "pomodoro_short_break_length",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "habits"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "pomodoro_units_before_long_break",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "habits"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "pomodoro_long_break_length",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "habits"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "habits"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "habits"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "time_blocks"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "time_blocks"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "activity_type_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "time_blocks"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 1,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "days_of_week",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "time_blocks"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "start_time",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "time_blocks"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "end_time",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "time_blocks"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "priority",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "time_blocks"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "time_blocks"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "time_blocks"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "habit_completions"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "habit_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "habit_completions"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "scheduled_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "habit_completions"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "completed_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "habit_completions"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "habit_completions"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "api_keys"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "api_keys"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "api_keys"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "key_hash",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "api_keys"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "key_prefix",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "api_keys"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 1,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "scopes",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "api_keys"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "last_used_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "api_keys"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "api_keys"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "revoked_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "api_keys"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "api_keys"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "activity_types_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "activity_types"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "todo_lists_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "todo_lists"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "activity_type_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "activity_types",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "RESTRICT",
+      "name": "todo_lists_activity_type_id_activity_types_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "todo_lists"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "todos_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "todos"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "list_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "todo_lists",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "RESTRICT",
+      "name": "todos_list_id_todo_lists_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "todos"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "habits_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "habits"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "activity_type_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "activity_types",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "RESTRICT",
+      "name": "habits_activity_type_id_activity_types_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "habits"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "time_blocks_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "time_blocks"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "activity_type_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "activity_types",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "RESTRICT",
+      "name": "time_blocks_activity_type_id_activity_types_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "time_blocks"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "habit_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "habits",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "habit_completions_habit_id_habits_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "habit_completions"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "api_keys_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "api_keys"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "users_pkey",
+      "schema": "public",
+      "table": "users",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "activity_types_pkey",
+      "schema": "public",
+      "table": "activity_types",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "todo_lists_pkey",
+      "schema": "public",
+      "table": "todo_lists",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "todos_pkey",
+      "schema": "public",
+      "table": "todos",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "habits_pkey",
+      "schema": "public",
+      "table": "habits",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "time_blocks_pkey",
+      "schema": "public",
+      "table": "time_blocks",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "habit_completions_pkey",
+      "schema": "public",
+      "table": "habit_completions",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "api_keys_pkey",
+      "schema": "public",
+      "table": "api_keys",
+      "entityType": "pks"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "email"
+      ],
+      "nullsNotDistinct": false,
+      "name": "users_email_key",
+      "schema": "public",
+      "table": "users",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "key_hash"
+      ],
+      "nullsNotDistinct": false,
+      "name": "api_keys_key_hash_key",
+      "schema": "public",
+      "table": "api_keys",
+      "entityType": "uniques"
+    }
+  ],
+  "renames": []
+}

--- a/packages/db/src/models/habits.ts
+++ b/packages/db/src/models/habits.ts
@@ -1,4 +1,11 @@
-import { integer, pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-core';
+import {
+  boolean,
+  integer,
+  pgTable,
+  text,
+  timestamp,
+  uuid,
+} from 'drizzle-orm/pg-core';
 import { activityTypes } from './activity_types.ts';
 import type { FrequencyUnit } from './enums.ts';
 import { users } from './users.ts';
@@ -18,6 +25,11 @@ export const habits = pgTable('habits', {
   frequencyCount: integer('frequency_count').notNull(),
   frequencyUnit: text('frequency_unit').notNull().$type<FrequencyUnit>(),
   minTimeBetweenInstances: integer('min_time_between_instances'),
+  pomodoroEnabled: boolean('pomodoro_enabled').notNull().default(false),
+  pomodoroUnitLength: integer('pomodoro_unit_length'),
+  pomodoroShortBreakLength: integer('pomodoro_short_break_length'),
+  pomodoroUnitsBeforeLongBreak: integer('pomodoro_units_before_long_break'),
+  pomodoroLongBreakLength: integer('pomodoro_long_break_length'),
   createdAt: timestamp('created_at').notNull().defaultNow(),
   updatedAt: timestamp('updated_at').notNull().defaultNow(),
 });

--- a/packages/server/src/__generated__/resolvers.ts
+++ b/packages/server/src/__generated__/resolvers.ts
@@ -1,0 +1,2501 @@
+import { GraphQLResolveInfo, GraphQLScalarType, GraphQLScalarTypeConfig } from 'graphql';
+import { Context } from '../context.ts';
+export type Maybe<T> = T | null;
+export type InputMaybe<T> = T | undefined;
+export type RequireFields<T, K extends keyof T> = Omit<T, K> & { [P in K]-?: NonNullable<T[P]> };
+/** All built-in and custom scalars, mapped to their actual values */
+export type Scalars = {
+  ID: { input: string; output: string; }
+  String: { input: string; output: string; }
+  Boolean: { input: boolean; output: boolean; }
+  Int: { input: number; output: number; }
+  Float: { input: number; output: number; }
+  /** A date-time string at UTC, such as 2007-12-03T10:15:30Z, compliant with the `date-time` format outlined in section 5.6 of the RFC 3339 profile of the ISO 8601 standard for representation of dates and times using the Gregorian calendar. */
+  DateTime: { input: unknown; output: unknown; }
+};
+
+export type ActivityType = {
+  __typename?: 'ActivityType';
+  color: Scalars['String']['output'];
+  /** DateTime */
+  createdAt: Scalars['DateTime']['output'];
+  habits: Array<Habit>;
+  id: Scalars['String']['output'];
+  name: Scalars['String']['output'];
+  timeBlocks: Array<TimeBlock>;
+  todoLists: Array<TodoList>;
+  /** DateTime */
+  updatedAt: Scalars['DateTime']['output'];
+  user: Maybe<User>;
+  userId: Scalars['String']['output'];
+};
+
+
+export type ActivityTypeHabitsArgs = {
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<HabitOrderBy>;
+  where?: InputMaybe<HabitFilters>;
+};
+
+
+export type ActivityTypeTimeBlocksArgs = {
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<TimeBlockOrderBy>;
+  where?: InputMaybe<TimeBlockFilters>;
+};
+
+
+export type ActivityTypeTodoListsArgs = {
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<TodoListOrderBy>;
+  where?: InputMaybe<TodoListFilters>;
+};
+
+
+export type ActivityTypeUserArgs = {
+  where?: InputMaybe<UserFilters>;
+};
+
+export type ActivityTypeFilters = {
+  OR?: InputMaybe<Array<ActivityTypeFiltersOr>>;
+  color?: InputMaybe<StringFilter>;
+  createdAt?: InputMaybe<DateTimeFilter>;
+  id?: InputMaybe<IdFilter>;
+  name?: InputMaybe<StringFilter>;
+  updatedAt?: InputMaybe<DateTimeFilter>;
+  userId?: InputMaybe<IdFilter>;
+};
+
+export type ActivityTypeFiltersOr = {
+  color?: InputMaybe<StringFilter>;
+  createdAt?: InputMaybe<DateTimeFilter>;
+  id?: InputMaybe<IdFilter>;
+  name?: InputMaybe<StringFilter>;
+  updatedAt?: InputMaybe<DateTimeFilter>;
+  userId?: InputMaybe<IdFilter>;
+};
+
+export type ActivityTypeOrderBy = {
+  color?: InputMaybe<InnerOrder>;
+  createdAt?: InputMaybe<InnerOrder>;
+  id?: InputMaybe<InnerOrder>;
+  name?: InputMaybe<InnerOrder>;
+  updatedAt?: InputMaybe<InnerOrder>;
+  userId?: InputMaybe<InnerOrder>;
+};
+
+export type ActivityTypeStats = {
+  __typename?: 'ActivityTypeStats';
+  activityTypeId: Scalars['String']['output'];
+  activityTypeName: Scalars['String']['output'];
+  completedTodos: Scalars['Int']['output'];
+  totalHabits: Scalars['Int']['output'];
+  totalTodos: Scalars['Int']['output'];
+};
+
+export type ApiKey = {
+  __typename?: 'ApiKey';
+  /** DateTime */
+  createdAt: Scalars['DateTime']['output'];
+  /** DateTime */
+  expiresAt: Maybe<Scalars['DateTime']['output']>;
+  id: Scalars['String']['output'];
+  keyHash: Scalars['String']['output'];
+  keyPrefix: Scalars['String']['output'];
+  /** DateTime */
+  lastUsedAt: Maybe<Scalars['DateTime']['output']>;
+  name: Scalars['String']['output'];
+  /** DateTime */
+  revokedAt: Maybe<Scalars['DateTime']['output']>;
+  scopes: Array<Scalars['String']['output']>;
+  user: Maybe<User>;
+  userId: Scalars['String']['output'];
+};
+
+
+export type ApiKeyUserArgs = {
+  where?: InputMaybe<UserFilters>;
+};
+
+export type ApiKeyFilters = {
+  OR?: InputMaybe<Array<ApiKeyFiltersOr>>;
+  createdAt?: InputMaybe<DateTimeFilter>;
+  expiresAt?: InputMaybe<DateTimeFilter>;
+  id?: InputMaybe<IdFilter>;
+  keyHash?: InputMaybe<StringFilter>;
+  keyPrefix?: InputMaybe<StringFilter>;
+  lastUsedAt?: InputMaybe<DateTimeFilter>;
+  name?: InputMaybe<StringFilter>;
+  revokedAt?: InputMaybe<DateTimeFilter>;
+  scopes?: InputMaybe<StringFilter>;
+  userId?: InputMaybe<IdFilter>;
+};
+
+export type ApiKeyFiltersOr = {
+  createdAt?: InputMaybe<DateTimeFilter>;
+  expiresAt?: InputMaybe<DateTimeFilter>;
+  id?: InputMaybe<IdFilter>;
+  keyHash?: InputMaybe<StringFilter>;
+  keyPrefix?: InputMaybe<StringFilter>;
+  lastUsedAt?: InputMaybe<DateTimeFilter>;
+  name?: InputMaybe<StringFilter>;
+  revokedAt?: InputMaybe<DateTimeFilter>;
+  scopes?: InputMaybe<StringFilter>;
+  userId?: InputMaybe<IdFilter>;
+};
+
+export type ApiKeyOrderBy = {
+  createdAt?: InputMaybe<InnerOrder>;
+  expiresAt?: InputMaybe<InnerOrder>;
+  id?: InputMaybe<InnerOrder>;
+  keyHash?: InputMaybe<InnerOrder>;
+  keyPrefix?: InputMaybe<InnerOrder>;
+  lastUsedAt?: InputMaybe<InnerOrder>;
+  name?: InputMaybe<InnerOrder>;
+  revokedAt?: InputMaybe<InnerOrder>;
+  scopes?: InputMaybe<InnerOrder>;
+  userId?: InputMaybe<InnerOrder>;
+};
+
+export type BooleanFilter = {
+  OR?: InputMaybe<Array<BooleanFilterOr>>;
+  eq?: InputMaybe<Scalars['Boolean']['input']>;
+  gt?: InputMaybe<Scalars['Boolean']['input']>;
+  gte?: InputMaybe<Scalars['Boolean']['input']>;
+  ilike?: InputMaybe<Scalars['String']['input']>;
+  /** Array<undefined> */
+  inArray?: InputMaybe<Array<Scalars['Boolean']['input']>>;
+  isNotNull?: InputMaybe<Scalars['Boolean']['input']>;
+  isNull?: InputMaybe<Scalars['Boolean']['input']>;
+  like?: InputMaybe<Scalars['String']['input']>;
+  lt?: InputMaybe<Scalars['Boolean']['input']>;
+  lte?: InputMaybe<Scalars['Boolean']['input']>;
+  ne?: InputMaybe<Scalars['Boolean']['input']>;
+  notIlike?: InputMaybe<Scalars['String']['input']>;
+  /** Array<undefined> */
+  notInArray?: InputMaybe<Array<Scalars['Boolean']['input']>>;
+  notLike?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type BooleanFilterOr = {
+  eq?: InputMaybe<Scalars['Boolean']['input']>;
+  gt?: InputMaybe<Scalars['Boolean']['input']>;
+  gte?: InputMaybe<Scalars['Boolean']['input']>;
+  ilike?: InputMaybe<Scalars['String']['input']>;
+  /** Array<undefined> */
+  inArray?: InputMaybe<Array<Scalars['Boolean']['input']>>;
+  isNotNull?: InputMaybe<Scalars['Boolean']['input']>;
+  isNull?: InputMaybe<Scalars['Boolean']['input']>;
+  like?: InputMaybe<Scalars['String']['input']>;
+  lt?: InputMaybe<Scalars['Boolean']['input']>;
+  lte?: InputMaybe<Scalars['Boolean']['input']>;
+  ne?: InputMaybe<Scalars['Boolean']['input']>;
+  notIlike?: InputMaybe<Scalars['String']['input']>;
+  /** Array<undefined> */
+  notInArray?: InputMaybe<Array<Scalars['Boolean']['input']>>;
+  notLike?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type CompleteHabitArgs = {
+  completedAt?: InputMaybe<Scalars['String']['input']>;
+  habitId: Scalars['ID']['input'];
+  scheduledAt?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type CreateActivityTypeArgs = {
+  color?: InputMaybe<Scalars['String']['input']>;
+  name: Scalars['String']['input'];
+};
+
+export type CreateActivityTypeInput = {
+  color?: InputMaybe<Scalars['String']['input']>;
+  /** DateTime */
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  id?: InputMaybe<Scalars['String']['input']>;
+  name: Scalars['String']['input'];
+  /** DateTime */
+  updatedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  userId: Scalars['String']['input'];
+};
+
+export type CreateApiKeyInput = {
+  /** DateTime */
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  /** DateTime */
+  expiresAt?: InputMaybe<Scalars['DateTime']['input']>;
+  id?: InputMaybe<Scalars['String']['input']>;
+  keyHash: Scalars['String']['input'];
+  keyPrefix: Scalars['String']['input'];
+  /** DateTime */
+  lastUsedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  name: Scalars['String']['input'];
+  /** DateTime */
+  revokedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  scopes: Scalars['String']['input'];
+  userId: Scalars['String']['input'];
+};
+
+export type CreateApiKeyResult = {
+  __typename?: 'CreateApiKeyResult';
+  apiKey: ApiKey;
+  token: Scalars['String']['output'];
+};
+
+export type CreateHabitArgs = {
+  activityTypeId: Scalars['ID']['input'];
+  description?: InputMaybe<Scalars['String']['input']>;
+  estimatedLength?: InputMaybe<Scalars['Int']['input']>;
+  frequencyCount: Scalars['Int']['input'];
+  frequencyUnit: Scalars['String']['input'];
+  minTimeBetweenInstances?: InputMaybe<Scalars['Int']['input']>;
+  pomodoroEnabled?: InputMaybe<Scalars['Boolean']['input']>;
+  pomodoroLongBreakLength?: InputMaybe<Scalars['Int']['input']>;
+  pomodoroShortBreakLength?: InputMaybe<Scalars['Int']['input']>;
+  pomodoroUnitLength?: InputMaybe<Scalars['Int']['input']>;
+  pomodoroUnitsBeforeLongBreak?: InputMaybe<Scalars['Int']['input']>;
+  priority?: InputMaybe<Scalars['Int']['input']>;
+  title: Scalars['String']['input'];
+};
+
+export type CreateHabitCompletionInput = {
+  /** DateTime */
+  completedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  /** DateTime */
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  habitId: Scalars['String']['input'];
+  id?: InputMaybe<Scalars['String']['input']>;
+  /** DateTime */
+  scheduledAt?: InputMaybe<Scalars['DateTime']['input']>;
+};
+
+export type CreateHabitInput = {
+  activityTypeId: Scalars['String']['input'];
+  /** DateTime */
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  estimatedLength: Scalars['Int']['input'];
+  frequencyCount: Scalars['Int']['input'];
+  frequencyUnit: Scalars['String']['input'];
+  id?: InputMaybe<Scalars['String']['input']>;
+  minTimeBetweenInstances?: InputMaybe<Scalars['Int']['input']>;
+  pomodoroEnabled?: InputMaybe<Scalars['Boolean']['input']>;
+  pomodoroLongBreakLength?: InputMaybe<Scalars['Int']['input']>;
+  pomodoroShortBreakLength?: InputMaybe<Scalars['Int']['input']>;
+  pomodoroUnitLength?: InputMaybe<Scalars['Int']['input']>;
+  pomodoroUnitsBeforeLongBreak?: InputMaybe<Scalars['Int']['input']>;
+  priority?: InputMaybe<Scalars['Int']['input']>;
+  title: Scalars['String']['input'];
+  /** DateTime */
+  updatedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  userId: Scalars['String']['input'];
+};
+
+export type CreateTimeBlockArgs = {
+  activityTypeId: Scalars['ID']['input'];
+  daysOfWeek: Array<Scalars['Int']['input']>;
+  endTime: Scalars['String']['input'];
+  priority?: InputMaybe<Scalars['Int']['input']>;
+  startTime: Scalars['String']['input'];
+};
+
+export type CreateTimeBlockInput = {
+  activityTypeId: Scalars['String']['input'];
+  /** DateTime */
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  daysOfWeek: Array<Scalars['Int']['input']>;
+  endTime: Scalars['String']['input'];
+  id?: InputMaybe<Scalars['String']['input']>;
+  priority?: InputMaybe<Scalars['Int']['input']>;
+  startTime: Scalars['String']['input'];
+  /** DateTime */
+  updatedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  userId: Scalars['String']['input'];
+};
+
+export type CreateTodoArgs = {
+  description?: InputMaybe<Scalars['String']['input']>;
+  dueAt?: InputMaybe<Scalars['String']['input']>;
+  estimatedLength?: InputMaybe<Scalars['Int']['input']>;
+  listId: Scalars['ID']['input'];
+  priority?: InputMaybe<Scalars['Int']['input']>;
+  scheduledAt?: InputMaybe<Scalars['String']['input']>;
+  title: Scalars['String']['input'];
+};
+
+export type CreateTodoInput = {
+  /** DateTime */
+  completedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  /** DateTime */
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  /** DateTime */
+  dueAt?: InputMaybe<Scalars['DateTime']['input']>;
+  estimatedLength: Scalars['Int']['input'];
+  id?: InputMaybe<Scalars['String']['input']>;
+  listId: Scalars['String']['input'];
+  manuallyScheduled?: InputMaybe<Scalars['Boolean']['input']>;
+  priority?: InputMaybe<Scalars['Int']['input']>;
+  /** DateTime */
+  scheduledAt?: InputMaybe<Scalars['DateTime']['input']>;
+  title: Scalars['String']['input'];
+  /** DateTime */
+  updatedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  userId: Scalars['String']['input'];
+};
+
+export type CreateTodoListArgs = {
+  activityTypeId: Scalars['ID']['input'];
+  defaultEstimatedLength?: InputMaybe<Scalars['Int']['input']>;
+  defaultPriority?: InputMaybe<Scalars['Int']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  name: Scalars['String']['input'];
+};
+
+export type CreateTodoListInput = {
+  activityTypeId: Scalars['String']['input'];
+  /** DateTime */
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  defaultEstimatedLength?: InputMaybe<Scalars['Int']['input']>;
+  defaultPriority?: InputMaybe<Scalars['Int']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  id?: InputMaybe<Scalars['String']['input']>;
+  name: Scalars['String']['input'];
+  /** DateTime */
+  updatedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  userId: Scalars['String']['input'];
+};
+
+export type CreateUserInput = {
+  /** DateTime */
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  email: Scalars['String']['input'];
+  id?: InputMaybe<Scalars['String']['input']>;
+  timezone?: InputMaybe<Scalars['String']['input']>;
+  /** DateTime */
+  updatedAt?: InputMaybe<Scalars['DateTime']['input']>;
+};
+
+export type DateTimeFilter = {
+  OR?: InputMaybe<Array<DateTimeFilterOr>>;
+  /** DateTime */
+  eq?: InputMaybe<Scalars['DateTime']['input']>;
+  /** DateTime */
+  gt?: InputMaybe<Scalars['DateTime']['input']>;
+  /** DateTime */
+  gte?: InputMaybe<Scalars['DateTime']['input']>;
+  ilike?: InputMaybe<Scalars['String']['input']>;
+  /** Array<DateTime> */
+  inArray?: InputMaybe<Array<Scalars['DateTime']['input']>>;
+  isNotNull?: InputMaybe<Scalars['Boolean']['input']>;
+  isNull?: InputMaybe<Scalars['Boolean']['input']>;
+  like?: InputMaybe<Scalars['String']['input']>;
+  /** DateTime */
+  lt?: InputMaybe<Scalars['DateTime']['input']>;
+  /** DateTime */
+  lte?: InputMaybe<Scalars['DateTime']['input']>;
+  /** DateTime */
+  ne?: InputMaybe<Scalars['DateTime']['input']>;
+  notIlike?: InputMaybe<Scalars['String']['input']>;
+  /** Array<DateTime> */
+  notInArray?: InputMaybe<Array<Scalars['DateTime']['input']>>;
+  notLike?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type DateTimeFilterOr = {
+  /** DateTime */
+  eq?: InputMaybe<Scalars['DateTime']['input']>;
+  /** DateTime */
+  gt?: InputMaybe<Scalars['DateTime']['input']>;
+  /** DateTime */
+  gte?: InputMaybe<Scalars['DateTime']['input']>;
+  ilike?: InputMaybe<Scalars['String']['input']>;
+  /** Array<DateTime> */
+  inArray?: InputMaybe<Array<Scalars['DateTime']['input']>>;
+  isNotNull?: InputMaybe<Scalars['Boolean']['input']>;
+  isNull?: InputMaybe<Scalars['Boolean']['input']>;
+  like?: InputMaybe<Scalars['String']['input']>;
+  /** DateTime */
+  lt?: InputMaybe<Scalars['DateTime']['input']>;
+  /** DateTime */
+  lte?: InputMaybe<Scalars['DateTime']['input']>;
+  /** DateTime */
+  ne?: InputMaybe<Scalars['DateTime']['input']>;
+  notIlike?: InputMaybe<Scalars['String']['input']>;
+  /** Array<DateTime> */
+  notInArray?: InputMaybe<Array<Scalars['DateTime']['input']>>;
+  notLike?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type FloatArrayFilter = {
+  OR?: InputMaybe<Array<FloatArrayFilterOr>>;
+  eq?: InputMaybe<Array<Scalars['Int']['input']>>;
+  gt?: InputMaybe<Array<Scalars['Int']['input']>>;
+  gte?: InputMaybe<Array<Scalars['Int']['input']>>;
+  ilike?: InputMaybe<Scalars['String']['input']>;
+  /** Array<undefined> */
+  inArray?: InputMaybe<Array<Array<Scalars['Int']['input']>>>;
+  isNotNull?: InputMaybe<Scalars['Boolean']['input']>;
+  isNull?: InputMaybe<Scalars['Boolean']['input']>;
+  like?: InputMaybe<Scalars['String']['input']>;
+  lt?: InputMaybe<Array<Scalars['Int']['input']>>;
+  lte?: InputMaybe<Array<Scalars['Int']['input']>>;
+  ne?: InputMaybe<Array<Scalars['Int']['input']>>;
+  notIlike?: InputMaybe<Scalars['String']['input']>;
+  /** Array<undefined> */
+  notInArray?: InputMaybe<Array<Array<Scalars['Int']['input']>>>;
+  notLike?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type FloatArrayFilterOr = {
+  eq?: InputMaybe<Array<Scalars['Int']['input']>>;
+  gt?: InputMaybe<Array<Scalars['Int']['input']>>;
+  gte?: InputMaybe<Array<Scalars['Int']['input']>>;
+  ilike?: InputMaybe<Scalars['String']['input']>;
+  /** Array<undefined> */
+  inArray?: InputMaybe<Array<Array<Scalars['Int']['input']>>>;
+  isNotNull?: InputMaybe<Scalars['Boolean']['input']>;
+  isNull?: InputMaybe<Scalars['Boolean']['input']>;
+  like?: InputMaybe<Scalars['String']['input']>;
+  lt?: InputMaybe<Array<Scalars['Int']['input']>>;
+  lte?: InputMaybe<Array<Scalars['Int']['input']>>;
+  ne?: InputMaybe<Array<Scalars['Int']['input']>>;
+  notIlike?: InputMaybe<Scalars['String']['input']>;
+  /** Array<undefined> */
+  notInArray?: InputMaybe<Array<Array<Scalars['Int']['input']>>>;
+  notLike?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type Habit = {
+  __typename?: 'Habit';
+  activityType: Maybe<ActivityType>;
+  activityTypeId: Scalars['String']['output'];
+  completions: Array<HabitCompletion>;
+  /** DateTime */
+  createdAt: Scalars['DateTime']['output'];
+  description: Maybe<Scalars['String']['output']>;
+  estimatedLength: Scalars['Int']['output'];
+  frequencyCount: Scalars['Int']['output'];
+  frequencyUnit: Scalars['String']['output'];
+  id: Scalars['String']['output'];
+  minTimeBetweenInstances: Maybe<Scalars['Int']['output']>;
+  pomodoroEnabled: Scalars['Boolean']['output'];
+  pomodoroLongBreakLength: Maybe<Scalars['Int']['output']>;
+  pomodoroShortBreakLength: Maybe<Scalars['Int']['output']>;
+  pomodoroUnitLength: Maybe<Scalars['Int']['output']>;
+  pomodoroUnitsBeforeLongBreak: Maybe<Scalars['Int']['output']>;
+  priority: Scalars['Int']['output'];
+  title: Scalars['String']['output'];
+  /** DateTime */
+  updatedAt: Scalars['DateTime']['output'];
+  user: Maybe<User>;
+  userId: Scalars['String']['output'];
+};
+
+
+export type HabitActivityTypeArgs = {
+  where?: InputMaybe<ActivityTypeFilters>;
+};
+
+
+export type HabitCompletionsArgs = {
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<HabitCompletionOrderBy>;
+  where?: InputMaybe<HabitCompletionFilters>;
+};
+
+
+export type HabitUserArgs = {
+  where?: InputMaybe<UserFilters>;
+};
+
+export type HabitCompletion = {
+  __typename?: 'HabitCompletion';
+  /** DateTime */
+  completedAt: Maybe<Scalars['DateTime']['output']>;
+  /** DateTime */
+  createdAt: Scalars['DateTime']['output'];
+  habit: Maybe<Habit>;
+  habitId: Scalars['String']['output'];
+  id: Scalars['String']['output'];
+  /** DateTime */
+  scheduledAt: Maybe<Scalars['DateTime']['output']>;
+};
+
+
+export type HabitCompletionHabitArgs = {
+  where?: InputMaybe<HabitFilters>;
+};
+
+export type HabitCompletionFilters = {
+  OR?: InputMaybe<Array<HabitCompletionFiltersOr>>;
+  completedAt?: InputMaybe<DateTimeFilter>;
+  createdAt?: InputMaybe<DateTimeFilter>;
+  habitId?: InputMaybe<IdFilter>;
+  id?: InputMaybe<IdFilter>;
+  scheduledAt?: InputMaybe<DateTimeFilter>;
+};
+
+export type HabitCompletionFiltersOr = {
+  completedAt?: InputMaybe<DateTimeFilter>;
+  createdAt?: InputMaybe<DateTimeFilter>;
+  habitId?: InputMaybe<IdFilter>;
+  id?: InputMaybe<IdFilter>;
+  scheduledAt?: InputMaybe<DateTimeFilter>;
+};
+
+export type HabitCompletionOrderBy = {
+  completedAt?: InputMaybe<InnerOrder>;
+  createdAt?: InputMaybe<InnerOrder>;
+  habitId?: InputMaybe<InnerOrder>;
+  id?: InputMaybe<InnerOrder>;
+  scheduledAt?: InputMaybe<InnerOrder>;
+};
+
+export type HabitDetail = {
+  __typename?: 'HabitDetail';
+  activityType: Maybe<ActivityType>;
+  allTimeRate: Scalars['Float']['output'];
+  description: Maybe<Scalars['String']['output']>;
+  estimatedLength: Scalars['Int']['output'];
+  frequencyCount: Scalars['Int']['output'];
+  frequencyUnit: Scalars['String']['output'];
+  habitId: Scalars['ID']['output'];
+  periods: Array<HabitPeriod>;
+  priority: Scalars['Int']['output'];
+  title: Scalars['String']['output'];
+  totalCompletions: Scalars['Int']['output'];
+};
+
+export type HabitFilters = {
+  OR?: InputMaybe<Array<HabitFiltersOr>>;
+  activityTypeId?: InputMaybe<IdFilter>;
+  createdAt?: InputMaybe<DateTimeFilter>;
+  description?: InputMaybe<StringFilter>;
+  estimatedLength?: InputMaybe<StringFilter>;
+  frequencyCount?: InputMaybe<StringFilter>;
+  frequencyUnit?: InputMaybe<StringFilter>;
+  id?: InputMaybe<IdFilter>;
+  minTimeBetweenInstances?: InputMaybe<StringFilter>;
+  pomodoroEnabled?: InputMaybe<BooleanFilter>;
+  pomodoroLongBreakLength?: InputMaybe<StringFilter>;
+  pomodoroShortBreakLength?: InputMaybe<StringFilter>;
+  pomodoroUnitLength?: InputMaybe<StringFilter>;
+  pomodoroUnitsBeforeLongBreak?: InputMaybe<StringFilter>;
+  priority?: InputMaybe<StringFilter>;
+  title?: InputMaybe<StringFilter>;
+  updatedAt?: InputMaybe<DateTimeFilter>;
+  userId?: InputMaybe<IdFilter>;
+};
+
+export type HabitFiltersOr = {
+  activityTypeId?: InputMaybe<IdFilter>;
+  createdAt?: InputMaybe<DateTimeFilter>;
+  description?: InputMaybe<StringFilter>;
+  estimatedLength?: InputMaybe<StringFilter>;
+  frequencyCount?: InputMaybe<StringFilter>;
+  frequencyUnit?: InputMaybe<StringFilter>;
+  id?: InputMaybe<IdFilter>;
+  minTimeBetweenInstances?: InputMaybe<StringFilter>;
+  pomodoroEnabled?: InputMaybe<BooleanFilter>;
+  pomodoroLongBreakLength?: InputMaybe<StringFilter>;
+  pomodoroShortBreakLength?: InputMaybe<StringFilter>;
+  pomodoroUnitLength?: InputMaybe<StringFilter>;
+  pomodoroUnitsBeforeLongBreak?: InputMaybe<StringFilter>;
+  priority?: InputMaybe<StringFilter>;
+  title?: InputMaybe<StringFilter>;
+  updatedAt?: InputMaybe<DateTimeFilter>;
+  userId?: InputMaybe<IdFilter>;
+};
+
+export type HabitOrderBy = {
+  activityTypeId?: InputMaybe<InnerOrder>;
+  createdAt?: InputMaybe<InnerOrder>;
+  description?: InputMaybe<InnerOrder>;
+  estimatedLength?: InputMaybe<InnerOrder>;
+  frequencyCount?: InputMaybe<InnerOrder>;
+  frequencyUnit?: InputMaybe<InnerOrder>;
+  id?: InputMaybe<InnerOrder>;
+  minTimeBetweenInstances?: InputMaybe<InnerOrder>;
+  pomodoroEnabled?: InputMaybe<InnerOrder>;
+  pomodoroLongBreakLength?: InputMaybe<InnerOrder>;
+  pomodoroShortBreakLength?: InputMaybe<InnerOrder>;
+  pomodoroUnitLength?: InputMaybe<InnerOrder>;
+  pomodoroUnitsBeforeLongBreak?: InputMaybe<InnerOrder>;
+  priority?: InputMaybe<InnerOrder>;
+  title?: InputMaybe<InnerOrder>;
+  updatedAt?: InputMaybe<InnerOrder>;
+  userId?: InputMaybe<InnerOrder>;
+};
+
+export type HabitPeriod = {
+  __typename?: 'HabitPeriod';
+  completions: Scalars['Int']['output'];
+  label: Scalars['String']['output'];
+  periodEnd: Scalars['String']['output'];
+  periodStart: Scalars['String']['output'];
+  rate: Scalars['Float']['output'];
+  target: Scalars['Int']['output'];
+};
+
+export type HabitStatSummary = {
+  __typename?: 'HabitStatSummary';
+  activityType: Maybe<ActivityType>;
+  completionRate: Scalars['Float']['output'];
+  completions: Scalars['Int']['output'];
+  frequencyCount: Scalars['Int']['output'];
+  frequencyUnit: Scalars['String']['output'];
+  habitId: Scalars['ID']['output'];
+  target: Scalars['Float']['output'];
+  title: Scalars['String']['output'];
+};
+
+export type HabitStats = {
+  __typename?: 'HabitStats';
+  completionRate: Scalars['Float']['output'];
+  habitId: Scalars['String']['output'];
+  title: Scalars['String']['output'];
+  totalCompletions: Scalars['Int']['output'];
+};
+
+export type IdFilter = {
+  OR?: InputMaybe<Array<IdFilterOr>>;
+  eq?: InputMaybe<Scalars['String']['input']>;
+  gt?: InputMaybe<Scalars['String']['input']>;
+  gte?: InputMaybe<Scalars['String']['input']>;
+  /** Array<undefined> */
+  inArray?: InputMaybe<Array<Scalars['String']['input']>>;
+  isNotNull?: InputMaybe<Scalars['Boolean']['input']>;
+  isNull?: InputMaybe<Scalars['Boolean']['input']>;
+  lt?: InputMaybe<Scalars['String']['input']>;
+  lte?: InputMaybe<Scalars['String']['input']>;
+  ne?: InputMaybe<Scalars['String']['input']>;
+  /** Array<undefined> */
+  notInArray?: InputMaybe<Array<Scalars['String']['input']>>;
+};
+
+export type IdFilterOr = {
+  eq?: InputMaybe<Scalars['String']['input']>;
+  gt?: InputMaybe<Scalars['String']['input']>;
+  gte?: InputMaybe<Scalars['String']['input']>;
+  /** Array<undefined> */
+  inArray?: InputMaybe<Array<Scalars['String']['input']>>;
+  isNotNull?: InputMaybe<Scalars['Boolean']['input']>;
+  isNull?: InputMaybe<Scalars['Boolean']['input']>;
+  lt?: InputMaybe<Scalars['String']['input']>;
+  lte?: InputMaybe<Scalars['String']['input']>;
+  ne?: InputMaybe<Scalars['String']['input']>;
+  /** Array<undefined> */
+  notInArray?: InputMaybe<Array<Scalars['String']['input']>>;
+};
+
+export type InnerOrder = {
+  direction: OrderDirection;
+  /** Priority of current field */
+  priority: Scalars['Int']['input'];
+};
+
+export type Mutation = {
+  __typename?: 'Mutation';
+  createActivityType: Maybe<ActivityType>;
+  createActivityTypes: Array<ActivityType>;
+  createApiKey: Maybe<ApiKey>;
+  createApiKeys: Array<ApiKey>;
+  createHabit: Maybe<Habit>;
+  createHabitCompletion: Maybe<HabitCompletion>;
+  createHabitCompletions: Array<HabitCompletion>;
+  createHabits: Array<Habit>;
+  createTimeBlock: Maybe<TimeBlock>;
+  createTimeBlocks: Array<TimeBlock>;
+  createTodo: Maybe<Todo>;
+  createTodoList: Maybe<TodoList>;
+  createTodoLists: Array<TodoList>;
+  createTodos: Array<Todo>;
+  createUser: Maybe<User>;
+  createUsers: Array<User>;
+  deleteActivityTypes: Array<ActivityType>;
+  deleteApiKeys: Array<ApiKey>;
+  deleteHabitCompletions: Array<HabitCompletion>;
+  deleteHabits: Array<Habit>;
+  deleteTimeBlocks: Array<TimeBlock>;
+  deleteTodoLists: Array<TodoList>;
+  deleteTodos: Array<Todo>;
+  deleteUsers: Array<User>;
+  myCompleteHabit: HabitCompletion;
+  myCompleteTodo: Todo;
+  myCreateActivityType: ActivityType;
+  myCreateApiKey: CreateApiKeyResult;
+  myCreateHabit: Habit;
+  myCreateTimeBlock: TimeBlock;
+  myCreateTodo: Todo;
+  myCreateTodoList: TodoList;
+  myDeleteActivityType: Scalars['Boolean']['output'];
+  myDeleteHabit: Scalars['Boolean']['output'];
+  myDeleteTimeBlock: Scalars['Boolean']['output'];
+  myDeleteTodo: Scalars['Boolean']['output'];
+  myDeleteTodoList: Scalars['Boolean']['output'];
+  myReschedule: Scalars['Boolean']['output'];
+  myRevokeApiKey: Scalars['Boolean']['output'];
+  myUncompleteHabit: Scalars['Boolean']['output'];
+  myUpdateActivityType: ActivityType;
+  myUpdateHabit: Habit;
+  myUpdateProfile: Scalars['Boolean']['output'];
+  myUpdateTimeBlock: TimeBlock;
+  myUpdateTodo: Todo;
+  myUpdateTodoList: TodoList;
+  requestMagicLink: RequestMagicLinkResult;
+  updateActivityTypes: Array<ActivityType>;
+  updateApiKeys: Array<ApiKey>;
+  updateHabitCompletions: Array<HabitCompletion>;
+  updateHabits: Array<Habit>;
+  updateTimeBlocks: Array<TimeBlock>;
+  updateTodoLists: Array<TodoList>;
+  updateTodos: Array<Todo>;
+  updateUsers: Array<User>;
+  verifyMagicLink: VerifyMagicLinkResult;
+};
+
+
+export type MutationCreateActivityTypeArgs = {
+  values: CreateActivityTypeInput;
+};
+
+
+export type MutationCreateActivityTypesArgs = {
+  values: Array<CreateActivityTypeInput>;
+};
+
+
+export type MutationCreateApiKeyArgs = {
+  values: CreateApiKeyInput;
+};
+
+
+export type MutationCreateApiKeysArgs = {
+  values: Array<CreateApiKeyInput>;
+};
+
+
+export type MutationCreateHabitArgs = {
+  values: CreateHabitInput;
+};
+
+
+export type MutationCreateHabitCompletionArgs = {
+  values: CreateHabitCompletionInput;
+};
+
+
+export type MutationCreateHabitCompletionsArgs = {
+  values: Array<CreateHabitCompletionInput>;
+};
+
+
+export type MutationCreateHabitsArgs = {
+  values: Array<CreateHabitInput>;
+};
+
+
+export type MutationCreateTimeBlockArgs = {
+  values: CreateTimeBlockInput;
+};
+
+
+export type MutationCreateTimeBlocksArgs = {
+  values: Array<CreateTimeBlockInput>;
+};
+
+
+export type MutationCreateTodoArgs = {
+  values: CreateTodoInput;
+};
+
+
+export type MutationCreateTodoListArgs = {
+  values: CreateTodoListInput;
+};
+
+
+export type MutationCreateTodoListsArgs = {
+  values: Array<CreateTodoListInput>;
+};
+
+
+export type MutationCreateTodosArgs = {
+  values: Array<CreateTodoInput>;
+};
+
+
+export type MutationCreateUserArgs = {
+  values: CreateUserInput;
+};
+
+
+export type MutationCreateUsersArgs = {
+  values: Array<CreateUserInput>;
+};
+
+
+export type MutationDeleteActivityTypesArgs = {
+  where?: InputMaybe<ActivityTypeFilters>;
+};
+
+
+export type MutationDeleteApiKeysArgs = {
+  where?: InputMaybe<ApiKeyFilters>;
+};
+
+
+export type MutationDeleteHabitCompletionsArgs = {
+  where?: InputMaybe<HabitCompletionFilters>;
+};
+
+
+export type MutationDeleteHabitsArgs = {
+  where?: InputMaybe<HabitFilters>;
+};
+
+
+export type MutationDeleteTimeBlocksArgs = {
+  where?: InputMaybe<TimeBlockFilters>;
+};
+
+
+export type MutationDeleteTodoListsArgs = {
+  where?: InputMaybe<TodoListFilters>;
+};
+
+
+export type MutationDeleteTodosArgs = {
+  where?: InputMaybe<TodoFilters>;
+};
+
+
+export type MutationDeleteUsersArgs = {
+  where?: InputMaybe<UserFilters>;
+};
+
+
+export type MutationMyCompleteHabitArgs = {
+  input: CompleteHabitArgs;
+};
+
+
+export type MutationMyCompleteTodoArgs = {
+  completedAt?: InputMaybe<Scalars['String']['input']>;
+  id: Scalars['ID']['input'];
+};
+
+
+export type MutationMyCreateActivityTypeArgs = {
+  input: CreateActivityTypeArgs;
+};
+
+
+export type MutationMyCreateApiKeyArgs = {
+  input: MyCreateApiKeyInput;
+};
+
+
+export type MutationMyCreateHabitArgs = {
+  input: CreateHabitArgs;
+};
+
+
+export type MutationMyCreateTimeBlockArgs = {
+  input: CreateTimeBlockArgs;
+};
+
+
+export type MutationMyCreateTodoArgs = {
+  input: CreateTodoArgs;
+};
+
+
+export type MutationMyCreateTodoListArgs = {
+  input: CreateTodoListArgs;
+};
+
+
+export type MutationMyDeleteActivityTypeArgs = {
+  id: Scalars['ID']['input'];
+};
+
+
+export type MutationMyDeleteHabitArgs = {
+  id: Scalars['ID']['input'];
+};
+
+
+export type MutationMyDeleteTimeBlockArgs = {
+  id: Scalars['ID']['input'];
+};
+
+
+export type MutationMyDeleteTodoArgs = {
+  id: Scalars['ID']['input'];
+};
+
+
+export type MutationMyDeleteTodoListArgs = {
+  id: Scalars['ID']['input'];
+};
+
+
+export type MutationMyRescheduleArgs = {
+  weekStart?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type MutationMyRevokeApiKeyArgs = {
+  id: Scalars['ID']['input'];
+};
+
+
+export type MutationMyUncompleteHabitArgs = {
+  completionId: Scalars['ID']['input'];
+};
+
+
+export type MutationMyUpdateActivityTypeArgs = {
+  input: UpdateActivityTypeArgs;
+};
+
+
+export type MutationMyUpdateHabitArgs = {
+  input: UpdateHabitArgs;
+};
+
+
+export type MutationMyUpdateProfileArgs = {
+  timezone: Scalars['String']['input'];
+};
+
+
+export type MutationMyUpdateTimeBlockArgs = {
+  input: UpdateTimeBlockArgs;
+};
+
+
+export type MutationMyUpdateTodoArgs = {
+  input: UpdateTodoArgs;
+};
+
+
+export type MutationMyUpdateTodoListArgs = {
+  input: UpdateTodoListArgs;
+};
+
+
+export type MutationRequestMagicLinkArgs = {
+  email: Scalars['String']['input'];
+};
+
+
+export type MutationUpdateActivityTypesArgs = {
+  set: UpdateActivityTypeInput;
+  where?: InputMaybe<ActivityTypeFilters>;
+};
+
+
+export type MutationUpdateApiKeysArgs = {
+  set: UpdateApiKeyInput;
+  where?: InputMaybe<ApiKeyFilters>;
+};
+
+
+export type MutationUpdateHabitCompletionsArgs = {
+  set: UpdateHabitCompletionInput;
+  where?: InputMaybe<HabitCompletionFilters>;
+};
+
+
+export type MutationUpdateHabitsArgs = {
+  set: UpdateHabitInput;
+  where?: InputMaybe<HabitFilters>;
+};
+
+
+export type MutationUpdateTimeBlocksArgs = {
+  set: UpdateTimeBlockInput;
+  where?: InputMaybe<TimeBlockFilters>;
+};
+
+
+export type MutationUpdateTodoListsArgs = {
+  set: UpdateTodoListInput;
+  where?: InputMaybe<TodoListFilters>;
+};
+
+
+export type MutationUpdateTodosArgs = {
+  set: UpdateTodoInput;
+  where?: InputMaybe<TodoFilters>;
+};
+
+
+export type MutationUpdateUsersArgs = {
+  set: UpdateUserInput;
+  where?: InputMaybe<UserFilters>;
+};
+
+
+export type MutationVerifyMagicLinkArgs = {
+  token: Scalars['String']['input'];
+};
+
+export type MyCreateApiKeyInput = {
+  expiresAt?: InputMaybe<Scalars['String']['input']>;
+  name: Scalars['String']['input'];
+  scopes: Array<Scalars['String']['input']>;
+};
+
+/** Order by direction */
+export enum OrderDirection {
+  /** Ascending order */
+  Asc = 'asc',
+  /** Descending order */
+  Desc = 'desc'
+}
+
+export type Query = {
+  __typename?: 'Query';
+  activityType: Maybe<ActivityType>;
+  activityTypeStats: Array<ActivityTypeStats>;
+  activityTypes: Array<ActivityType>;
+  apiKey: Maybe<ApiKey>;
+  apiKeys: Array<ApiKey>;
+  habit: Maybe<Habit>;
+  habitCompletion: Maybe<HabitCompletion>;
+  habitCompletions: Array<HabitCompletion>;
+  habitStats: Array<HabitStats>;
+  habits: Array<Habit>;
+  myActivityTypes: Array<ActivityType>;
+  myApiKeys: Array<ApiKey>;
+  myHabitDetail: HabitDetail;
+  myHabits: Array<Habit>;
+  myProfile: Maybe<UserProfile>;
+  mySchedule: Array<ScheduledItem>;
+  myStats: StatsOverview;
+  myTimeBlocks: Array<TimeBlock>;
+  myTodoLists: Array<TodoList>;
+  myTodos: Array<Todo>;
+  timeBlock: Maybe<TimeBlock>;
+  timeBlocks: Array<TimeBlock>;
+  todo: Maybe<Todo>;
+  todoList: Maybe<TodoList>;
+  todoLists: Array<TodoList>;
+  todos: Array<Todo>;
+  user: Maybe<User>;
+  users: Array<User>;
+};
+
+
+export type QueryActivityTypeArgs = {
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<ActivityTypeOrderBy>;
+  where?: InputMaybe<ActivityTypeFilters>;
+};
+
+
+export type QueryActivityTypeStatsArgs = {
+  endDate?: InputMaybe<Scalars['String']['input']>;
+  startDate?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryActivityTypesArgs = {
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<ActivityTypeOrderBy>;
+  where?: InputMaybe<ActivityTypeFilters>;
+};
+
+
+export type QueryApiKeyArgs = {
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<ApiKeyOrderBy>;
+  where?: InputMaybe<ApiKeyFilters>;
+};
+
+
+export type QueryApiKeysArgs = {
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<ApiKeyOrderBy>;
+  where?: InputMaybe<ApiKeyFilters>;
+};
+
+
+export type QueryHabitArgs = {
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<HabitOrderBy>;
+  where?: InputMaybe<HabitFilters>;
+};
+
+
+export type QueryHabitCompletionArgs = {
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<HabitCompletionOrderBy>;
+  where?: InputMaybe<HabitCompletionFilters>;
+};
+
+
+export type QueryHabitCompletionsArgs = {
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<HabitCompletionOrderBy>;
+  where?: InputMaybe<HabitCompletionFilters>;
+};
+
+
+export type QueryHabitStatsArgs = {
+  endDate?: InputMaybe<Scalars['String']['input']>;
+  habitId?: InputMaybe<Scalars['ID']['input']>;
+  startDate?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryHabitsArgs = {
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<HabitOrderBy>;
+  where?: InputMaybe<HabitFilters>;
+};
+
+
+export type QueryMyHabitDetailArgs = {
+  habitId: Scalars['ID']['input'];
+  periods?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+export type QueryMyHabitsArgs = {
+  activityTypeId?: InputMaybe<Scalars['ID']['input']>;
+};
+
+
+export type QueryMyScheduleArgs = {
+  timezone?: InputMaybe<Scalars['String']['input']>;
+  weekStart?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryMyStatsArgs = {
+  endDate?: InputMaybe<Scalars['String']['input']>;
+  startDate?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryMyTimeBlocksArgs = {
+  activityTypeId?: InputMaybe<Scalars['ID']['input']>;
+  containsDay?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+export type QueryMyTodosArgs = {
+  completed?: InputMaybe<Scalars['Boolean']['input']>;
+  listId?: InputMaybe<Scalars['ID']['input']>;
+  orderBy?: InputMaybe<TodoOrderBy>;
+};
+
+
+export type QueryTimeBlockArgs = {
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<TimeBlockOrderBy>;
+  where?: InputMaybe<TimeBlockFilters>;
+};
+
+
+export type QueryTimeBlocksArgs = {
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<TimeBlockOrderBy>;
+  where?: InputMaybe<TimeBlockFilters>;
+};
+
+
+export type QueryTodoArgs = {
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<TodoOrderBy>;
+  where?: InputMaybe<TodoFilters>;
+};
+
+
+export type QueryTodoListArgs = {
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<TodoListOrderBy>;
+  where?: InputMaybe<TodoListFilters>;
+};
+
+
+export type QueryTodoListsArgs = {
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<TodoListOrderBy>;
+  where?: InputMaybe<TodoListFilters>;
+};
+
+
+export type QueryTodosArgs = {
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<TodoOrderBy>;
+  where?: InputMaybe<TodoFilters>;
+};
+
+
+export type QueryUserArgs = {
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<UserOrderBy>;
+  where?: InputMaybe<UserFilters>;
+};
+
+
+export type QueryUsersArgs = {
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<UserOrderBy>;
+  where?: InputMaybe<UserFilters>;
+};
+
+export type RequestMagicLinkResult = {
+  __typename?: 'RequestMagicLinkResult';
+  magicLink: Maybe<Scalars['String']['output']>;
+  ok: Scalars['Boolean']['output'];
+};
+
+export type ScheduledItem = {
+  __typename?: 'ScheduledItem';
+  activityType: Maybe<ActivityType>;
+  completedAt: Maybe<Scalars['String']['output']>;
+  estimatedLength: Scalars['Int']['output'];
+  id: Scalars['ID']['output'];
+  isOverdue: Scalars['Boolean']['output'];
+  isScheduled: Scalars['Boolean']['output'];
+  kind: ScheduledItemKind;
+  priority: Scalars['Int']['output'];
+  scheduledEnd: Maybe<Scalars['String']['output']>;
+  scheduledStart: Maybe<Scalars['String']['output']>;
+  title: Scalars['String']['output'];
+};
+
+export enum ScheduledItemKind {
+  Habit = 'habit',
+  Pomodoro = 'pomodoro',
+  Todo = 'todo'
+}
+
+export type StatsOverview = {
+  __typename?: 'StatsOverview';
+  habitScore: Maybe<Scalars['Float']['output']>;
+  habits: Array<HabitStatSummary>;
+  todoScore: Maybe<Scalars['Float']['output']>;
+  todos: TodoStatSummary;
+  weightedScore: Maybe<Scalars['Float']['output']>;
+};
+
+export type StringFilter = {
+  OR?: InputMaybe<Array<StringFilterOr>>;
+  eq?: InputMaybe<Scalars['String']['input']>;
+  gt?: InputMaybe<Scalars['String']['input']>;
+  gte?: InputMaybe<Scalars['String']['input']>;
+  ilike?: InputMaybe<Scalars['String']['input']>;
+  /** Array<undefined> */
+  inArray?: InputMaybe<Array<Scalars['String']['input']>>;
+  isNotNull?: InputMaybe<Scalars['Boolean']['input']>;
+  isNull?: InputMaybe<Scalars['Boolean']['input']>;
+  like?: InputMaybe<Scalars['String']['input']>;
+  lt?: InputMaybe<Scalars['String']['input']>;
+  lte?: InputMaybe<Scalars['String']['input']>;
+  ne?: InputMaybe<Scalars['String']['input']>;
+  notIlike?: InputMaybe<Scalars['String']['input']>;
+  /** Array<undefined> */
+  notInArray?: InputMaybe<Array<Scalars['String']['input']>>;
+  notLike?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type StringFilterOr = {
+  eq?: InputMaybe<Scalars['String']['input']>;
+  gt?: InputMaybe<Scalars['String']['input']>;
+  gte?: InputMaybe<Scalars['String']['input']>;
+  ilike?: InputMaybe<Scalars['String']['input']>;
+  /** Array<undefined> */
+  inArray?: InputMaybe<Array<Scalars['String']['input']>>;
+  isNotNull?: InputMaybe<Scalars['Boolean']['input']>;
+  isNull?: InputMaybe<Scalars['Boolean']['input']>;
+  like?: InputMaybe<Scalars['String']['input']>;
+  lt?: InputMaybe<Scalars['String']['input']>;
+  lte?: InputMaybe<Scalars['String']['input']>;
+  ne?: InputMaybe<Scalars['String']['input']>;
+  notIlike?: InputMaybe<Scalars['String']['input']>;
+  /** Array<undefined> */
+  notInArray?: InputMaybe<Array<Scalars['String']['input']>>;
+  notLike?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type Subscription = {
+  __typename?: 'Subscription';
+  myTodoListsUpdated: TodoListEvent;
+  myTodosUpdated: TodoEvent;
+};
+
+export type TimeBlock = {
+  __typename?: 'TimeBlock';
+  activityType: Maybe<ActivityType>;
+  activityTypeId: Scalars['String']['output'];
+  /** DateTime */
+  createdAt: Scalars['DateTime']['output'];
+  daysOfWeek: Array<Scalars['Int']['output']>;
+  endTime: Scalars['String']['output'];
+  id: Scalars['String']['output'];
+  priority: Scalars['Int']['output'];
+  startTime: Scalars['String']['output'];
+  /** DateTime */
+  updatedAt: Scalars['DateTime']['output'];
+  user: Maybe<User>;
+  userId: Scalars['String']['output'];
+};
+
+
+export type TimeBlockActivityTypeArgs = {
+  where?: InputMaybe<ActivityTypeFilters>;
+};
+
+
+export type TimeBlockUserArgs = {
+  where?: InputMaybe<UserFilters>;
+};
+
+export type TimeBlockFilters = {
+  OR?: InputMaybe<Array<TimeBlockFiltersOr>>;
+  activityTypeId?: InputMaybe<IdFilter>;
+  createdAt?: InputMaybe<DateTimeFilter>;
+  daysOfWeek?: InputMaybe<FloatArrayFilter>;
+  endTime?: InputMaybe<StringFilter>;
+  id?: InputMaybe<IdFilter>;
+  priority?: InputMaybe<StringFilter>;
+  startTime?: InputMaybe<StringFilter>;
+  updatedAt?: InputMaybe<DateTimeFilter>;
+  userId?: InputMaybe<IdFilter>;
+};
+
+export type TimeBlockFiltersOr = {
+  activityTypeId?: InputMaybe<IdFilter>;
+  createdAt?: InputMaybe<DateTimeFilter>;
+  daysOfWeek?: InputMaybe<FloatArrayFilter>;
+  endTime?: InputMaybe<StringFilter>;
+  id?: InputMaybe<IdFilter>;
+  priority?: InputMaybe<StringFilter>;
+  startTime?: InputMaybe<StringFilter>;
+  updatedAt?: InputMaybe<DateTimeFilter>;
+  userId?: InputMaybe<IdFilter>;
+};
+
+export type TimeBlockOrderBy = {
+  activityTypeId?: InputMaybe<InnerOrder>;
+  createdAt?: InputMaybe<InnerOrder>;
+  daysOfWeek?: InputMaybe<InnerOrder>;
+  endTime?: InputMaybe<InnerOrder>;
+  id?: InputMaybe<InnerOrder>;
+  priority?: InputMaybe<InnerOrder>;
+  startTime?: InputMaybe<InnerOrder>;
+  updatedAt?: InputMaybe<InnerOrder>;
+  userId?: InputMaybe<InnerOrder>;
+};
+
+export type Todo = {
+  __typename?: 'Todo';
+  activityType: Maybe<ActivityType>;
+  /** DateTime */
+  completedAt: Maybe<Scalars['DateTime']['output']>;
+  /** DateTime */
+  createdAt: Scalars['DateTime']['output'];
+  description: Maybe<Scalars['String']['output']>;
+  /** DateTime */
+  dueAt: Maybe<Scalars['DateTime']['output']>;
+  estimatedLength: Scalars['Int']['output'];
+  id: Scalars['String']['output'];
+  list: Maybe<TodoList>;
+  listId: Scalars['String']['output'];
+  manuallyScheduled: Scalars['Boolean']['output'];
+  priority: Scalars['Int']['output'];
+  /** DateTime */
+  scheduledAt: Maybe<Scalars['DateTime']['output']>;
+  title: Scalars['String']['output'];
+  /** DateTime */
+  updatedAt: Scalars['DateTime']['output'];
+  user: Maybe<User>;
+  userId: Scalars['String']['output'];
+};
+
+
+export type TodoListArgs = {
+  where?: InputMaybe<TodoListFilters>;
+};
+
+
+export type TodoUserArgs = {
+  where?: InputMaybe<UserFilters>;
+};
+
+export type TodoEvent = {
+  __typename?: 'TodoEvent';
+  deletedId: Maybe<Scalars['ID']['output']>;
+  todo: Maybe<Todo>;
+  type: TodoEventType;
+};
+
+export enum TodoEventType {
+  Created = 'created',
+  Deleted = 'deleted',
+  Updated = 'updated'
+}
+
+export type TodoFilters = {
+  OR?: InputMaybe<Array<TodoFiltersOr>>;
+  completedAt?: InputMaybe<DateTimeFilter>;
+  createdAt?: InputMaybe<DateTimeFilter>;
+  description?: InputMaybe<StringFilter>;
+  dueAt?: InputMaybe<DateTimeFilter>;
+  estimatedLength?: InputMaybe<StringFilter>;
+  id?: InputMaybe<IdFilter>;
+  listId?: InputMaybe<IdFilter>;
+  manuallyScheduled?: InputMaybe<BooleanFilter>;
+  priority?: InputMaybe<StringFilter>;
+  scheduledAt?: InputMaybe<DateTimeFilter>;
+  title?: InputMaybe<StringFilter>;
+  updatedAt?: InputMaybe<DateTimeFilter>;
+  userId?: InputMaybe<IdFilter>;
+};
+
+export type TodoFiltersOr = {
+  completedAt?: InputMaybe<DateTimeFilter>;
+  createdAt?: InputMaybe<DateTimeFilter>;
+  description?: InputMaybe<StringFilter>;
+  dueAt?: InputMaybe<DateTimeFilter>;
+  estimatedLength?: InputMaybe<StringFilter>;
+  id?: InputMaybe<IdFilter>;
+  listId?: InputMaybe<IdFilter>;
+  manuallyScheduled?: InputMaybe<BooleanFilter>;
+  priority?: InputMaybe<StringFilter>;
+  scheduledAt?: InputMaybe<DateTimeFilter>;
+  title?: InputMaybe<StringFilter>;
+  updatedAt?: InputMaybe<DateTimeFilter>;
+  userId?: InputMaybe<IdFilter>;
+};
+
+export type TodoList = {
+  __typename?: 'TodoList';
+  activityType: Maybe<ActivityType>;
+  activityTypeId: Scalars['String']['output'];
+  /** DateTime */
+  createdAt: Scalars['DateTime']['output'];
+  defaultEstimatedLength: Scalars['Int']['output'];
+  defaultPriority: Scalars['Int']['output'];
+  description: Maybe<Scalars['String']['output']>;
+  id: Scalars['String']['output'];
+  name: Scalars['String']['output'];
+  todos: Array<Todo>;
+  /** DateTime */
+  updatedAt: Scalars['DateTime']['output'];
+  user: Maybe<User>;
+  userId: Scalars['String']['output'];
+};
+
+
+export type TodoListActivityTypeArgs = {
+  where?: InputMaybe<ActivityTypeFilters>;
+};
+
+
+export type TodoListTodosArgs = {
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<TodoOrderBy>;
+  where?: InputMaybe<TodoFilters>;
+};
+
+
+export type TodoListUserArgs = {
+  where?: InputMaybe<UserFilters>;
+};
+
+export type TodoListEvent = {
+  __typename?: 'TodoListEvent';
+  deletedId: Maybe<Scalars['ID']['output']>;
+  todoList: Maybe<TodoList>;
+  type: TodoEventType;
+};
+
+export type TodoListFilters = {
+  OR?: InputMaybe<Array<TodoListFiltersOr>>;
+  activityTypeId?: InputMaybe<IdFilter>;
+  createdAt?: InputMaybe<DateTimeFilter>;
+  defaultEstimatedLength?: InputMaybe<StringFilter>;
+  defaultPriority?: InputMaybe<StringFilter>;
+  description?: InputMaybe<StringFilter>;
+  id?: InputMaybe<IdFilter>;
+  name?: InputMaybe<StringFilter>;
+  updatedAt?: InputMaybe<DateTimeFilter>;
+  userId?: InputMaybe<IdFilter>;
+};
+
+export type TodoListFiltersOr = {
+  activityTypeId?: InputMaybe<IdFilter>;
+  createdAt?: InputMaybe<DateTimeFilter>;
+  defaultEstimatedLength?: InputMaybe<StringFilter>;
+  defaultPriority?: InputMaybe<StringFilter>;
+  description?: InputMaybe<StringFilter>;
+  id?: InputMaybe<IdFilter>;
+  name?: InputMaybe<StringFilter>;
+  updatedAt?: InputMaybe<DateTimeFilter>;
+  userId?: InputMaybe<IdFilter>;
+};
+
+export type TodoListOrderBy = {
+  activityTypeId?: InputMaybe<InnerOrder>;
+  createdAt?: InputMaybe<InnerOrder>;
+  defaultEstimatedLength?: InputMaybe<InnerOrder>;
+  defaultPriority?: InputMaybe<InnerOrder>;
+  description?: InputMaybe<InnerOrder>;
+  id?: InputMaybe<InnerOrder>;
+  name?: InputMaybe<InnerOrder>;
+  updatedAt?: InputMaybe<InnerOrder>;
+  userId?: InputMaybe<InnerOrder>;
+};
+
+export type TodoOrderBy = {
+  completedAt?: InputMaybe<InnerOrder>;
+  createdAt?: InputMaybe<InnerOrder>;
+  description?: InputMaybe<InnerOrder>;
+  dueAt?: InputMaybe<InnerOrder>;
+  estimatedLength?: InputMaybe<InnerOrder>;
+  id?: InputMaybe<InnerOrder>;
+  listId?: InputMaybe<InnerOrder>;
+  manuallyScheduled?: InputMaybe<InnerOrder>;
+  priority?: InputMaybe<InnerOrder>;
+  scheduledAt?: InputMaybe<InnerOrder>;
+  title?: InputMaybe<InnerOrder>;
+  updatedAt?: InputMaybe<InnerOrder>;
+  userId?: InputMaybe<InnerOrder>;
+};
+
+export type TodoStatSummary = {
+  __typename?: 'TodoStatSummary';
+  completed: Scalars['Int']['output'];
+  completionRate: Scalars['Float']['output'];
+  overdue: Scalars['Int']['output'];
+  total: Scalars['Int']['output'];
+};
+
+export type UpdateActivityTypeArgs = {
+  color?: InputMaybe<Scalars['String']['input']>;
+  id: Scalars['ID']['input'];
+  name?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type UpdateActivityTypeInput = {
+  color?: InputMaybe<Scalars['String']['input']>;
+  /** DateTime */
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  id?: InputMaybe<Scalars['String']['input']>;
+  name?: InputMaybe<Scalars['String']['input']>;
+  /** DateTime */
+  updatedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  userId?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type UpdateApiKeyInput = {
+  /** DateTime */
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  /** DateTime */
+  expiresAt?: InputMaybe<Scalars['DateTime']['input']>;
+  id?: InputMaybe<Scalars['String']['input']>;
+  keyHash?: InputMaybe<Scalars['String']['input']>;
+  keyPrefix?: InputMaybe<Scalars['String']['input']>;
+  /** DateTime */
+  lastUsedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  name?: InputMaybe<Scalars['String']['input']>;
+  /** DateTime */
+  revokedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  scopes?: InputMaybe<Scalars['String']['input']>;
+  userId?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type UpdateHabitArgs = {
+  activityTypeId?: InputMaybe<Scalars['ID']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  estimatedLength?: InputMaybe<Scalars['Int']['input']>;
+  frequencyCount?: InputMaybe<Scalars['Int']['input']>;
+  frequencyUnit?: InputMaybe<Scalars['String']['input']>;
+  id: Scalars['ID']['input'];
+  minTimeBetweenInstances?: InputMaybe<Scalars['Int']['input']>;
+  pomodoroEnabled?: InputMaybe<Scalars['Boolean']['input']>;
+  pomodoroLongBreakLength?: InputMaybe<Scalars['Int']['input']>;
+  pomodoroShortBreakLength?: InputMaybe<Scalars['Int']['input']>;
+  pomodoroUnitLength?: InputMaybe<Scalars['Int']['input']>;
+  pomodoroUnitsBeforeLongBreak?: InputMaybe<Scalars['Int']['input']>;
+  priority?: InputMaybe<Scalars['Int']['input']>;
+  title?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type UpdateHabitCompletionInput = {
+  /** DateTime */
+  completedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  /** DateTime */
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  habitId?: InputMaybe<Scalars['String']['input']>;
+  id?: InputMaybe<Scalars['String']['input']>;
+  /** DateTime */
+  scheduledAt?: InputMaybe<Scalars['DateTime']['input']>;
+};
+
+export type UpdateHabitInput = {
+  activityTypeId?: InputMaybe<Scalars['String']['input']>;
+  /** DateTime */
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  estimatedLength?: InputMaybe<Scalars['Int']['input']>;
+  frequencyCount?: InputMaybe<Scalars['Int']['input']>;
+  frequencyUnit?: InputMaybe<Scalars['String']['input']>;
+  id?: InputMaybe<Scalars['String']['input']>;
+  minTimeBetweenInstances?: InputMaybe<Scalars['Int']['input']>;
+  pomodoroEnabled?: InputMaybe<Scalars['Boolean']['input']>;
+  pomodoroLongBreakLength?: InputMaybe<Scalars['Int']['input']>;
+  pomodoroShortBreakLength?: InputMaybe<Scalars['Int']['input']>;
+  pomodoroUnitLength?: InputMaybe<Scalars['Int']['input']>;
+  pomodoroUnitsBeforeLongBreak?: InputMaybe<Scalars['Int']['input']>;
+  priority?: InputMaybe<Scalars['Int']['input']>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  /** DateTime */
+  updatedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  userId?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type UpdateTimeBlockArgs = {
+  activityTypeId?: InputMaybe<Scalars['ID']['input']>;
+  daysOfWeek?: InputMaybe<Array<Scalars['Int']['input']>>;
+  endTime?: InputMaybe<Scalars['String']['input']>;
+  id: Scalars['ID']['input'];
+  priority?: InputMaybe<Scalars['Int']['input']>;
+  startTime?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type UpdateTimeBlockInput = {
+  activityTypeId?: InputMaybe<Scalars['String']['input']>;
+  /** DateTime */
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  daysOfWeek?: InputMaybe<Array<Scalars['Int']['input']>>;
+  endTime?: InputMaybe<Scalars['String']['input']>;
+  id?: InputMaybe<Scalars['String']['input']>;
+  priority?: InputMaybe<Scalars['Int']['input']>;
+  startTime?: InputMaybe<Scalars['String']['input']>;
+  /** DateTime */
+  updatedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  userId?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type UpdateTodoArgs = {
+  completedAt?: InputMaybe<Scalars['String']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  dueAt?: InputMaybe<Scalars['String']['input']>;
+  estimatedLength?: InputMaybe<Scalars['Int']['input']>;
+  id: Scalars['ID']['input'];
+  listId?: InputMaybe<Scalars['ID']['input']>;
+  manuallyScheduled?: InputMaybe<Scalars['Boolean']['input']>;
+  priority?: InputMaybe<Scalars['Int']['input']>;
+  scheduledAt?: InputMaybe<Scalars['String']['input']>;
+  title?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type UpdateTodoInput = {
+  /** DateTime */
+  completedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  /** DateTime */
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  /** DateTime */
+  dueAt?: InputMaybe<Scalars['DateTime']['input']>;
+  estimatedLength?: InputMaybe<Scalars['Int']['input']>;
+  id?: InputMaybe<Scalars['String']['input']>;
+  listId?: InputMaybe<Scalars['String']['input']>;
+  manuallyScheduled?: InputMaybe<Scalars['Boolean']['input']>;
+  priority?: InputMaybe<Scalars['Int']['input']>;
+  /** DateTime */
+  scheduledAt?: InputMaybe<Scalars['DateTime']['input']>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  /** DateTime */
+  updatedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  userId?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type UpdateTodoListArgs = {
+  activityTypeId?: InputMaybe<Scalars['ID']['input']>;
+  defaultEstimatedLength?: InputMaybe<Scalars['Int']['input']>;
+  defaultPriority?: InputMaybe<Scalars['Int']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  id: Scalars['ID']['input'];
+  name?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type UpdateTodoListInput = {
+  activityTypeId?: InputMaybe<Scalars['String']['input']>;
+  /** DateTime */
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  defaultEstimatedLength?: InputMaybe<Scalars['Int']['input']>;
+  defaultPriority?: InputMaybe<Scalars['Int']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  id?: InputMaybe<Scalars['String']['input']>;
+  name?: InputMaybe<Scalars['String']['input']>;
+  /** DateTime */
+  updatedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  userId?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type UpdateUserInput = {
+  /** DateTime */
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  email?: InputMaybe<Scalars['String']['input']>;
+  id?: InputMaybe<Scalars['String']['input']>;
+  timezone?: InputMaybe<Scalars['String']['input']>;
+  /** DateTime */
+  updatedAt?: InputMaybe<Scalars['DateTime']['input']>;
+};
+
+export type User = {
+  __typename?: 'User';
+  activityTypes: Array<ActivityType>;
+  apiKeys: Array<ApiKey>;
+  /** DateTime */
+  createdAt: Scalars['DateTime']['output'];
+  email: Scalars['String']['output'];
+  habits: Array<Habit>;
+  id: Scalars['String']['output'];
+  timeBlocks: Array<TimeBlock>;
+  timezone: Scalars['String']['output'];
+  todoLists: Array<TodoList>;
+  todos: Array<Todo>;
+  /** DateTime */
+  updatedAt: Scalars['DateTime']['output'];
+};
+
+
+export type UserActivityTypesArgs = {
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<ActivityTypeOrderBy>;
+  where?: InputMaybe<ActivityTypeFilters>;
+};
+
+
+export type UserApiKeysArgs = {
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<ApiKeyOrderBy>;
+  where?: InputMaybe<ApiKeyFilters>;
+};
+
+
+export type UserHabitsArgs = {
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<HabitOrderBy>;
+  where?: InputMaybe<HabitFilters>;
+};
+
+
+export type UserTimeBlocksArgs = {
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<TimeBlockOrderBy>;
+  where?: InputMaybe<TimeBlockFilters>;
+};
+
+
+export type UserTodoListsArgs = {
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<TodoListOrderBy>;
+  where?: InputMaybe<TodoListFilters>;
+};
+
+
+export type UserTodosArgs = {
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<TodoOrderBy>;
+  where?: InputMaybe<TodoFilters>;
+};
+
+export type UserFilters = {
+  OR?: InputMaybe<Array<UserFiltersOr>>;
+  createdAt?: InputMaybe<DateTimeFilter>;
+  email?: InputMaybe<StringFilter>;
+  id?: InputMaybe<IdFilter>;
+  timezone?: InputMaybe<StringFilter>;
+  updatedAt?: InputMaybe<DateTimeFilter>;
+};
+
+export type UserFiltersOr = {
+  createdAt?: InputMaybe<DateTimeFilter>;
+  email?: InputMaybe<StringFilter>;
+  id?: InputMaybe<IdFilter>;
+  timezone?: InputMaybe<StringFilter>;
+  updatedAt?: InputMaybe<DateTimeFilter>;
+};
+
+export type UserOrderBy = {
+  createdAt?: InputMaybe<InnerOrder>;
+  email?: InputMaybe<InnerOrder>;
+  id?: InputMaybe<InnerOrder>;
+  timezone?: InputMaybe<InnerOrder>;
+  updatedAt?: InputMaybe<InnerOrder>;
+};
+
+export type UserProfile = {
+  __typename?: 'UserProfile';
+  email: Scalars['String']['output'];
+  id: Scalars['ID']['output'];
+  timezone: Scalars['String']['output'];
+};
+
+export type VerifyMagicLinkResult = {
+  __typename?: 'VerifyMagicLinkResult';
+  token: Scalars['String']['output'];
+  userId: Scalars['ID']['output'];
+};
+
+
+
+export type ResolverTypeWrapper<T> = Promise<T> | T;
+
+
+export type ResolverWithResolve<TResult, TParent, TContext, TArgs> = {
+  resolve: ResolverFn<TResult, TParent, TContext, TArgs>;
+};
+export type Resolver<TResult, TParent = Record<PropertyKey, never>, TContext = Record<PropertyKey, never>, TArgs = Record<PropertyKey, never>> = ResolverFn<TResult, TParent, TContext, TArgs> | ResolverWithResolve<TResult, TParent, TContext, TArgs>;
+
+export type ResolverFn<TResult, TParent, TContext, TArgs> = (
+  parent: TParent,
+  args: TArgs,
+  context: TContext,
+  info: GraphQLResolveInfo
+) => Promise<TResult> | TResult;
+
+export type SubscriptionSubscribeFn<TResult, TParent, TContext, TArgs> = (
+  parent: TParent,
+  args: TArgs,
+  context: TContext,
+  info: GraphQLResolveInfo
+) => AsyncIterable<TResult> | Promise<AsyncIterable<TResult>>;
+
+export type SubscriptionResolveFn<TResult, TParent, TContext, TArgs> = (
+  parent: TParent,
+  args: TArgs,
+  context: TContext,
+  info: GraphQLResolveInfo
+) => TResult | Promise<TResult>;
+
+export interface SubscriptionSubscriberObject<TResult, TKey extends string, TParent, TContext, TArgs> {
+  subscribe: SubscriptionSubscribeFn<{ [key in TKey]: TResult }, TParent, TContext, TArgs>;
+  resolve?: SubscriptionResolveFn<TResult, { [key in TKey]: TResult }, TContext, TArgs>;
+}
+
+export interface SubscriptionResolverObject<TResult, TParent, TContext, TArgs> {
+  subscribe: SubscriptionSubscribeFn<any, TParent, TContext, TArgs>;
+  resolve: SubscriptionResolveFn<TResult, any, TContext, TArgs>;
+}
+
+export type SubscriptionObject<TResult, TKey extends string, TParent, TContext, TArgs> =
+  | SubscriptionSubscriberObject<TResult, TKey, TParent, TContext, TArgs>
+  | SubscriptionResolverObject<TResult, TParent, TContext, TArgs>;
+
+export type SubscriptionResolver<TResult, TKey extends string, TParent = Record<PropertyKey, never>, TContext = Record<PropertyKey, never>, TArgs = Record<PropertyKey, never>> =
+  | ((...args: any[]) => SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>)
+  | SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>;
+
+export type TypeResolveFn<TTypes, TParent = Record<PropertyKey, never>, TContext = Record<PropertyKey, never>> = (
+  parent: TParent,
+  context: TContext,
+  info: GraphQLResolveInfo
+) => Maybe<TTypes> | Promise<Maybe<TTypes>>;
+
+export type IsTypeOfResolverFn<T = Record<PropertyKey, never>, TContext = Record<PropertyKey, never>> = (obj: T, context: TContext, info: GraphQLResolveInfo) => boolean | Promise<boolean>;
+
+export type NextResolverFn<T> = () => Promise<T>;
+
+export type DirectiveResolverFn<TResult = Record<PropertyKey, never>, TParent = Record<PropertyKey, never>, TContext = Record<PropertyKey, never>, TArgs = Record<PropertyKey, never>> = (
+  next: NextResolverFn<TResult>,
+  parent: TParent,
+  args: TArgs,
+  context: TContext,
+  info: GraphQLResolveInfo
+) => TResult | Promise<TResult>;
+
+
+
+
+
+/** Mapping between all available schema types and the resolvers types */
+export type ResolversTypes = {
+  ActivityType: ResolverTypeWrapper<ActivityType>;
+  ActivityTypeFilters: ActivityTypeFilters;
+  ActivityTypeFiltersOr: ActivityTypeFiltersOr;
+  ActivityTypeOrderBy: ActivityTypeOrderBy;
+  ActivityTypeStats: ResolverTypeWrapper<ActivityTypeStats>;
+  ApiKey: ResolverTypeWrapper<ApiKey>;
+  ApiKeyFilters: ApiKeyFilters;
+  ApiKeyFiltersOr: ApiKeyFiltersOr;
+  ApiKeyOrderBy: ApiKeyOrderBy;
+  Boolean: ResolverTypeWrapper<Scalars['Boolean']['output']>;
+  BooleanFilter: BooleanFilter;
+  BooleanFilterOr: BooleanFilterOr;
+  CompleteHabitArgs: CompleteHabitArgs;
+  CreateActivityTypeArgs: CreateActivityTypeArgs;
+  CreateActivityTypeInput: CreateActivityTypeInput;
+  CreateApiKeyInput: CreateApiKeyInput;
+  CreateApiKeyResult: ResolverTypeWrapper<CreateApiKeyResult>;
+  CreateHabitArgs: CreateHabitArgs;
+  CreateHabitCompletionInput: CreateHabitCompletionInput;
+  CreateHabitInput: CreateHabitInput;
+  CreateTimeBlockArgs: CreateTimeBlockArgs;
+  CreateTimeBlockInput: CreateTimeBlockInput;
+  CreateTodoArgs: CreateTodoArgs;
+  CreateTodoInput: CreateTodoInput;
+  CreateTodoListArgs: CreateTodoListArgs;
+  CreateTodoListInput: CreateTodoListInput;
+  CreateUserInput: CreateUserInput;
+  DateTime: ResolverTypeWrapper<Scalars['DateTime']['output']>;
+  DateTimeFilter: DateTimeFilter;
+  DateTimeFilterOr: DateTimeFilterOr;
+  Float: ResolverTypeWrapper<Scalars['Float']['output']>;
+  FloatArrayFilter: FloatArrayFilter;
+  FloatArrayFilterOr: FloatArrayFilterOr;
+  Habit: ResolverTypeWrapper<Habit>;
+  HabitCompletion: ResolverTypeWrapper<HabitCompletion>;
+  HabitCompletionFilters: HabitCompletionFilters;
+  HabitCompletionFiltersOr: HabitCompletionFiltersOr;
+  HabitCompletionOrderBy: HabitCompletionOrderBy;
+  HabitDetail: ResolverTypeWrapper<HabitDetail>;
+  HabitFilters: HabitFilters;
+  HabitFiltersOr: HabitFiltersOr;
+  HabitOrderBy: HabitOrderBy;
+  HabitPeriod: ResolverTypeWrapper<HabitPeriod>;
+  HabitStatSummary: ResolverTypeWrapper<HabitStatSummary>;
+  HabitStats: ResolverTypeWrapper<HabitStats>;
+  ID: ResolverTypeWrapper<Scalars['ID']['output']>;
+  IdFilter: IdFilter;
+  IdFilterOr: IdFilterOr;
+  InnerOrder: InnerOrder;
+  Int: ResolverTypeWrapper<Scalars['Int']['output']>;
+  Mutation: ResolverTypeWrapper<Record<PropertyKey, never>>;
+  MyCreateApiKeyInput: MyCreateApiKeyInput;
+  OrderDirection: OrderDirection;
+  Query: ResolverTypeWrapper<Record<PropertyKey, never>>;
+  RequestMagicLinkResult: ResolverTypeWrapper<RequestMagicLinkResult>;
+  ScheduledItem: ResolverTypeWrapper<ScheduledItem>;
+  ScheduledItemKind: ScheduledItemKind;
+  StatsOverview: ResolverTypeWrapper<StatsOverview>;
+  String: ResolverTypeWrapper<Scalars['String']['output']>;
+  StringFilter: StringFilter;
+  StringFilterOr: StringFilterOr;
+  Subscription: ResolverTypeWrapper<Record<PropertyKey, never>>;
+  TimeBlock: ResolverTypeWrapper<TimeBlock>;
+  TimeBlockFilters: TimeBlockFilters;
+  TimeBlockFiltersOr: TimeBlockFiltersOr;
+  TimeBlockOrderBy: TimeBlockOrderBy;
+  Todo: ResolverTypeWrapper<Todo>;
+  TodoEvent: ResolverTypeWrapper<TodoEvent>;
+  TodoEventType: TodoEventType;
+  TodoFilters: TodoFilters;
+  TodoFiltersOr: TodoFiltersOr;
+  TodoList: ResolverTypeWrapper<TodoList>;
+  TodoListEvent: ResolverTypeWrapper<TodoListEvent>;
+  TodoListFilters: TodoListFilters;
+  TodoListFiltersOr: TodoListFiltersOr;
+  TodoListOrderBy: TodoListOrderBy;
+  TodoOrderBy: TodoOrderBy;
+  TodoStatSummary: ResolverTypeWrapper<TodoStatSummary>;
+  UpdateActivityTypeArgs: UpdateActivityTypeArgs;
+  UpdateActivityTypeInput: UpdateActivityTypeInput;
+  UpdateApiKeyInput: UpdateApiKeyInput;
+  UpdateHabitArgs: UpdateHabitArgs;
+  UpdateHabitCompletionInput: UpdateHabitCompletionInput;
+  UpdateHabitInput: UpdateHabitInput;
+  UpdateTimeBlockArgs: UpdateTimeBlockArgs;
+  UpdateTimeBlockInput: UpdateTimeBlockInput;
+  UpdateTodoArgs: UpdateTodoArgs;
+  UpdateTodoInput: UpdateTodoInput;
+  UpdateTodoListArgs: UpdateTodoListArgs;
+  UpdateTodoListInput: UpdateTodoListInput;
+  UpdateUserInput: UpdateUserInput;
+  User: ResolverTypeWrapper<User>;
+  UserFilters: UserFilters;
+  UserFiltersOr: UserFiltersOr;
+  UserOrderBy: UserOrderBy;
+  UserProfile: ResolverTypeWrapper<UserProfile>;
+  VerifyMagicLinkResult: ResolverTypeWrapper<VerifyMagicLinkResult>;
+};
+
+/** Mapping between all available schema types and the resolvers parents */
+export type ResolversParentTypes = {
+  ActivityType: ActivityType;
+  ActivityTypeFilters: ActivityTypeFilters;
+  ActivityTypeFiltersOr: ActivityTypeFiltersOr;
+  ActivityTypeOrderBy: ActivityTypeOrderBy;
+  ActivityTypeStats: ActivityTypeStats;
+  ApiKey: ApiKey;
+  ApiKeyFilters: ApiKeyFilters;
+  ApiKeyFiltersOr: ApiKeyFiltersOr;
+  ApiKeyOrderBy: ApiKeyOrderBy;
+  Boolean: Scalars['Boolean']['output'];
+  BooleanFilter: BooleanFilter;
+  BooleanFilterOr: BooleanFilterOr;
+  CompleteHabitArgs: CompleteHabitArgs;
+  CreateActivityTypeArgs: CreateActivityTypeArgs;
+  CreateActivityTypeInput: CreateActivityTypeInput;
+  CreateApiKeyInput: CreateApiKeyInput;
+  CreateApiKeyResult: CreateApiKeyResult;
+  CreateHabitArgs: CreateHabitArgs;
+  CreateHabitCompletionInput: CreateHabitCompletionInput;
+  CreateHabitInput: CreateHabitInput;
+  CreateTimeBlockArgs: CreateTimeBlockArgs;
+  CreateTimeBlockInput: CreateTimeBlockInput;
+  CreateTodoArgs: CreateTodoArgs;
+  CreateTodoInput: CreateTodoInput;
+  CreateTodoListArgs: CreateTodoListArgs;
+  CreateTodoListInput: CreateTodoListInput;
+  CreateUserInput: CreateUserInput;
+  DateTime: Scalars['DateTime']['output'];
+  DateTimeFilter: DateTimeFilter;
+  DateTimeFilterOr: DateTimeFilterOr;
+  Float: Scalars['Float']['output'];
+  FloatArrayFilter: FloatArrayFilter;
+  FloatArrayFilterOr: FloatArrayFilterOr;
+  Habit: Habit;
+  HabitCompletion: HabitCompletion;
+  HabitCompletionFilters: HabitCompletionFilters;
+  HabitCompletionFiltersOr: HabitCompletionFiltersOr;
+  HabitCompletionOrderBy: HabitCompletionOrderBy;
+  HabitDetail: HabitDetail;
+  HabitFilters: HabitFilters;
+  HabitFiltersOr: HabitFiltersOr;
+  HabitOrderBy: HabitOrderBy;
+  HabitPeriod: HabitPeriod;
+  HabitStatSummary: HabitStatSummary;
+  HabitStats: HabitStats;
+  ID: Scalars['ID']['output'];
+  IdFilter: IdFilter;
+  IdFilterOr: IdFilterOr;
+  InnerOrder: InnerOrder;
+  Int: Scalars['Int']['output'];
+  Mutation: Record<PropertyKey, never>;
+  MyCreateApiKeyInput: MyCreateApiKeyInput;
+  Query: Record<PropertyKey, never>;
+  RequestMagicLinkResult: RequestMagicLinkResult;
+  ScheduledItem: ScheduledItem;
+  StatsOverview: StatsOverview;
+  String: Scalars['String']['output'];
+  StringFilter: StringFilter;
+  StringFilterOr: StringFilterOr;
+  Subscription: Record<PropertyKey, never>;
+  TimeBlock: TimeBlock;
+  TimeBlockFilters: TimeBlockFilters;
+  TimeBlockFiltersOr: TimeBlockFiltersOr;
+  TimeBlockOrderBy: TimeBlockOrderBy;
+  Todo: Todo;
+  TodoEvent: TodoEvent;
+  TodoFilters: TodoFilters;
+  TodoFiltersOr: TodoFiltersOr;
+  TodoList: TodoList;
+  TodoListEvent: TodoListEvent;
+  TodoListFilters: TodoListFilters;
+  TodoListFiltersOr: TodoListFiltersOr;
+  TodoListOrderBy: TodoListOrderBy;
+  TodoOrderBy: TodoOrderBy;
+  TodoStatSummary: TodoStatSummary;
+  UpdateActivityTypeArgs: UpdateActivityTypeArgs;
+  UpdateActivityTypeInput: UpdateActivityTypeInput;
+  UpdateApiKeyInput: UpdateApiKeyInput;
+  UpdateHabitArgs: UpdateHabitArgs;
+  UpdateHabitCompletionInput: UpdateHabitCompletionInput;
+  UpdateHabitInput: UpdateHabitInput;
+  UpdateTimeBlockArgs: UpdateTimeBlockArgs;
+  UpdateTimeBlockInput: UpdateTimeBlockInput;
+  UpdateTodoArgs: UpdateTodoArgs;
+  UpdateTodoInput: UpdateTodoInput;
+  UpdateTodoListArgs: UpdateTodoListArgs;
+  UpdateTodoListInput: UpdateTodoListInput;
+  UpdateUserInput: UpdateUserInput;
+  User: User;
+  UserFilters: UserFilters;
+  UserFiltersOr: UserFiltersOr;
+  UserOrderBy: UserOrderBy;
+  UserProfile: UserProfile;
+  VerifyMagicLinkResult: VerifyMagicLinkResult;
+};
+
+export type ActivityTypeResolvers<ContextType = Context, ParentType extends ResolversParentTypes['ActivityType'] = ResolversParentTypes['ActivityType']> = {
+  color?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  createdAt?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
+  habits?: Resolver<Array<ResolversTypes['Habit']>, ParentType, ContextType, Partial<ActivityTypeHabitsArgs>>;
+  id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  timeBlocks?: Resolver<Array<ResolversTypes['TimeBlock']>, ParentType, ContextType, Partial<ActivityTypeTimeBlocksArgs>>;
+  todoLists?: Resolver<Array<ResolversTypes['TodoList']>, ParentType, ContextType, Partial<ActivityTypeTodoListsArgs>>;
+  updatedAt?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
+  user?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType, Partial<ActivityTypeUserArgs>>;
+  userId?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+};
+
+export type ActivityTypeStatsResolvers<ContextType = Context, ParentType extends ResolversParentTypes['ActivityTypeStats'] = ResolversParentTypes['ActivityTypeStats']> = {
+  activityTypeId?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  activityTypeName?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  completedTodos?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  totalHabits?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  totalTodos?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+};
+
+export type ApiKeyResolvers<ContextType = Context, ParentType extends ResolversParentTypes['ApiKey'] = ResolversParentTypes['ApiKey']> = {
+  createdAt?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
+  expiresAt?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
+  id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  keyHash?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  keyPrefix?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  lastUsedAt?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
+  name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  revokedAt?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
+  scopes?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
+  user?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType, Partial<ApiKeyUserArgs>>;
+  userId?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+};
+
+export type CreateApiKeyResultResolvers<ContextType = Context, ParentType extends ResolversParentTypes['CreateApiKeyResult'] = ResolversParentTypes['CreateApiKeyResult']> = {
+  apiKey?: Resolver<ResolversTypes['ApiKey'], ParentType, ContextType>;
+  token?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+};
+
+export interface DateTimeScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['DateTime'], any> {
+  name: 'DateTime';
+}
+
+export type HabitResolvers<ContextType = Context, ParentType extends ResolversParentTypes['Habit'] = ResolversParentTypes['Habit']> = {
+  activityType?: Resolver<Maybe<ResolversTypes['ActivityType']>, ParentType, ContextType, Partial<HabitActivityTypeArgs>>;
+  activityTypeId?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  completions?: Resolver<Array<ResolversTypes['HabitCompletion']>, ParentType, ContextType, Partial<HabitCompletionsArgs>>;
+  createdAt?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
+  description?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  estimatedLength?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  frequencyCount?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  frequencyUnit?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  minTimeBetweenInstances?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  pomodoroEnabled?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  pomodoroLongBreakLength?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  pomodoroShortBreakLength?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  pomodoroUnitLength?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  pomodoroUnitsBeforeLongBreak?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  priority?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  title?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  updatedAt?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
+  user?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType, Partial<HabitUserArgs>>;
+  userId?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+};
+
+export type HabitCompletionResolvers<ContextType = Context, ParentType extends ResolversParentTypes['HabitCompletion'] = ResolversParentTypes['HabitCompletion']> = {
+  completedAt?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
+  createdAt?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
+  habit?: Resolver<Maybe<ResolversTypes['Habit']>, ParentType, ContextType, Partial<HabitCompletionHabitArgs>>;
+  habitId?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  scheduledAt?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
+};
+
+export type HabitDetailResolvers<ContextType = Context, ParentType extends ResolversParentTypes['HabitDetail'] = ResolversParentTypes['HabitDetail']> = {
+  activityType?: Resolver<Maybe<ResolversTypes['ActivityType']>, ParentType, ContextType>;
+  allTimeRate?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
+  description?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  estimatedLength?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  frequencyCount?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  frequencyUnit?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  habitId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  periods?: Resolver<Array<ResolversTypes['HabitPeriod']>, ParentType, ContextType>;
+  priority?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  title?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  totalCompletions?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+};
+
+export type HabitPeriodResolvers<ContextType = Context, ParentType extends ResolversParentTypes['HabitPeriod'] = ResolversParentTypes['HabitPeriod']> = {
+  completions?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  label?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  periodEnd?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  periodStart?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  rate?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
+  target?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+};
+
+export type HabitStatSummaryResolvers<ContextType = Context, ParentType extends ResolversParentTypes['HabitStatSummary'] = ResolversParentTypes['HabitStatSummary']> = {
+  activityType?: Resolver<Maybe<ResolversTypes['ActivityType']>, ParentType, ContextType>;
+  completionRate?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
+  completions?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  frequencyCount?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  frequencyUnit?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  habitId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  target?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
+  title?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+};
+
+export type HabitStatsResolvers<ContextType = Context, ParentType extends ResolversParentTypes['HabitStats'] = ResolversParentTypes['HabitStats']> = {
+  completionRate?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
+  habitId?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  title?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  totalCompletions?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+};
+
+export type MutationResolvers<ContextType = Context, ParentType extends ResolversParentTypes['Mutation'] = ResolversParentTypes['Mutation']> = {
+  createActivityType?: Resolver<Maybe<ResolversTypes['ActivityType']>, ParentType, ContextType, RequireFields<MutationCreateActivityTypeArgs, 'values'>>;
+  createActivityTypes?: Resolver<Array<ResolversTypes['ActivityType']>, ParentType, ContextType, RequireFields<MutationCreateActivityTypesArgs, 'values'>>;
+  createApiKey?: Resolver<Maybe<ResolversTypes['ApiKey']>, ParentType, ContextType, RequireFields<MutationCreateApiKeyArgs, 'values'>>;
+  createApiKeys?: Resolver<Array<ResolversTypes['ApiKey']>, ParentType, ContextType, RequireFields<MutationCreateApiKeysArgs, 'values'>>;
+  createHabit?: Resolver<Maybe<ResolversTypes['Habit']>, ParentType, ContextType, RequireFields<MutationCreateHabitArgs, 'values'>>;
+  createHabitCompletion?: Resolver<Maybe<ResolversTypes['HabitCompletion']>, ParentType, ContextType, RequireFields<MutationCreateHabitCompletionArgs, 'values'>>;
+  createHabitCompletions?: Resolver<Array<ResolversTypes['HabitCompletion']>, ParentType, ContextType, RequireFields<MutationCreateHabitCompletionsArgs, 'values'>>;
+  createHabits?: Resolver<Array<ResolversTypes['Habit']>, ParentType, ContextType, RequireFields<MutationCreateHabitsArgs, 'values'>>;
+  createTimeBlock?: Resolver<Maybe<ResolversTypes['TimeBlock']>, ParentType, ContextType, RequireFields<MutationCreateTimeBlockArgs, 'values'>>;
+  createTimeBlocks?: Resolver<Array<ResolversTypes['TimeBlock']>, ParentType, ContextType, RequireFields<MutationCreateTimeBlocksArgs, 'values'>>;
+  createTodo?: Resolver<Maybe<ResolversTypes['Todo']>, ParentType, ContextType, RequireFields<MutationCreateTodoArgs, 'values'>>;
+  createTodoList?: Resolver<Maybe<ResolversTypes['TodoList']>, ParentType, ContextType, RequireFields<MutationCreateTodoListArgs, 'values'>>;
+  createTodoLists?: Resolver<Array<ResolversTypes['TodoList']>, ParentType, ContextType, RequireFields<MutationCreateTodoListsArgs, 'values'>>;
+  createTodos?: Resolver<Array<ResolversTypes['Todo']>, ParentType, ContextType, RequireFields<MutationCreateTodosArgs, 'values'>>;
+  createUser?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType, RequireFields<MutationCreateUserArgs, 'values'>>;
+  createUsers?: Resolver<Array<ResolversTypes['User']>, ParentType, ContextType, RequireFields<MutationCreateUsersArgs, 'values'>>;
+  deleteActivityTypes?: Resolver<Array<ResolversTypes['ActivityType']>, ParentType, ContextType, Partial<MutationDeleteActivityTypesArgs>>;
+  deleteApiKeys?: Resolver<Array<ResolversTypes['ApiKey']>, ParentType, ContextType, Partial<MutationDeleteApiKeysArgs>>;
+  deleteHabitCompletions?: Resolver<Array<ResolversTypes['HabitCompletion']>, ParentType, ContextType, Partial<MutationDeleteHabitCompletionsArgs>>;
+  deleteHabits?: Resolver<Array<ResolversTypes['Habit']>, ParentType, ContextType, Partial<MutationDeleteHabitsArgs>>;
+  deleteTimeBlocks?: Resolver<Array<ResolversTypes['TimeBlock']>, ParentType, ContextType, Partial<MutationDeleteTimeBlocksArgs>>;
+  deleteTodoLists?: Resolver<Array<ResolversTypes['TodoList']>, ParentType, ContextType, Partial<MutationDeleteTodoListsArgs>>;
+  deleteTodos?: Resolver<Array<ResolversTypes['Todo']>, ParentType, ContextType, Partial<MutationDeleteTodosArgs>>;
+  deleteUsers?: Resolver<Array<ResolversTypes['User']>, ParentType, ContextType, Partial<MutationDeleteUsersArgs>>;
+  myCompleteHabit?: Resolver<ResolversTypes['HabitCompletion'], ParentType, ContextType, RequireFields<MutationMyCompleteHabitArgs, 'input'>>;
+  myCompleteTodo?: Resolver<ResolversTypes['Todo'], ParentType, ContextType, RequireFields<MutationMyCompleteTodoArgs, 'id'>>;
+  myCreateActivityType?: Resolver<ResolversTypes['ActivityType'], ParentType, ContextType, RequireFields<MutationMyCreateActivityTypeArgs, 'input'>>;
+  myCreateApiKey?: Resolver<ResolversTypes['CreateApiKeyResult'], ParentType, ContextType, RequireFields<MutationMyCreateApiKeyArgs, 'input'>>;
+  myCreateHabit?: Resolver<ResolversTypes['Habit'], ParentType, ContextType, RequireFields<MutationMyCreateHabitArgs, 'input'>>;
+  myCreateTimeBlock?: Resolver<ResolversTypes['TimeBlock'], ParentType, ContextType, RequireFields<MutationMyCreateTimeBlockArgs, 'input'>>;
+  myCreateTodo?: Resolver<ResolversTypes['Todo'], ParentType, ContextType, RequireFields<MutationMyCreateTodoArgs, 'input'>>;
+  myCreateTodoList?: Resolver<ResolversTypes['TodoList'], ParentType, ContextType, RequireFields<MutationMyCreateTodoListArgs, 'input'>>;
+  myDeleteActivityType?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType, RequireFields<MutationMyDeleteActivityTypeArgs, 'id'>>;
+  myDeleteHabit?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType, RequireFields<MutationMyDeleteHabitArgs, 'id'>>;
+  myDeleteTimeBlock?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType, RequireFields<MutationMyDeleteTimeBlockArgs, 'id'>>;
+  myDeleteTodo?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType, RequireFields<MutationMyDeleteTodoArgs, 'id'>>;
+  myDeleteTodoList?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType, RequireFields<MutationMyDeleteTodoListArgs, 'id'>>;
+  myReschedule?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType, Partial<MutationMyRescheduleArgs>>;
+  myRevokeApiKey?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType, RequireFields<MutationMyRevokeApiKeyArgs, 'id'>>;
+  myUncompleteHabit?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType, RequireFields<MutationMyUncompleteHabitArgs, 'completionId'>>;
+  myUpdateActivityType?: Resolver<ResolversTypes['ActivityType'], ParentType, ContextType, RequireFields<MutationMyUpdateActivityTypeArgs, 'input'>>;
+  myUpdateHabit?: Resolver<ResolversTypes['Habit'], ParentType, ContextType, RequireFields<MutationMyUpdateHabitArgs, 'input'>>;
+  myUpdateProfile?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType, RequireFields<MutationMyUpdateProfileArgs, 'timezone'>>;
+  myUpdateTimeBlock?: Resolver<ResolversTypes['TimeBlock'], ParentType, ContextType, RequireFields<MutationMyUpdateTimeBlockArgs, 'input'>>;
+  myUpdateTodo?: Resolver<ResolversTypes['Todo'], ParentType, ContextType, RequireFields<MutationMyUpdateTodoArgs, 'input'>>;
+  myUpdateTodoList?: Resolver<ResolversTypes['TodoList'], ParentType, ContextType, RequireFields<MutationMyUpdateTodoListArgs, 'input'>>;
+  requestMagicLink?: Resolver<ResolversTypes['RequestMagicLinkResult'], ParentType, ContextType, RequireFields<MutationRequestMagicLinkArgs, 'email'>>;
+  updateActivityTypes?: Resolver<Array<ResolversTypes['ActivityType']>, ParentType, ContextType, RequireFields<MutationUpdateActivityTypesArgs, 'set'>>;
+  updateApiKeys?: Resolver<Array<ResolversTypes['ApiKey']>, ParentType, ContextType, RequireFields<MutationUpdateApiKeysArgs, 'set'>>;
+  updateHabitCompletions?: Resolver<Array<ResolversTypes['HabitCompletion']>, ParentType, ContextType, RequireFields<MutationUpdateHabitCompletionsArgs, 'set'>>;
+  updateHabits?: Resolver<Array<ResolversTypes['Habit']>, ParentType, ContextType, RequireFields<MutationUpdateHabitsArgs, 'set'>>;
+  updateTimeBlocks?: Resolver<Array<ResolversTypes['TimeBlock']>, ParentType, ContextType, RequireFields<MutationUpdateTimeBlocksArgs, 'set'>>;
+  updateTodoLists?: Resolver<Array<ResolversTypes['TodoList']>, ParentType, ContextType, RequireFields<MutationUpdateTodoListsArgs, 'set'>>;
+  updateTodos?: Resolver<Array<ResolversTypes['Todo']>, ParentType, ContextType, RequireFields<MutationUpdateTodosArgs, 'set'>>;
+  updateUsers?: Resolver<Array<ResolversTypes['User']>, ParentType, ContextType, RequireFields<MutationUpdateUsersArgs, 'set'>>;
+  verifyMagicLink?: Resolver<ResolversTypes['VerifyMagicLinkResult'], ParentType, ContextType, RequireFields<MutationVerifyMagicLinkArgs, 'token'>>;
+};
+
+export type QueryResolvers<ContextType = Context, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = {
+  activityType?: Resolver<Maybe<ResolversTypes['ActivityType']>, ParentType, ContextType, Partial<QueryActivityTypeArgs>>;
+  activityTypeStats?: Resolver<Array<ResolversTypes['ActivityTypeStats']>, ParentType, ContextType, Partial<QueryActivityTypeStatsArgs>>;
+  activityTypes?: Resolver<Array<ResolversTypes['ActivityType']>, ParentType, ContextType, Partial<QueryActivityTypesArgs>>;
+  apiKey?: Resolver<Maybe<ResolversTypes['ApiKey']>, ParentType, ContextType, Partial<QueryApiKeyArgs>>;
+  apiKeys?: Resolver<Array<ResolversTypes['ApiKey']>, ParentType, ContextType, Partial<QueryApiKeysArgs>>;
+  habit?: Resolver<Maybe<ResolversTypes['Habit']>, ParentType, ContextType, Partial<QueryHabitArgs>>;
+  habitCompletion?: Resolver<Maybe<ResolversTypes['HabitCompletion']>, ParentType, ContextType, Partial<QueryHabitCompletionArgs>>;
+  habitCompletions?: Resolver<Array<ResolversTypes['HabitCompletion']>, ParentType, ContextType, Partial<QueryHabitCompletionsArgs>>;
+  habitStats?: Resolver<Array<ResolversTypes['HabitStats']>, ParentType, ContextType, Partial<QueryHabitStatsArgs>>;
+  habits?: Resolver<Array<ResolversTypes['Habit']>, ParentType, ContextType, Partial<QueryHabitsArgs>>;
+  myActivityTypes?: Resolver<Array<ResolversTypes['ActivityType']>, ParentType, ContextType>;
+  myApiKeys?: Resolver<Array<ResolversTypes['ApiKey']>, ParentType, ContextType>;
+  myHabitDetail?: Resolver<ResolversTypes['HabitDetail'], ParentType, ContextType, RequireFields<QueryMyHabitDetailArgs, 'habitId'>>;
+  myHabits?: Resolver<Array<ResolversTypes['Habit']>, ParentType, ContextType, Partial<QueryMyHabitsArgs>>;
+  myProfile?: Resolver<Maybe<ResolversTypes['UserProfile']>, ParentType, ContextType>;
+  mySchedule?: Resolver<Array<ResolversTypes['ScheduledItem']>, ParentType, ContextType, Partial<QueryMyScheduleArgs>>;
+  myStats?: Resolver<ResolversTypes['StatsOverview'], ParentType, ContextType, Partial<QueryMyStatsArgs>>;
+  myTimeBlocks?: Resolver<Array<ResolversTypes['TimeBlock']>, ParentType, ContextType, Partial<QueryMyTimeBlocksArgs>>;
+  myTodoLists?: Resolver<Array<ResolversTypes['TodoList']>, ParentType, ContextType>;
+  myTodos?: Resolver<Array<ResolversTypes['Todo']>, ParentType, ContextType, Partial<QueryMyTodosArgs>>;
+  timeBlock?: Resolver<Maybe<ResolversTypes['TimeBlock']>, ParentType, ContextType, Partial<QueryTimeBlockArgs>>;
+  timeBlocks?: Resolver<Array<ResolversTypes['TimeBlock']>, ParentType, ContextType, Partial<QueryTimeBlocksArgs>>;
+  todo?: Resolver<Maybe<ResolversTypes['Todo']>, ParentType, ContextType, Partial<QueryTodoArgs>>;
+  todoList?: Resolver<Maybe<ResolversTypes['TodoList']>, ParentType, ContextType, Partial<QueryTodoListArgs>>;
+  todoLists?: Resolver<Array<ResolversTypes['TodoList']>, ParentType, ContextType, Partial<QueryTodoListsArgs>>;
+  todos?: Resolver<Array<ResolversTypes['Todo']>, ParentType, ContextType, Partial<QueryTodosArgs>>;
+  user?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType, Partial<QueryUserArgs>>;
+  users?: Resolver<Array<ResolversTypes['User']>, ParentType, ContextType, Partial<QueryUsersArgs>>;
+};
+
+export type RequestMagicLinkResultResolvers<ContextType = Context, ParentType extends ResolversParentTypes['RequestMagicLinkResult'] = ResolversParentTypes['RequestMagicLinkResult']> = {
+  magicLink?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  ok?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+};
+
+export type ScheduledItemResolvers<ContextType = Context, ParentType extends ResolversParentTypes['ScheduledItem'] = ResolversParentTypes['ScheduledItem']> = {
+  activityType?: Resolver<Maybe<ResolversTypes['ActivityType']>, ParentType, ContextType>;
+  completedAt?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  estimatedLength?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  isOverdue?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  isScheduled?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  kind?: Resolver<ResolversTypes['ScheduledItemKind'], ParentType, ContextType>;
+  priority?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  scheduledEnd?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  scheduledStart?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  title?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+};
+
+export type StatsOverviewResolvers<ContextType = Context, ParentType extends ResolversParentTypes['StatsOverview'] = ResolversParentTypes['StatsOverview']> = {
+  habitScore?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  habits?: Resolver<Array<ResolversTypes['HabitStatSummary']>, ParentType, ContextType>;
+  todoScore?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  todos?: Resolver<ResolversTypes['TodoStatSummary'], ParentType, ContextType>;
+  weightedScore?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+};
+
+export type SubscriptionResolvers<ContextType = Context, ParentType extends ResolversParentTypes['Subscription'] = ResolversParentTypes['Subscription']> = {
+  myTodoListsUpdated?: SubscriptionResolver<ResolversTypes['TodoListEvent'], "myTodoListsUpdated", ParentType, ContextType>;
+  myTodosUpdated?: SubscriptionResolver<ResolversTypes['TodoEvent'], "myTodosUpdated", ParentType, ContextType>;
+};
+
+export type TimeBlockResolvers<ContextType = Context, ParentType extends ResolversParentTypes['TimeBlock'] = ResolversParentTypes['TimeBlock']> = {
+  activityType?: Resolver<Maybe<ResolversTypes['ActivityType']>, ParentType, ContextType, Partial<TimeBlockActivityTypeArgs>>;
+  activityTypeId?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  createdAt?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
+  daysOfWeek?: Resolver<Array<ResolversTypes['Int']>, ParentType, ContextType>;
+  endTime?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  priority?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  startTime?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  updatedAt?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
+  user?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType, Partial<TimeBlockUserArgs>>;
+  userId?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+};
+
+export type TodoResolvers<ContextType = Context, ParentType extends ResolversParentTypes['Todo'] = ResolversParentTypes['Todo']> = {
+  activityType?: Resolver<Maybe<ResolversTypes['ActivityType']>, ParentType, ContextType>;
+  completedAt?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
+  createdAt?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
+  description?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  dueAt?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
+  estimatedLength?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  list?: Resolver<Maybe<ResolversTypes['TodoList']>, ParentType, ContextType, Partial<TodoListArgs>>;
+  listId?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  manuallyScheduled?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  priority?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  scheduledAt?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
+  title?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  updatedAt?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
+  user?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType, Partial<TodoUserArgs>>;
+  userId?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+};
+
+export type TodoEventResolvers<ContextType = Context, ParentType extends ResolversParentTypes['TodoEvent'] = ResolversParentTypes['TodoEvent']> = {
+  deletedId?: Resolver<Maybe<ResolversTypes['ID']>, ParentType, ContextType>;
+  todo?: Resolver<Maybe<ResolversTypes['Todo']>, ParentType, ContextType>;
+  type?: Resolver<ResolversTypes['TodoEventType'], ParentType, ContextType>;
+};
+
+export type TodoListResolvers<ContextType = Context, ParentType extends ResolversParentTypes['TodoList'] = ResolversParentTypes['TodoList']> = {
+  activityType?: Resolver<Maybe<ResolversTypes['ActivityType']>, ParentType, ContextType, Partial<TodoListActivityTypeArgs>>;
+  activityTypeId?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  createdAt?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
+  defaultEstimatedLength?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  defaultPriority?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  description?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  todos?: Resolver<Array<ResolversTypes['Todo']>, ParentType, ContextType, Partial<TodoListTodosArgs>>;
+  updatedAt?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
+  user?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType, Partial<TodoListUserArgs>>;
+  userId?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+};
+
+export type TodoListEventResolvers<ContextType = Context, ParentType extends ResolversParentTypes['TodoListEvent'] = ResolversParentTypes['TodoListEvent']> = {
+  deletedId?: Resolver<Maybe<ResolversTypes['ID']>, ParentType, ContextType>;
+  todoList?: Resolver<Maybe<ResolversTypes['TodoList']>, ParentType, ContextType>;
+  type?: Resolver<ResolversTypes['TodoEventType'], ParentType, ContextType>;
+};
+
+export type TodoStatSummaryResolvers<ContextType = Context, ParentType extends ResolversParentTypes['TodoStatSummary'] = ResolversParentTypes['TodoStatSummary']> = {
+  completed?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  completionRate?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
+  overdue?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  total?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+};
+
+export type UserResolvers<ContextType = Context, ParentType extends ResolversParentTypes['User'] = ResolversParentTypes['User']> = {
+  activityTypes?: Resolver<Array<ResolversTypes['ActivityType']>, ParentType, ContextType, Partial<UserActivityTypesArgs>>;
+  apiKeys?: Resolver<Array<ResolversTypes['ApiKey']>, ParentType, ContextType, Partial<UserApiKeysArgs>>;
+  createdAt?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
+  email?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  habits?: Resolver<Array<ResolversTypes['Habit']>, ParentType, ContextType, Partial<UserHabitsArgs>>;
+  id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  timeBlocks?: Resolver<Array<ResolversTypes['TimeBlock']>, ParentType, ContextType, Partial<UserTimeBlocksArgs>>;
+  timezone?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  todoLists?: Resolver<Array<ResolversTypes['TodoList']>, ParentType, ContextType, Partial<UserTodoListsArgs>>;
+  todos?: Resolver<Array<ResolversTypes['Todo']>, ParentType, ContextType, Partial<UserTodosArgs>>;
+  updatedAt?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
+};
+
+export type UserProfileResolvers<ContextType = Context, ParentType extends ResolversParentTypes['UserProfile'] = ResolversParentTypes['UserProfile']> = {
+  email?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  timezone?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+};
+
+export type VerifyMagicLinkResultResolvers<ContextType = Context, ParentType extends ResolversParentTypes['VerifyMagicLinkResult'] = ResolversParentTypes['VerifyMagicLinkResult']> = {
+  token?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  userId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+};
+
+export type Resolvers<ContextType = Context> = {
+  ActivityType?: ActivityTypeResolvers<ContextType>;
+  ActivityTypeStats?: ActivityTypeStatsResolvers<ContextType>;
+  ApiKey?: ApiKeyResolvers<ContextType>;
+  CreateApiKeyResult?: CreateApiKeyResultResolvers<ContextType>;
+  DateTime?: GraphQLScalarType;
+  Habit?: HabitResolvers<ContextType>;
+  HabitCompletion?: HabitCompletionResolvers<ContextType>;
+  HabitDetail?: HabitDetailResolvers<ContextType>;
+  HabitPeriod?: HabitPeriodResolvers<ContextType>;
+  HabitStatSummary?: HabitStatSummaryResolvers<ContextType>;
+  HabitStats?: HabitStatsResolvers<ContextType>;
+  Mutation?: MutationResolvers<ContextType>;
+  Query?: QueryResolvers<ContextType>;
+  RequestMagicLinkResult?: RequestMagicLinkResultResolvers<ContextType>;
+  ScheduledItem?: ScheduledItemResolvers<ContextType>;
+  StatsOverview?: StatsOverviewResolvers<ContextType>;
+  Subscription?: SubscriptionResolvers<ContextType>;
+  TimeBlock?: TimeBlockResolvers<ContextType>;
+  Todo?: TodoResolvers<ContextType>;
+  TodoEvent?: TodoEventResolvers<ContextType>;
+  TodoList?: TodoListResolvers<ContextType>;
+  TodoListEvent?: TodoListEventResolvers<ContextType>;
+  TodoStatSummary?: TodoStatSummaryResolvers<ContextType>;
+  User?: UserResolvers<ContextType>;
+  UserProfile?: UserProfileResolvers<ContextType>;
+  VerifyMagicLinkResult?: VerifyMagicLinkResultResolvers<ContextType>;
+};
+

--- a/packages/server/src/__generated__/schema.graphql
+++ b/packages/server/src/__generated__/schema.graphql
@@ -1,0 +1,1331 @@
+input CreateActivityTypeInput {
+  id: String
+  userId: String!
+  name: String!
+  color: String
+
+  """DateTime"""
+  createdAt: DateTime
+
+  """DateTime"""
+  updatedAt: DateTime
+}
+
+"""
+A date-time string at UTC, such as 2007-12-03T10:15:30Z, compliant with the `date-time` format outlined in section 5.6 of the RFC 3339 profile of the ISO 8601 standard for representation of dates and times using the Gregorian calendar.
+"""
+scalar DateTime
+
+input UpdateActivityTypeInput {
+  id: String
+  userId: String
+  name: String
+  color: String
+
+  """DateTime"""
+  createdAt: DateTime
+
+  """DateTime"""
+  updatedAt: DateTime
+}
+
+input ActivityTypeFilters {
+  id: IdFilter
+  userId: IdFilter
+  name: StringFilter
+  color: StringFilter
+  createdAt: DateTimeFilter
+  updatedAt: DateTimeFilter
+  OR: [ActivityTypeFiltersOr!]
+}
+
+input IdFilter {
+  eq: String
+  ne: String
+  lt: String
+  lte: String
+  gt: String
+  gte: String
+
+  """Array<undefined>"""
+  inArray: [String!]
+
+  """Array<undefined>"""
+  notInArray: [String!]
+  isNull: Boolean
+  isNotNull: Boolean
+  OR: [IdFilterOr!]
+}
+
+input IdFilterOr {
+  eq: String
+  ne: String
+  lt: String
+  lte: String
+  gt: String
+  gte: String
+
+  """Array<undefined>"""
+  inArray: [String!]
+
+  """Array<undefined>"""
+  notInArray: [String!]
+  isNull: Boolean
+  isNotNull: Boolean
+}
+
+input StringFilter {
+  eq: String
+  ne: String
+  lt: String
+  lte: String
+  gt: String
+  gte: String
+  like: String
+  notLike: String
+  ilike: String
+  notIlike: String
+
+  """Array<undefined>"""
+  inArray: [String!]
+
+  """Array<undefined>"""
+  notInArray: [String!]
+  isNull: Boolean
+  isNotNull: Boolean
+  OR: [StringFilterOr!]
+}
+
+input StringFilterOr {
+  eq: String
+  ne: String
+  lt: String
+  lte: String
+  gt: String
+  gte: String
+  like: String
+  notLike: String
+  ilike: String
+  notIlike: String
+
+  """Array<undefined>"""
+  inArray: [String!]
+
+  """Array<undefined>"""
+  notInArray: [String!]
+  isNull: Boolean
+  isNotNull: Boolean
+}
+
+input DateTimeFilter {
+  """DateTime"""
+  eq: DateTime
+
+  """DateTime"""
+  ne: DateTime
+
+  """DateTime"""
+  lt: DateTime
+
+  """DateTime"""
+  lte: DateTime
+
+  """DateTime"""
+  gt: DateTime
+
+  """DateTime"""
+  gte: DateTime
+  like: String
+  notLike: String
+  ilike: String
+  notIlike: String
+
+  """Array<DateTime>"""
+  inArray: [DateTime!]
+
+  """Array<DateTime>"""
+  notInArray: [DateTime!]
+  isNull: Boolean
+  isNotNull: Boolean
+  OR: [DateTimeFilterOr!]
+}
+
+input DateTimeFilterOr {
+  """DateTime"""
+  eq: DateTime
+
+  """DateTime"""
+  ne: DateTime
+
+  """DateTime"""
+  lt: DateTime
+
+  """DateTime"""
+  lte: DateTime
+
+  """DateTime"""
+  gt: DateTime
+
+  """DateTime"""
+  gte: DateTime
+  like: String
+  notLike: String
+  ilike: String
+  notIlike: String
+
+  """Array<DateTime>"""
+  inArray: [DateTime!]
+
+  """Array<DateTime>"""
+  notInArray: [DateTime!]
+  isNull: Boolean
+  isNotNull: Boolean
+}
+
+input ActivityTypeFiltersOr {
+  id: IdFilter
+  userId: IdFilter
+  name: StringFilter
+  color: StringFilter
+  createdAt: DateTimeFilter
+  updatedAt: DateTimeFilter
+}
+
+input ActivityTypeOrderBy {
+  id: InnerOrder
+  userId: InnerOrder
+  name: InnerOrder
+  color: InnerOrder
+  createdAt: InnerOrder
+  updatedAt: InnerOrder
+}
+
+input InnerOrder {
+  direction: OrderDirection!
+
+  """Priority of current field"""
+  priority: Int!
+}
+
+"""Order by direction"""
+enum OrderDirection {
+  """Ascending order"""
+  asc
+
+  """Descending order"""
+  desc
+}
+
+input CreateApiKeyInput {
+  id: String
+  userId: String!
+  name: String!
+  keyHash: String!
+  keyPrefix: String!
+  scopes: String!
+
+  """DateTime"""
+  lastUsedAt: DateTime
+
+  """DateTime"""
+  expiresAt: DateTime
+
+  """DateTime"""
+  revokedAt: DateTime
+
+  """DateTime"""
+  createdAt: DateTime
+}
+
+input UpdateApiKeyInput {
+  id: String
+  userId: String
+  name: String
+  keyHash: String
+  keyPrefix: String
+  scopes: String
+
+  """DateTime"""
+  lastUsedAt: DateTime
+
+  """DateTime"""
+  expiresAt: DateTime
+
+  """DateTime"""
+  revokedAt: DateTime
+
+  """DateTime"""
+  createdAt: DateTime
+}
+
+input ApiKeyFilters {
+  id: IdFilter
+  userId: IdFilter
+  name: StringFilter
+  keyHash: StringFilter
+  keyPrefix: StringFilter
+  scopes: StringFilter
+  lastUsedAt: DateTimeFilter
+  expiresAt: DateTimeFilter
+  revokedAt: DateTimeFilter
+  createdAt: DateTimeFilter
+  OR: [ApiKeyFiltersOr!]
+}
+
+input ApiKeyFiltersOr {
+  id: IdFilter
+  userId: IdFilter
+  name: StringFilter
+  keyHash: StringFilter
+  keyPrefix: StringFilter
+  scopes: StringFilter
+  lastUsedAt: DateTimeFilter
+  expiresAt: DateTimeFilter
+  revokedAt: DateTimeFilter
+  createdAt: DateTimeFilter
+}
+
+input ApiKeyOrderBy {
+  id: InnerOrder
+  userId: InnerOrder
+  name: InnerOrder
+  keyHash: InnerOrder
+  keyPrefix: InnerOrder
+  scopes: InnerOrder
+  lastUsedAt: InnerOrder
+  expiresAt: InnerOrder
+  revokedAt: InnerOrder
+  createdAt: InnerOrder
+}
+
+input CreateHabitCompletionInput {
+  id: String
+  habitId: String!
+
+  """DateTime"""
+  scheduledAt: DateTime
+
+  """DateTime"""
+  completedAt: DateTime
+
+  """DateTime"""
+  createdAt: DateTime
+}
+
+input UpdateHabitCompletionInput {
+  id: String
+  habitId: String
+
+  """DateTime"""
+  scheduledAt: DateTime
+
+  """DateTime"""
+  completedAt: DateTime
+
+  """DateTime"""
+  createdAt: DateTime
+}
+
+input HabitCompletionFilters {
+  id: IdFilter
+  habitId: IdFilter
+  scheduledAt: DateTimeFilter
+  completedAt: DateTimeFilter
+  createdAt: DateTimeFilter
+  OR: [HabitCompletionFiltersOr!]
+}
+
+input HabitCompletionFiltersOr {
+  id: IdFilter
+  habitId: IdFilter
+  scheduledAt: DateTimeFilter
+  completedAt: DateTimeFilter
+  createdAt: DateTimeFilter
+}
+
+input HabitCompletionOrderBy {
+  id: InnerOrder
+  habitId: InnerOrder
+  scheduledAt: InnerOrder
+  completedAt: InnerOrder
+  createdAt: InnerOrder
+}
+
+input CreateHabitInput {
+  id: String
+  userId: String!
+  title: String!
+  description: String
+  priority: Int
+  estimatedLength: Int!
+  activityTypeId: String!
+  frequencyCount: Int!
+  frequencyUnit: String!
+  minTimeBetweenInstances: Int
+  pomodoroEnabled: Boolean
+  pomodoroUnitLength: Int
+  pomodoroShortBreakLength: Int
+  pomodoroUnitsBeforeLongBreak: Int
+  pomodoroLongBreakLength: Int
+
+  """DateTime"""
+  createdAt: DateTime
+
+  """DateTime"""
+  updatedAt: DateTime
+}
+
+input UpdateHabitInput {
+  id: String
+  userId: String
+  title: String
+  description: String
+  priority: Int
+  estimatedLength: Int
+  activityTypeId: String
+  frequencyCount: Int
+  frequencyUnit: String
+  minTimeBetweenInstances: Int
+  pomodoroEnabled: Boolean
+  pomodoroUnitLength: Int
+  pomodoroShortBreakLength: Int
+  pomodoroUnitsBeforeLongBreak: Int
+  pomodoroLongBreakLength: Int
+
+  """DateTime"""
+  createdAt: DateTime
+
+  """DateTime"""
+  updatedAt: DateTime
+}
+
+input HabitFilters {
+  id: IdFilter
+  userId: IdFilter
+  title: StringFilter
+  description: StringFilter
+  priority: StringFilter
+  estimatedLength: StringFilter
+  activityTypeId: IdFilter
+  frequencyCount: StringFilter
+  frequencyUnit: StringFilter
+  minTimeBetweenInstances: StringFilter
+  pomodoroEnabled: BooleanFilter
+  pomodoroUnitLength: StringFilter
+  pomodoroShortBreakLength: StringFilter
+  pomodoroUnitsBeforeLongBreak: StringFilter
+  pomodoroLongBreakLength: StringFilter
+  createdAt: DateTimeFilter
+  updatedAt: DateTimeFilter
+  OR: [HabitFiltersOr!]
+}
+
+input BooleanFilter {
+  eq: Boolean
+  ne: Boolean
+  lt: Boolean
+  lte: Boolean
+  gt: Boolean
+  gte: Boolean
+  like: String
+  notLike: String
+  ilike: String
+  notIlike: String
+
+  """Array<undefined>"""
+  inArray: [Boolean!]
+
+  """Array<undefined>"""
+  notInArray: [Boolean!]
+  isNull: Boolean
+  isNotNull: Boolean
+  OR: [BooleanFilterOr!]
+}
+
+input BooleanFilterOr {
+  eq: Boolean
+  ne: Boolean
+  lt: Boolean
+  lte: Boolean
+  gt: Boolean
+  gte: Boolean
+  like: String
+  notLike: String
+  ilike: String
+  notIlike: String
+
+  """Array<undefined>"""
+  inArray: [Boolean!]
+
+  """Array<undefined>"""
+  notInArray: [Boolean!]
+  isNull: Boolean
+  isNotNull: Boolean
+}
+
+input HabitFiltersOr {
+  id: IdFilter
+  userId: IdFilter
+  title: StringFilter
+  description: StringFilter
+  priority: StringFilter
+  estimatedLength: StringFilter
+  activityTypeId: IdFilter
+  frequencyCount: StringFilter
+  frequencyUnit: StringFilter
+  minTimeBetweenInstances: StringFilter
+  pomodoroEnabled: BooleanFilter
+  pomodoroUnitLength: StringFilter
+  pomodoroShortBreakLength: StringFilter
+  pomodoroUnitsBeforeLongBreak: StringFilter
+  pomodoroLongBreakLength: StringFilter
+  createdAt: DateTimeFilter
+  updatedAt: DateTimeFilter
+}
+
+input HabitOrderBy {
+  id: InnerOrder
+  userId: InnerOrder
+  title: InnerOrder
+  description: InnerOrder
+  priority: InnerOrder
+  estimatedLength: InnerOrder
+  activityTypeId: InnerOrder
+  frequencyCount: InnerOrder
+  frequencyUnit: InnerOrder
+  minTimeBetweenInstances: InnerOrder
+  pomodoroEnabled: InnerOrder
+  pomodoroUnitLength: InnerOrder
+  pomodoroShortBreakLength: InnerOrder
+  pomodoroUnitsBeforeLongBreak: InnerOrder
+  pomodoroLongBreakLength: InnerOrder
+  createdAt: InnerOrder
+  updatedAt: InnerOrder
+}
+
+input CreateTimeBlockInput {
+  id: String
+  userId: String!
+  activityTypeId: String!
+  daysOfWeek: [Int!]!
+  startTime: String!
+  endTime: String!
+  priority: Int
+
+  """DateTime"""
+  createdAt: DateTime
+
+  """DateTime"""
+  updatedAt: DateTime
+}
+
+input UpdateTimeBlockInput {
+  id: String
+  userId: String
+  activityTypeId: String
+  daysOfWeek: [Int!]
+  startTime: String
+  endTime: String
+  priority: Int
+
+  """DateTime"""
+  createdAt: DateTime
+
+  """DateTime"""
+  updatedAt: DateTime
+}
+
+input TimeBlockFilters {
+  id: IdFilter
+  userId: IdFilter
+  activityTypeId: IdFilter
+  daysOfWeek: FloatArrayFilter
+  startTime: StringFilter
+  endTime: StringFilter
+  priority: StringFilter
+  createdAt: DateTimeFilter
+  updatedAt: DateTimeFilter
+  OR: [TimeBlockFiltersOr!]
+}
+
+input FloatArrayFilter {
+  eq: [Int!]
+  ne: [Int!]
+  lt: [Int!]
+  lte: [Int!]
+  gt: [Int!]
+  gte: [Int!]
+  like: String
+  notLike: String
+  ilike: String
+  notIlike: String
+
+  """Array<undefined>"""
+  inArray: [[Int!]!]
+
+  """Array<undefined>"""
+  notInArray: [[Int!]!]
+  isNull: Boolean
+  isNotNull: Boolean
+  OR: [FloatArrayFilterOr!]
+}
+
+input FloatArrayFilterOr {
+  eq: [Int!]
+  ne: [Int!]
+  lt: [Int!]
+  lte: [Int!]
+  gt: [Int!]
+  gte: [Int!]
+  like: String
+  notLike: String
+  ilike: String
+  notIlike: String
+
+  """Array<undefined>"""
+  inArray: [[Int!]!]
+
+  """Array<undefined>"""
+  notInArray: [[Int!]!]
+  isNull: Boolean
+  isNotNull: Boolean
+}
+
+input TimeBlockFiltersOr {
+  id: IdFilter
+  userId: IdFilter
+  activityTypeId: IdFilter
+  daysOfWeek: FloatArrayFilter
+  startTime: StringFilter
+  endTime: StringFilter
+  priority: StringFilter
+  createdAt: DateTimeFilter
+  updatedAt: DateTimeFilter
+}
+
+input TimeBlockOrderBy {
+  id: InnerOrder
+  userId: InnerOrder
+  activityTypeId: InnerOrder
+  daysOfWeek: InnerOrder
+  startTime: InnerOrder
+  endTime: InnerOrder
+  priority: InnerOrder
+  createdAt: InnerOrder
+  updatedAt: InnerOrder
+}
+
+input CreateTodoListInput {
+  id: String
+  userId: String!
+  name: String!
+  description: String
+  activityTypeId: String!
+  defaultPriority: Int
+  defaultEstimatedLength: Int
+
+  """DateTime"""
+  createdAt: DateTime
+
+  """DateTime"""
+  updatedAt: DateTime
+}
+
+input UpdateTodoListInput {
+  id: String
+  userId: String
+  name: String
+  description: String
+  activityTypeId: String
+  defaultPriority: Int
+  defaultEstimatedLength: Int
+
+  """DateTime"""
+  createdAt: DateTime
+
+  """DateTime"""
+  updatedAt: DateTime
+}
+
+input TodoListFilters {
+  id: IdFilter
+  userId: IdFilter
+  name: StringFilter
+  description: StringFilter
+  activityTypeId: IdFilter
+  defaultPriority: StringFilter
+  defaultEstimatedLength: StringFilter
+  createdAt: DateTimeFilter
+  updatedAt: DateTimeFilter
+  OR: [TodoListFiltersOr!]
+}
+
+input TodoListFiltersOr {
+  id: IdFilter
+  userId: IdFilter
+  name: StringFilter
+  description: StringFilter
+  activityTypeId: IdFilter
+  defaultPriority: StringFilter
+  defaultEstimatedLength: StringFilter
+  createdAt: DateTimeFilter
+  updatedAt: DateTimeFilter
+}
+
+input TodoListOrderBy {
+  id: InnerOrder
+  userId: InnerOrder
+  name: InnerOrder
+  description: InnerOrder
+  activityTypeId: InnerOrder
+  defaultPriority: InnerOrder
+  defaultEstimatedLength: InnerOrder
+  createdAt: InnerOrder
+  updatedAt: InnerOrder
+}
+
+input CreateTodoInput {
+  id: String
+  userId: String!
+  listId: String!
+  title: String!
+  description: String
+  priority: Int
+  estimatedLength: Int!
+
+  """DateTime"""
+  dueAt: DateTime
+
+  """DateTime"""
+  scheduledAt: DateTime
+
+  """DateTime"""
+  completedAt: DateTime
+  manuallyScheduled: Boolean
+
+  """DateTime"""
+  createdAt: DateTime
+
+  """DateTime"""
+  updatedAt: DateTime
+}
+
+input UpdateTodoInput {
+  id: String
+  userId: String
+  listId: String
+  title: String
+  description: String
+  priority: Int
+  estimatedLength: Int
+
+  """DateTime"""
+  dueAt: DateTime
+
+  """DateTime"""
+  scheduledAt: DateTime
+
+  """DateTime"""
+  completedAt: DateTime
+  manuallyScheduled: Boolean
+
+  """DateTime"""
+  createdAt: DateTime
+
+  """DateTime"""
+  updatedAt: DateTime
+}
+
+input TodoFilters {
+  id: IdFilter
+  userId: IdFilter
+  listId: IdFilter
+  title: StringFilter
+  description: StringFilter
+  priority: StringFilter
+  estimatedLength: StringFilter
+  dueAt: DateTimeFilter
+  scheduledAt: DateTimeFilter
+  completedAt: DateTimeFilter
+  manuallyScheduled: BooleanFilter
+  createdAt: DateTimeFilter
+  updatedAt: DateTimeFilter
+  OR: [TodoFiltersOr!]
+}
+
+input TodoFiltersOr {
+  id: IdFilter
+  userId: IdFilter
+  listId: IdFilter
+  title: StringFilter
+  description: StringFilter
+  priority: StringFilter
+  estimatedLength: StringFilter
+  dueAt: DateTimeFilter
+  scheduledAt: DateTimeFilter
+  completedAt: DateTimeFilter
+  manuallyScheduled: BooleanFilter
+  createdAt: DateTimeFilter
+  updatedAt: DateTimeFilter
+}
+
+input TodoOrderBy {
+  id: InnerOrder
+  userId: InnerOrder
+  listId: InnerOrder
+  title: InnerOrder
+  description: InnerOrder
+  priority: InnerOrder
+  estimatedLength: InnerOrder
+  dueAt: InnerOrder
+  scheduledAt: InnerOrder
+  completedAt: InnerOrder
+  manuallyScheduled: InnerOrder
+  createdAt: InnerOrder
+  updatedAt: InnerOrder
+}
+
+input CreateUserInput {
+  id: String
+  email: String!
+  timezone: String
+
+  """DateTime"""
+  createdAt: DateTime
+
+  """DateTime"""
+  updatedAt: DateTime
+}
+
+input UpdateUserInput {
+  id: String
+  email: String
+  timezone: String
+
+  """DateTime"""
+  createdAt: DateTime
+
+  """DateTime"""
+  updatedAt: DateTime
+}
+
+input UserFilters {
+  id: IdFilter
+  email: StringFilter
+  timezone: StringFilter
+  createdAt: DateTimeFilter
+  updatedAt: DateTimeFilter
+  OR: [UserFiltersOr!]
+}
+
+input UserFiltersOr {
+  id: IdFilter
+  email: StringFilter
+  timezone: StringFilter
+  createdAt: DateTimeFilter
+  updatedAt: DateTimeFilter
+}
+
+input UserOrderBy {
+  id: InnerOrder
+  email: InnerOrder
+  timezone: InnerOrder
+  createdAt: InnerOrder
+  updatedAt: InnerOrder
+}
+
+type ActivityType {
+  id: String!
+  userId: String!
+  name: String!
+  color: String!
+
+  """DateTime"""
+  createdAt: DateTime!
+
+  """DateTime"""
+  updatedAt: DateTime!
+  user(where: UserFilters): User
+  todoLists(where: TodoListFilters, orderBy: TodoListOrderBy, offset: Int, limit: Int): [TodoList!]!
+  habits(where: HabitFilters, orderBy: HabitOrderBy, offset: Int, limit: Int): [Habit!]!
+  timeBlocks(where: TimeBlockFilters, orderBy: TimeBlockOrderBy, offset: Int, limit: Int): [TimeBlock!]!
+}
+
+type ApiKey {
+  id: String!
+  userId: String!
+  name: String!
+  keyHash: String!
+  keyPrefix: String!
+  scopes: [String!]!
+
+  """DateTime"""
+  lastUsedAt: DateTime
+
+  """DateTime"""
+  expiresAt: DateTime
+
+  """DateTime"""
+  revokedAt: DateTime
+
+  """DateTime"""
+  createdAt: DateTime!
+  user(where: UserFilters): User
+}
+
+type HabitCompletion {
+  id: String!
+  habitId: String!
+
+  """DateTime"""
+  scheduledAt: DateTime
+
+  """DateTime"""
+  completedAt: DateTime
+
+  """DateTime"""
+  createdAt: DateTime!
+  habit(where: HabitFilters): Habit
+}
+
+type Habit {
+  id: String!
+  userId: String!
+  title: String!
+  description: String
+  priority: Int!
+  estimatedLength: Int!
+  activityTypeId: String!
+  frequencyCount: Int!
+  frequencyUnit: String!
+  minTimeBetweenInstances: Int
+  pomodoroEnabled: Boolean!
+  pomodoroUnitLength: Int
+  pomodoroShortBreakLength: Int
+  pomodoroUnitsBeforeLongBreak: Int
+  pomodoroLongBreakLength: Int
+
+  """DateTime"""
+  createdAt: DateTime!
+
+  """DateTime"""
+  updatedAt: DateTime!
+  user(where: UserFilters): User
+  activityType(where: ActivityTypeFilters): ActivityType
+  completions(where: HabitCompletionFilters, orderBy: HabitCompletionOrderBy, offset: Int, limit: Int): [HabitCompletion!]!
+}
+
+type TimeBlock {
+  id: String!
+  userId: String!
+  activityTypeId: String!
+  daysOfWeek: [Int!]!
+  startTime: String!
+  endTime: String!
+  priority: Int!
+
+  """DateTime"""
+  createdAt: DateTime!
+
+  """DateTime"""
+  updatedAt: DateTime!
+  user(where: UserFilters): User
+  activityType(where: ActivityTypeFilters): ActivityType
+}
+
+type TodoList {
+  id: String!
+  userId: String!
+  name: String!
+  description: String
+  activityTypeId: String!
+  defaultPriority: Int!
+  defaultEstimatedLength: Int!
+
+  """DateTime"""
+  createdAt: DateTime!
+
+  """DateTime"""
+  updatedAt: DateTime!
+  user(where: UserFilters): User
+  activityType(where: ActivityTypeFilters): ActivityType
+  todos(where: TodoFilters, orderBy: TodoOrderBy, offset: Int, limit: Int): [Todo!]!
+}
+
+type Todo {
+  id: String!
+  userId: String!
+  listId: String!
+  title: String!
+  description: String
+  priority: Int!
+  estimatedLength: Int!
+
+  """DateTime"""
+  dueAt: DateTime
+
+  """DateTime"""
+  scheduledAt: DateTime
+
+  """DateTime"""
+  completedAt: DateTime
+  manuallyScheduled: Boolean!
+
+  """DateTime"""
+  createdAt: DateTime!
+
+  """DateTime"""
+  updatedAt: DateTime!
+  user(where: UserFilters): User
+  list(where: TodoListFilters): TodoList
+  activityType: ActivityType
+}
+
+type User {
+  id: String!
+  email: String!
+  timezone: String!
+
+  """DateTime"""
+  createdAt: DateTime!
+
+  """DateTime"""
+  updatedAt: DateTime!
+  activityTypes(where: ActivityTypeFilters, orderBy: ActivityTypeOrderBy, offset: Int, limit: Int): [ActivityType!]!
+  todoLists(where: TodoListFilters, orderBy: TodoListOrderBy, offset: Int, limit: Int): [TodoList!]!
+  todos(where: TodoFilters, orderBy: TodoOrderBy, offset: Int, limit: Int): [Todo!]!
+  habits(where: HabitFilters, orderBy: HabitOrderBy, offset: Int, limit: Int): [Habit!]!
+  timeBlocks(where: TimeBlockFilters, orderBy: TimeBlockOrderBy, offset: Int, limit: Int): [TimeBlock!]!
+  apiKeys(where: ApiKeyFilters, orderBy: ApiKeyOrderBy, offset: Int, limit: Int): [ApiKey!]!
+}
+
+type Query {
+  activityTypes(offset: Int, limit: Int, orderBy: ActivityTypeOrderBy, where: ActivityTypeFilters): [ActivityType!]!
+  activityType(offset: Int, orderBy: ActivityTypeOrderBy, where: ActivityTypeFilters): ActivityType
+  apiKeys(offset: Int, limit: Int, orderBy: ApiKeyOrderBy, where: ApiKeyFilters): [ApiKey!]!
+  apiKey(offset: Int, orderBy: ApiKeyOrderBy, where: ApiKeyFilters): ApiKey
+  habitCompletions(offset: Int, limit: Int, orderBy: HabitCompletionOrderBy, where: HabitCompletionFilters): [HabitCompletion!]!
+  habitCompletion(offset: Int, orderBy: HabitCompletionOrderBy, where: HabitCompletionFilters): HabitCompletion
+  habits(offset: Int, limit: Int, orderBy: HabitOrderBy, where: HabitFilters): [Habit!]!
+  habit(offset: Int, orderBy: HabitOrderBy, where: HabitFilters): Habit
+  timeBlocks(offset: Int, limit: Int, orderBy: TimeBlockOrderBy, where: TimeBlockFilters): [TimeBlock!]!
+  timeBlock(offset: Int, orderBy: TimeBlockOrderBy, where: TimeBlockFilters): TimeBlock
+  todoLists(offset: Int, limit: Int, orderBy: TodoListOrderBy, where: TodoListFilters): [TodoList!]!
+  todoList(offset: Int, orderBy: TodoListOrderBy, where: TodoListFilters): TodoList
+  todos(offset: Int, limit: Int, orderBy: TodoOrderBy, where: TodoFilters): [Todo!]!
+  todo(offset: Int, orderBy: TodoOrderBy, where: TodoFilters): Todo
+  users(offset: Int, limit: Int, orderBy: UserOrderBy, where: UserFilters): [User!]!
+  user(offset: Int, orderBy: UserOrderBy, where: UserFilters): User
+  myProfile: UserProfile
+  myActivityTypes: [ActivityType!]!
+  myTodoLists: [TodoList!]!
+  myTodos(listId: ID, completed: Boolean, orderBy: TodoOrderBy): [Todo!]!
+  myHabits(activityTypeId: ID): [Habit!]!
+  myTimeBlocks(activityTypeId: ID, containsDay: Int): [TimeBlock!]!
+  activityTypeStats(startDate: String, endDate: String): [ActivityTypeStats!]!
+  habitStats(habitId: ID, startDate: String, endDate: String): [HabitStats!]!
+  myHabitDetail(habitId: ID!, periods: Int): HabitDetail!
+  myStats(startDate: String, endDate: String): StatsOverview!
+  mySchedule(weekStart: String, timezone: String): [ScheduledItem!]!
+  myApiKeys: [ApiKey!]!
+}
+
+type Mutation {
+  createActivityTypes(values: [CreateActivityTypeInput!]!): [ActivityType!]!
+  createActivityType(values: CreateActivityTypeInput!): ActivityType
+  updateActivityTypes(set: UpdateActivityTypeInput!, where: ActivityTypeFilters): [ActivityType!]!
+  deleteActivityTypes(where: ActivityTypeFilters): [ActivityType!]!
+  createApiKeys(values: [CreateApiKeyInput!]!): [ApiKey!]!
+  createApiKey(values: CreateApiKeyInput!): ApiKey
+  updateApiKeys(set: UpdateApiKeyInput!, where: ApiKeyFilters): [ApiKey!]!
+  deleteApiKeys(where: ApiKeyFilters): [ApiKey!]!
+  createHabitCompletions(values: [CreateHabitCompletionInput!]!): [HabitCompletion!]!
+  createHabitCompletion(values: CreateHabitCompletionInput!): HabitCompletion
+  updateHabitCompletions(set: UpdateHabitCompletionInput!, where: HabitCompletionFilters): [HabitCompletion!]!
+  deleteHabitCompletions(where: HabitCompletionFilters): [HabitCompletion!]!
+  createHabits(values: [CreateHabitInput!]!): [Habit!]!
+  createHabit(values: CreateHabitInput!): Habit
+  updateHabits(set: UpdateHabitInput!, where: HabitFilters): [Habit!]!
+  deleteHabits(where: HabitFilters): [Habit!]!
+  createTimeBlocks(values: [CreateTimeBlockInput!]!): [TimeBlock!]!
+  createTimeBlock(values: CreateTimeBlockInput!): TimeBlock
+  updateTimeBlocks(set: UpdateTimeBlockInput!, where: TimeBlockFilters): [TimeBlock!]!
+  deleteTimeBlocks(where: TimeBlockFilters): [TimeBlock!]!
+  createTodoLists(values: [CreateTodoListInput!]!): [TodoList!]!
+  createTodoList(values: CreateTodoListInput!): TodoList
+  updateTodoLists(set: UpdateTodoListInput!, where: TodoListFilters): [TodoList!]!
+  deleteTodoLists(where: TodoListFilters): [TodoList!]!
+  createTodos(values: [CreateTodoInput!]!): [Todo!]!
+  createTodo(values: CreateTodoInput!): Todo
+  updateTodos(set: UpdateTodoInput!, where: TodoFilters): [Todo!]!
+  deleteTodos(where: TodoFilters): [Todo!]!
+  createUsers(values: [CreateUserInput!]!): [User!]!
+  createUser(values: CreateUserInput!): User
+  updateUsers(set: UpdateUserInput!, where: UserFilters): [User!]!
+  deleteUsers(where: UserFilters): [User!]!
+  myUpdateProfile(timezone: String!): Boolean!
+  myCreateActivityType(input: CreateActivityTypeArgs!): ActivityType!
+  myUpdateActivityType(input: UpdateActivityTypeArgs!): ActivityType!
+  myDeleteActivityType(id: ID!): Boolean!
+  myCreateTodoList(input: CreateTodoListArgs!): TodoList!
+  myUpdateTodoList(input: UpdateTodoListArgs!): TodoList!
+  myDeleteTodoList(id: ID!): Boolean!
+  myCreateTodo(input: CreateTodoArgs!): Todo!
+  myUpdateTodo(input: UpdateTodoArgs!): Todo!
+  myCompleteTodo(id: ID!, completedAt: String): Todo!
+  myDeleteTodo(id: ID!): Boolean!
+  myCreateHabit(input: CreateHabitArgs!): Habit!
+  myDeleteHabit(id: ID!): Boolean!
+  myUpdateHabit(input: UpdateHabitArgs!): Habit!
+  myUpdateTimeBlock(input: UpdateTimeBlockArgs!): TimeBlock!
+  myCompleteHabit(input: CompleteHabitArgs!): HabitCompletion!
+  myUncompleteHabit(completionId: ID!): Boolean!
+  myCreateTimeBlock(input: CreateTimeBlockArgs!): TimeBlock!
+  myDeleteTimeBlock(id: ID!): Boolean!
+  myReschedule(weekStart: String): Boolean!
+  requestMagicLink(email: String!): RequestMagicLinkResult!
+  verifyMagicLink(token: String!): VerifyMagicLinkResult!
+  myCreateApiKey(input: MyCreateApiKeyInput!): CreateApiKeyResult!
+  myRevokeApiKey(id: ID!): Boolean!
+}
+
+type UserProfile {
+  id: ID!
+  email: String!
+  timezone: String!
+}
+
+type ActivityTypeStats {
+  activityTypeId: String!
+  activityTypeName: String!
+  totalTodos: Int!
+  completedTodos: Int!
+  totalHabits: Int!
+}
+
+type HabitStats {
+  habitId: String!
+  title: String!
+  completionRate: Float!
+  totalCompletions: Int!
+}
+
+type HabitPeriod {
+  label: String!
+  periodStart: String!
+  periodEnd: String!
+  completions: Int!
+  target: Int!
+  rate: Float!
+}
+
+type HabitDetail {
+  habitId: ID!
+  title: String!
+  description: String
+  priority: Int!
+  estimatedLength: Int!
+  frequencyCount: Int!
+  frequencyUnit: String!
+  activityType: ActivityType
+  totalCompletions: Int!
+  allTimeRate: Float!
+  periods: [HabitPeriod!]!
+}
+
+type HabitStatSummary {
+  habitId: ID!
+  title: String!
+  completionRate: Float!
+  completions: Int!
+  target: Float!
+  frequencyUnit: String!
+  frequencyCount: Int!
+  activityType: ActivityType
+}
+
+type TodoStatSummary {
+  total: Int!
+  completed: Int!
+  overdue: Int!
+  completionRate: Float!
+}
+
+type StatsOverview {
+  weightedScore: Float
+  habitScore: Float
+  todoScore: Float
+  habits: [HabitStatSummary!]!
+  todos: TodoStatSummary!
+}
+
+enum ScheduledItemKind {
+  todo
+  habit
+  pomodoro
+}
+
+type ScheduledItem {
+  kind: ScheduledItemKind!
+  id: ID!
+  title: String!
+  priority: Int!
+  estimatedLength: Int!
+  activityType: ActivityType
+  scheduledStart: String
+  scheduledEnd: String
+  isScheduled: Boolean!
+  isOverdue: Boolean!
+  completedAt: String
+}
+
+input CreateActivityTypeArgs {
+  name: String!
+  color: String
+}
+
+input UpdateActivityTypeArgs {
+  id: ID!
+  name: String
+  color: String
+}
+
+input CreateTodoListArgs {
+  name: String!
+  description: String
+  activityTypeId: ID!
+  defaultPriority: Int
+  defaultEstimatedLength: Int
+}
+
+input UpdateTodoListArgs {
+  id: ID!
+  name: String
+  description: String
+  activityTypeId: ID
+  defaultPriority: Int
+  defaultEstimatedLength: Int
+}
+
+input CreateTodoArgs {
+  listId: ID!
+  title: String!
+  description: String
+  priority: Int
+  estimatedLength: Int
+  dueAt: String
+  scheduledAt: String
+}
+
+input UpdateTodoArgs {
+  id: ID!
+  listId: ID
+  title: String
+  description: String
+  priority: Int
+  estimatedLength: Int
+  dueAt: String
+  scheduledAt: String
+  manuallyScheduled: Boolean
+  completedAt: String
+}
+
+input CreateHabitArgs {
+  title: String!
+  description: String
+  priority: Int
+  estimatedLength: Int
+  activityTypeId: ID!
+  frequencyCount: Int!
+  frequencyUnit: String!
+  minTimeBetweenInstances: Int
+  pomodoroEnabled: Boolean
+  pomodoroUnitLength: Int
+  pomodoroShortBreakLength: Int
+  pomodoroUnitsBeforeLongBreak: Int
+  pomodoroLongBreakLength: Int
+}
+
+input CreateTimeBlockArgs {
+  activityTypeId: ID!
+  daysOfWeek: [Int!]!
+  startTime: String!
+  endTime: String!
+  priority: Int
+}
+
+input UpdateHabitArgs {
+  id: ID!
+  title: String
+  description: String
+  priority: Int
+  estimatedLength: Int
+  activityTypeId: ID
+  frequencyCount: Int
+  frequencyUnit: String
+  minTimeBetweenInstances: Int
+  pomodoroEnabled: Boolean
+  pomodoroUnitLength: Int
+  pomodoroShortBreakLength: Int
+  pomodoroUnitsBeforeLongBreak: Int
+  pomodoroLongBreakLength: Int
+}
+
+input UpdateTimeBlockArgs {
+  id: ID!
+  activityTypeId: ID
+  daysOfWeek: [Int!]
+  startTime: String
+  endTime: String
+  priority: Int
+}
+
+input CompleteHabitArgs {
+  habitId: ID!
+  scheduledAt: String
+  completedAt: String
+}
+
+type CreateApiKeyResult {
+  apiKey: ApiKey!
+  token: String!
+}
+
+input MyCreateApiKeyInput {
+  name: String!
+  scopes: [String!]!
+  expiresAt: String
+}
+
+enum TodoEventType {
+  created
+  updated
+  deleted
+}
+
+type TodoListEvent {
+  type: TodoEventType!
+  todoList: TodoList
+  deletedId: ID
+}
+
+type TodoEvent {
+  type: TodoEventType!
+  todo: Todo
+  deletedId: ID
+}
+
+type Subscription {
+  myTodoListsUpdated: TodoListEvent!
+  myTodosUpdated: TodoEvent!
+}
+
+type RequestMagicLinkResult {
+  ok: Boolean!
+  magicLink: String
+}
+
+type VerifyMagicLinkResult {
+  token: String!
+  userId: ID!
+}

--- a/packages/server/src/schema/resolvers/habits.ts
+++ b/packages/server/src/schema/resolvers/habits.ts
@@ -25,6 +25,29 @@ const UpdateHabitInput = z.object({
   frequencyCount: z.number().int().positive().min(1).max(30).optional(),
   frequencyUnit: z.enum(['week', 'month'] as const).optional(),
   minTimeBetweenInstances: z.number().int().min(0).nullable().optional(),
+  pomodoroEnabled: z.boolean().optional(),
+  pomodoroUnitLength: z.number().int().min(1).max(120).nullable().optional(),
+  pomodoroShortBreakLength: z
+    .number()
+    .int()
+    .min(1)
+    .max(60)
+    .nullable()
+    .optional(),
+  pomodoroUnitsBeforeLongBreak: z
+    .number()
+    .int()
+    .min(1)
+    .max(20)
+    .nullable()
+    .optional(),
+  pomodoroLongBreakLength: z
+    .number()
+    .int()
+    .min(1)
+    .max(120)
+    .nullable()
+    .optional(),
 });
 
 export function applyHabitResolvers(
@@ -209,6 +232,12 @@ export function applyHabitResolvers(
         frequencyCount: input.frequencyCount,
         frequencyUnit: input.frequencyUnit,
         minTimeBetweenInstances: input.minTimeBetweenInstances ?? null,
+        pomodoroEnabled: input.pomodoroEnabled ?? false,
+        pomodoroUnitLength: input.pomodoroUnitLength ?? null,
+        pomodoroShortBreakLength: input.pomodoroShortBreakLength ?? null,
+        pomodoroUnitsBeforeLongBreak:
+          input.pomodoroUnitsBeforeLongBreak ?? null,
+        pomodoroLongBreakLength: input.pomodoroLongBreakLength ?? null,
       })
       .returning();
     if (!habit) throw new Error('Failed to create habit');
@@ -268,6 +297,21 @@ export function applyHabitResolvers(
         }),
         ...(input.minTimeBetweenInstances !== undefined && {
           minTimeBetweenInstances: input.minTimeBetweenInstances,
+        }),
+        ...(input.pomodoroEnabled !== undefined && {
+          pomodoroEnabled: input.pomodoroEnabled,
+        }),
+        ...(input.pomodoroUnitLength !== undefined && {
+          pomodoroUnitLength: input.pomodoroUnitLength,
+        }),
+        ...(input.pomodoroShortBreakLength !== undefined && {
+          pomodoroShortBreakLength: input.pomodoroShortBreakLength,
+        }),
+        ...(input.pomodoroUnitsBeforeLongBreak !== undefined && {
+          pomodoroUnitsBeforeLongBreak: input.pomodoroUnitsBeforeLongBreak,
+        }),
+        ...(input.pomodoroLongBreakLength !== undefined && {
+          pomodoroLongBreakLength: input.pomodoroLongBreakLength,
         }),
         updatedAt: new Date(),
       })

--- a/packages/server/src/schema/resolvers/index.ts
+++ b/packages/server/src/schema/resolvers/index.ts
@@ -94,6 +94,7 @@ const extensionSDL = `
   enum ScheduledItemKind {
     todo
     habit
+    pomodoro
   }
 
   type ScheduledItem {
@@ -170,6 +171,11 @@ const extensionSDL = `
     frequencyCount: Int!
     frequencyUnit: String!
     minTimeBetweenInstances: Int
+    pomodoroEnabled: Boolean
+    pomodoroUnitLength: Int
+    pomodoroShortBreakLength: Int
+    pomodoroUnitsBeforeLongBreak: Int
+    pomodoroLongBreakLength: Int
   }
 
   input CreateTimeBlockArgs {
@@ -190,6 +196,11 @@ const extensionSDL = `
     frequencyCount: Int
     frequencyUnit: String
     minTimeBetweenInstances: Int
+    pomodoroEnabled: Boolean
+    pomodoroUnitLength: Int
+    pomodoroShortBreakLength: Int
+    pomodoroUnitsBeforeLongBreak: Int
+    pomodoroLongBreakLength: Int
   }
 
   input UpdateTimeBlockArgs {

--- a/packages/server/src/schema/validators.ts
+++ b/packages/server/src/schema/validators.ts
@@ -66,7 +66,7 @@ export const CreateHabitInput = z.object({
   activityTypeId: z.string().uuid(),
   frequencyCount: z.number().int().positive().min(1).max(30),
   frequencyUnit: z.enum(['week', 'month'] as const),
-  minTimeBetweenInstances: z.number().int().min(0).optional(),
+  minTimeBetweenInstances: z.number().int().min(0).nullable().optional(),
   pomodoroEnabled: z.boolean().optional(),
   pomodoroUnitLength: z.number().int().min(1).max(120).optional(),
   pomodoroShortBreakLength: z.number().int().min(1).max(60).optional(),

--- a/packages/server/src/schema/validators.ts
+++ b/packages/server/src/schema/validators.ts
@@ -67,6 +67,11 @@ export const CreateHabitInput = z.object({
   frequencyCount: z.number().int().positive().min(1).max(30),
   frequencyUnit: z.enum(['week', 'month'] as const),
   minTimeBetweenInstances: z.number().int().min(0).optional(),
+  pomodoroEnabled: z.boolean().optional(),
+  pomodoroUnitLength: z.number().int().min(1).max(120).optional(),
+  pomodoroShortBreakLength: z.number().int().min(1).max(60).optional(),
+  pomodoroUnitsBeforeLongBreak: z.number().int().min(1).max(20).optional(),
+  pomodoroLongBreakLength: z.number().int().min(1).max(120).optional(),
 });
 
 export const UpdateHabitInput = z.object({

--- a/packages/server/src/services/scheduler-writeback.ts
+++ b/packages/server/src/services/scheduler-writeback.ts
@@ -250,7 +250,12 @@ export async function runSchedulerWriteback(
     > = [];
     for (const h of userHabits) {
       if (!h.activityTypeId) continue;
-      if (h.pomodoroEnabled) continue; // pomodoro habits fill time via auto-fill, not instances
+      if (h.pomodoroEnabled) {
+        // Pomodoro habits don't use frequency-based instances — pass one entry
+        // so computeSchedule's pomodoro fill phase can see the habit config.
+        habitInstances.push({ ...h, instanceIndex: 0 });
+        continue;
+      }
       const counts = h.frequencyUnit === 'week' ? weekCounts : monthCounts;
       const done = counts.get(h.id) ?? 0;
       const deficit = h.frequencyCount - done;

--- a/packages/server/src/services/scheduler-writeback.ts
+++ b/packages/server/src/services/scheduler-writeback.ts
@@ -250,6 +250,7 @@ export async function runSchedulerWriteback(
     > = [];
     for (const h of userHabits) {
       if (!h.activityTypeId) continue;
+      if (h.pomodoroEnabled) continue; // pomodoro habits fill time via auto-fill, not instances
       const counts = h.frequencyUnit === 'week' ? weekCounts : monthCounts;
       const done = counts.get(h.id) ?? 0;
       const deficit = h.frequencyCount - done;

--- a/packages/server/src/services/scheduler.ts
+++ b/packages/server/src/services/scheduler.ts
@@ -456,7 +456,8 @@ export function computeSchedule(
       : null;
 
     const slotDayMidnightCache = new Map<string, number>();
-    let pomodoroCount = 0; // unique across all slots for this habit
+    let pomodoroCount = 0; // unique across all slots for this habit (used for ID)
+    const pomodoroPerDay = new Map<string, number>(); // per-day label counter
 
     for (const slot of slots) {
       let cursor = slot.startMinutes + slot.usedMinutes;
@@ -479,10 +480,13 @@ export function computeSchedule(
         const unitStart = cursor;
         const unitEnd = cursor + habit.pomodoroUnitLength;
 
+        const dayLabel = (pomodoroPerDay.get(slot.dateStr) ?? 0) + 1;
+        pomodoroPerDay.set(slot.dateStr, dayLabel);
+
         results.push({
           kind: 'pomodoro',
           id: `${habit.id}-pom-${pomodoroCount}`,
-          title: `${habit.title} - pom ${pomodoroCount + 1}`,
+          title: `${habit.title} - pom ${dayLabel}`,
           priority: habit.priority,
           estimatedLength: habit.pomodoroUnitLength,
           activityTypeId: habit.activityTypeId,

--- a/packages/server/src/services/scheduler.ts
+++ b/packages/server/src/services/scheduler.ts
@@ -6,7 +6,7 @@ export type TodoWithActivityType = Todo & { activityTypeId: string | null };
 
 // ─── Output Types ────────────────────────────────────────────────────────────
 
-export type ScheduledItemKind = 'todo' | 'habit';
+export type ScheduledItemKind = 'todo' | 'habit' | 'pomodoro';
 
 export type ScheduledItem = {
   kind: ScheduledItemKind;
@@ -415,6 +415,101 @@ export function computeSchedule(
       isScheduled: true,
       isOverdue: task.isOverdue ?? false,
     });
+  }
+
+  // 5. Pomodoro auto-fill: fill remaining slot capacity with pomodoro units
+  //    for habits that have pomodoroEnabled = true. Sorted by priority DESC so
+  //    higher-priority habits claim remaining time first.
+  const pomodoroHabits = habits
+    .filter(
+      (
+        h,
+      ): h is typeof h & {
+        pomodoroEnabled: true;
+        pomodoroUnitLength: number;
+        pomodoroShortBreakLength: number;
+        pomodoroUnitsBeforeLongBreak: number;
+        pomodoroLongBreakLength: number;
+      } =>
+        h.pomodoroEnabled === true &&
+        h.pomodoroUnitLength != null &&
+        h.pomodoroShortBreakLength != null &&
+        h.pomodoroUnitsBeforeLongBreak != null &&
+        h.pomodoroLongBreakLength != null,
+    )
+    .sort((a, b) => b.priority - a.priority);
+
+  // De-duplicate by habit base ID (only the highest-instanceIndex matters for fill)
+  const seenPomodoroHabitIds = new Set<string>();
+  const uniquePomodoroHabits = pomodoroHabits.filter((h) => {
+    if (seenPomodoroHabitIds.has(h.id)) return false;
+    seenPomodoroHabitIds.add(h.id);
+    return true;
+  });
+
+  for (const habit of uniquePomodoroHabits) {
+    const slots = slotsByActivityType.get(habit.activityTypeId ?? '');
+    if (!slots) continue;
+
+    const activityType = habit.activityTypeId
+      ? (activityTypeMap.get(habit.activityTypeId) ?? null)
+      : null;
+
+    const slotDayMidnightCache = new Map<string, number>();
+
+    for (const slot of slots) {
+      let cursor = slot.startMinutes + slot.usedMinutes;
+      const slotEnd = slot.startMinutes + slot.totalMinutes;
+
+      // Advance cursor past current time
+      if (!slotDayMidnightCache.has(slot.dateStr)) {
+        slotDayMidnightCache.set(
+          slot.dateStr,
+          new Date(`${slot.dateStr}T00:00:00`).getTime(),
+        );
+      }
+      const midnightMs = slotDayMidnightCache.get(slot.dateStr) ?? 0;
+      const nowMins = (now.getTime() - midnightMs) / (1000 * 60);
+      cursor = Math.max(cursor, Math.ceil(nowMins));
+
+      let unitCountInCycle = 0;
+      let pomodoroIndex = 0;
+
+      while (cursor + habit.pomodoroUnitLength <= slotEnd) {
+        const unitStart = cursor;
+        const unitEnd = cursor + habit.pomodoroUnitLength;
+
+        results.push({
+          kind: 'pomodoro',
+          id: `${habit.id}-pom-${slot.dateStr}-${pomodoroIndex}`,
+          title: `${habit.title} (${pomodoroIndex + 1})`,
+          priority: habit.priority,
+          estimatedLength: habit.pomodoroUnitLength,
+          activityTypeId: habit.activityTypeId,
+          activityType,
+          scheduledStart: localToUtcIso(slot.dateStr, unitStart, timezone),
+          scheduledEnd: localToUtcIso(slot.dateStr, unitEnd, timezone),
+          isScheduled: true,
+          isOverdue: false,
+        });
+
+        pomodoroIndex++;
+        unitCountInCycle++;
+
+        const isLongBreak =
+          unitCountInCycle >= habit.pomodoroUnitsBeforeLongBreak;
+        const breakLength = isLongBreak
+          ? habit.pomodoroLongBreakLength
+          : habit.pomodoroShortBreakLength;
+
+        if (isLongBreak) unitCountInCycle = 0;
+
+        cursor = unitEnd + breakLength;
+      }
+
+      // Consume the remaining slot so no other pomodoro habit double-fills it
+      slot.usedMinutes = slotEnd - slot.startMinutes;
+    }
   }
 
   return results;

--- a/packages/server/src/services/scheduler.ts
+++ b/packages/server/src/services/scheduler.ts
@@ -234,7 +234,7 @@ export function computeSchedule(
     }));
 
   const habitTasks: Task[] = habits
-    .filter((h) => h.activityTypeId !== null)
+    .filter((h) => h.activityTypeId !== null && !h.pomodoroEnabled)
     .map((h) => ({
       kind: 'habit' as const,
       id: `${h.id}-${h.instanceIndex}`,

--- a/packages/server/src/services/scheduler.ts
+++ b/packages/server/src/services/scheduler.ts
@@ -456,6 +456,7 @@ export function computeSchedule(
       : null;
 
     const slotDayMidnightCache = new Map<string, number>();
+    let pomodoroCount = 0; // unique across all slots for this habit
 
     for (const slot of slots) {
       let cursor = slot.startMinutes + slot.usedMinutes;
@@ -473,7 +474,6 @@ export function computeSchedule(
       cursor = Math.max(cursor, Math.ceil(nowMins));
 
       let unitCountInCycle = 0;
-      let pomodoroIndex = 0;
 
       while (cursor + habit.pomodoroUnitLength <= slotEnd) {
         const unitStart = cursor;
@@ -481,8 +481,8 @@ export function computeSchedule(
 
         results.push({
           kind: 'pomodoro',
-          id: `${habit.id}-pom-${slot.dateStr}-${pomodoroIndex}`,
-          title: `${habit.title} - pom ${pomodoroIndex + 1}`,
+          id: `${habit.id}-pom-${pomodoroCount}`,
+          title: `${habit.title} - pom ${pomodoroCount + 1}`,
           priority: habit.priority,
           estimatedLength: habit.pomodoroUnitLength,
           activityTypeId: habit.activityTypeId,
@@ -493,7 +493,7 @@ export function computeSchedule(
           isOverdue: false,
         });
 
-        pomodoroIndex++;
+        pomodoroCount++;
         unitCountInCycle++;
 
         const isLongBreak =

--- a/packages/server/src/services/scheduler.ts
+++ b/packages/server/src/services/scheduler.ts
@@ -482,7 +482,7 @@ export function computeSchedule(
         results.push({
           kind: 'pomodoro',
           id: `${habit.id}-pom-${slot.dateStr}-${pomodoroIndex}`,
-          title: `${habit.title} (${pomodoroIndex + 1})`,
+          title: `${habit.title} - pom ${pomodoroIndex + 1}`,
           priority: habit.priority,
           estimatedLength: habit.pomodoroUnitLength,
           activityTypeId: habit.activityTypeId,

--- a/packages/server/src/services/scheduler.ts
+++ b/packages/server/src/services/scheduler.ts
@@ -508,7 +508,14 @@ export function computeSchedule(
 
         if (isLongBreak) unitCountInCycle = 0;
 
-        cursor = unitEnd + breakLength;
+        // Only consume the break gap when another full unit can follow it.
+        // If the break would push past the slot end, sit at unitEnd so the
+        // while condition can still fit one more unit without a leading break.
+        const nextWithBreak = unitEnd + breakLength;
+        cursor =
+          nextWithBreak + habit.pomodoroUnitLength <= slotEnd
+            ? nextWithBreak
+            : unitEnd;
       }
 
       // Consume the remaining slot so no other pomodoro habit double-fills it

--- a/packages/server/src/test-mocks.ts
+++ b/packages/server/src/test-mocks.ts
@@ -102,6 +102,11 @@ export function makeHabit(overrides: Partial<Habit> = {}): Habit {
     frequencyUnit: 'week',
     estimatedLength: 30,
     priority: 1,
+    pomodoroEnabled: false,
+    pomodoroUnitLength: null,
+    pomodoroShortBreakLength: null,
+    pomodoroUnitsBeforeLongBreak: null,
+    pomodoroLongBreakLength: null,
     ...overrides,
   };
 }


### PR DESCRIPTION
## Summary

- Adds an **Auto-generate pomodoros** toggle to habits. When enabled, the scheduler fills remaining slot capacity with timed work units instead of scheduling the habit as a frequency-based instance.
- Four pomodoro settings appear when the toggle is on: **unit length**, **short break**, **units before long break**, and **long break length** (classic 25/5/4/15 defaults).
- Scheduling-specific fields (Duration, Frequency, Min time between sessions) are hidden when pomodoro mode is on.
- Pomodoro units emit as a new `ScheduledItemKind: pomodoro`, so they don't create habit completion records or count toward frequency targets.
- Units are titled `"<habit> - pom N"` (N resets per day); IDs use a global counter per habit to avoid React key collisions.
- A trailing break at the end of a time block is skipped when it would prevent fitting one more work unit.
- `db:clean` script added to wipe the local PGLite data directory for a fresh start.

## Technical details

- **DB**: 5 new columns on `habits` (`pomodoro_enabled NOT NULL DEFAULT false`, four nullable int columns); migration `20260528041948_past_mordo`.
- **Scheduler**: after all regular tasks are placed, a fill phase iterates remaining slot capacity for pomodoro-enabled habits. Break gaps are only inserted when a full unit can still follow them.
- **Writeback**: pomodoro habits are passed to `computeSchedule` (so the fill phase sees them) but skipped in the frequency-deficit loop (no regular instances generated).
- **SDL / validators / resolvers**: `CreateHabitArgs` and `UpdateHabitArgs` extended; `minTimeBetweenInstances` validator now accepts `null`.
- **Client**: `Switch` UI component added (`@radix-ui/react-switch`); `HabitForm` conditionally renders scheduling vs pomodoro config fields.

## Test plan

- [ ] Create a habit with pomodoro disabled — existing scheduling behaviour unchanged
- [ ] Create a habit with pomodoro enabled — verify Duration/Frequency/Min-time fields are hidden
- [ ] Confirm pomodoro units appear on the schedule view named `"<habit> - pom 1"`, `"<habit> - pom 2"`, etc., resetting each day
- [ ] Verify completing/uncompleting a regular habit does not affect pomodoro items
- [ ] Run `npm run db:clean && npm run dev` and confirm fresh DB migration applies cleanly
- [ ] `npm test` — all 253 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)