### PR TITLE
Replace web calendar with FullCalendar v7

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -12,6 +12,8 @@
   "dependencies": {
     "@apollo/client": "^4.1.9",
     "@expo/metro-runtime": "~57.0.3",
+    "@fullcalendar/core": "^7.0.1",
+    "@fullcalendar/react": "^7.0.1",
     "@radix-ui/react-dialog": "^1.1.4",
     "@radix-ui/react-dropdown-menu": "^2.1.4",
     "@radix-ui/react-label": "^2.1.1",
@@ -37,7 +39,6 @@
     "lucide-react-native": "^1.34.0",
     "nativewind": "^4.2.3",
     "react": "19.2.3",
-    "react-big-calendar": "^1.19.4",
     "react-day-picker": "^10.0.0",
     "react-dom": "19.2.3",
     "react-native": "0.86.0",
@@ -50,11 +51,11 @@
     "react-native-worklets": "0.10.0",
     "tailwind-merge": "^2.5.5",
     "tailwindcss-animate": "^1.0.7",
+    "temporal-polyfill": "^1.0.1",
     "zod": "^3.25.76"
   },
   "devDependencies": {
     "@types/react": "^19.2.0",
-    "@types/react-big-calendar": "^1.16.3",
     "@types/react-dom": "^19.2.0",
     "autoprefixer": "^10.4.20",
     "babel-plugin-module-resolver": "^5.0.3",

--- a/client/src/components/domain/dashboard/CalendarView.web.tsx
+++ b/client/src/components/domain/dashboard/CalendarView.web.tsx
@@ -3,43 +3,44 @@ import type {
   TimeBlock_CalendarViewFragment,
 } from '@/__generated__/graphql.js';
 import { graphql } from '@/__generated__/index.js';
+import { ColorDot } from '@/components/ui/color-dot';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
 import { Check, LoaderCircle } from '@/components/ui/icons';
 import { useToast } from '@/components/ui/toast';
 import { DERIVED, invalidate } from '@/lib/cache';
 import { weekStart } from '@/lib/date';
+import { priorityLabel } from '@/lib/utils';
 import { useMutation } from '@apollo/client/react';
+import FullCalendar, {
+  type CalendarRef,
+  type EventClickInfo,
+  type EventDisplayInfo,
+  type EventDropInfo,
+  type EventInput,
+} from '@fullcalendar/react';
+import dayGridPlugin from '@fullcalendar/react/daygrid';
+import interactionPlugin from '@fullcalendar/react/interaction';
+import classicTheme from '@fullcalendar/react/themes/classic';
+import timeGridPlugin from '@fullcalendar/react/timegrid';
 import {
   addDays,
   format,
-  getDay,
-  parse,
+  parseISO,
   setHours,
   setMinutes,
   startOfDay,
 } from 'date-fns';
-import { enUS } from 'date-fns/locale/en-US';
-import type React from 'react';
-import { useMemo } from 'react';
-import { Calendar, dateFnsLocalizer } from 'react-big-calendar';
-import withDragAndDrop from 'react-big-calendar/lib/addons/dragAndDrop';
-import 'react-big-calendar/lib/addons/dragAndDrop/styles.css';
-import 'react-big-calendar/lib/css/react-big-calendar.css';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
-const locales = { 'en-US': enUS };
-
-const localizer = dateFnsLocalizer({
-  format,
-  parse,
-  startOfWeek: () => weekStart(new Date()),
-  getDay,
-  locales,
-});
-
-// Create DnD-enabled Calendar
-// biome-ignore lint/suspicious/noExplicitAny: react-big-calendar DnD wrapper lacks proper generic types
-const wdnd: any = (withDragAndDrop as any).default ?? withDragAndDrop;
-// biome-ignore lint/suspicious/noExplicitAny: react-big-calendar DnD wrapper lacks proper generic types
-const DnDCalendar = wdnd(Calendar as any) as any;
+import '@fullcalendar/react/skeleton.css';
+import '@fullcalendar/react/themes/classic/theme.css';
+import '@fullcalendar/react/themes/classic/palette.css';
 
 // ─── GraphQL ────────────────────────────────────────────────────────────────
 
@@ -60,6 +61,8 @@ graphql(`
     kind
     id
     title
+    priority
+    estimatedLength
     isScheduled
     isOverdue
     scheduledStart
@@ -91,34 +94,44 @@ const COMPLETE_TODO = graphql(`
   }
 `);
 
-// ─── Types ──────────────────────────────────────────────────────────────────
+// ─── Helpers ─────────────────────────────────────────────────────────────────
 
-interface CalendarEvent {
-  id: string;
-  title: string;
-  start: Date;
-  end: Date;
-  color: string;
-  isTask?: boolean;
-  isPast?: boolean;
-  isCompleted?: boolean;
+const FALLBACK_COLOR = '#64748b';
+
+// Metadata carried on each FullCalendar event via extendedProps.
+interface EventMeta {
+  isTask: boolean;
+  isBackground: boolean;
+  isCompleted: boolean;
   kind?: string;
+  itemId?: string;
+  habitId?: string;
+  // Fields surfaced in the click-to-open detail dialog (tasks only).
+  detailTitle?: string;
+  activityName?: string;
+  activityColor?: string;
+  isOverdue?: boolean;
+  priority?: number;
+  estimatedLength?: number;
+  startISO?: string;
+  endISO?: string;
+  completedAtISO?: string;
 }
 
-// ─── Helpers ─────────────────────────────────────────────────────────────────
+/** Human-readable date + time range for the detail dialog. */
+function formatDetailRange(startISO?: string, endISO?: string): string | null {
+  if (!startISO || !endISO) return null;
+  const start = parseISO(startISO);
+  const end = parseISO(endISO);
+  const sameDay = format(start, 'yyyy-MM-dd') === format(end, 'yyyy-MM-dd');
+  return sameDay
+    ? `${format(start, 'EEE, MMM d')} · ${format(start, 'h:mm a')} – ${format(end, 'h:mm a')}`
+    : `${format(start, 'EEE, MMM d, h:mm a')} – ${format(end, 'EEE, MMM d, h:mm a')}`;
+}
 
 function parseTime(time: string): { hours: number; minutes: number } {
   const [h, m] = time.split(':').map(Number);
   return { hours: h ?? 0, minutes: m ?? 0 };
-}
-
-function darkenColor(hex: string): string {
-  if (!hex.startsWith('#')) return hex;
-  const n = Number.parseInt(hex.replace('#', ''), 16);
-  const r = Math.max(0, (n >> 16) - 40);
-  const g = Math.max(0, ((n >> 8) & 0xff) - 40);
-  const b = Math.max(0, (n & 0xff) - 40);
-  return `#${r.toString(16).padStart(2, '0')}${g.toString(16).padStart(2, '0')}${b.toString(16).padStart(2, '0')}`;
 }
 
 function desaturateColor(hex: string, amount = 0.2): string {
@@ -137,8 +150,10 @@ function desaturateColor(hex: string, amount = 0.2): string {
 function expandTimeBlock(
   block: TimeBlock_CalendarViewFragment,
   referenceDate: Date,
-): CalendarEvent[] {
+  now: Date,
+): EventInput[] {
   if (!block.activityType) return [];
+  // `weekStart` is Monday-based, matching the server's ISO week convention.
   const monday = weekStart(referenceDate);
   const { hours: startH, minutes: startM } = parseTime(block.startTime);
   const { hours: endH, minutes: endM } = parseTime(block.endTime);
@@ -146,64 +161,35 @@ function expandTimeBlock(
   const color = block.activityType.color;
 
   return block.daysOfWeek.map((dayIndex: number) => {
-    // dayIndex: 0=Sun, 1=Mon…6=Sat.
+    // dayIndex: 0=Sun, 1=Mon…6=Sat. `monday` is the Monday of that week.
     // offset from Monday: Mon=0, Tue=1…Sat=5, Sun=6
     const offsetFromMonday = dayIndex === 0 ? 6 : dayIndex - 1;
     const dayDate = addDays(monday, offsetFromMonday);
     const start = setMinutes(setHours(startOfDay(dayDate), startH), startM);
     const end = setMinutes(setHours(startOfDay(dayDate), endH), endM);
+    const isPast = end < now;
+    const meta: EventMeta = {
+      isTask: false,
+      isBackground: true,
+      isCompleted: false,
+    };
     return {
       id: `${block.id}-${dayIndex}`,
       title,
       start,
       end,
-      color,
-    };
+      display: 'background',
+      color: isPast ? desaturateColor(color) : color,
+      editable: false,
+      extendedProps: meta,
+    } satisfies EventInput;
   });
 }
 
-// ─── Event Style ─────────────────────────────────────────────────────────────
+// ─── Custom Event Content ────────────────────────────────────────────────────
 
-function eventStyleGetter(event: CalendarEvent) {
-  const bgColor = event.isPast ? desaturateColor(event.color) : event.color;
-
-  if (event.isTask) {
-    return {
-      style: {
-        backgroundColor: bgColor,
-        borderColor: event.isPast
-          ? desaturateColor(darkenColor(event.color))
-          : darkenColor(event.color),
-        color: event.isPast ? '#aaa' : '#fff',
-        borderRadius: '4px',
-        border: `2px solid ${event.isPast ? desaturateColor(darkenColor(event.color)) : darkenColor(event.color)}`,
-        opacity: 1,
-        fontWeight: event.isCompleted ? 400 : 600,
-        fontSize: '0.75rem',
-        zIndex: 10,
-        textDecoration: event.isCompleted ? 'line-through' : 'none',
-        fontStyle: event.isCompleted ? 'italic' : 'normal',
-      },
-    };
-  }
-
-  return {
-    style: {
-      backgroundColor: bgColor,
-      borderColor: bgColor,
-      color: event.isPast ? '#999' : '#fff',
-      borderRadius: '4px',
-      border: 'none',
-      opacity: 0.85,
-      fontWeight: 500,
-      fontSize: '0.8rem',
-    },
-  };
-}
-
-// ─── Custom Event Component ──────────────────────────────────────────────────
-
-function CalendarEventComponent({ event }: { event: CalendarEvent }) {
+function TaskEventContent({ arg }: { arg: EventDisplayInfo }) {
+  const meta = arg.event.extendedProps as EventMeta;
   const toast = useToast();
 
   // These fire optimistically, so a rejection silently rolls the event back to
@@ -225,52 +211,61 @@ function CalendarEventComponent({ event }: { event: CalendarEvent }) {
   );
 
   const completing = completingHabit || completingTodo;
-  const isHabit = event.isTask && event.kind === 'habit';
-  const isTodo = event.isTask && event.kind === 'todo';
+  const isHabit = meta.kind === 'habit';
+  const isTodo = meta.kind === 'todo';
+  const canComplete = (isHabit || isTodo) && !meta.isCompleted;
 
   function handleClick(e: React.MouseEvent) {
     e.stopPropagation();
     const now = new Date().toISOString();
-    if (isHabit) {
-      const raw = event.id.replace(/^scheduled-habit-/, '');
-      const habitId = raw.replace(/-\d+$/, '');
+    const start = arg.event.start ?? new Date();
+    if (isHabit && meta.habitId) {
       completeHabit({
         variables: {
           input: {
-            habitId,
-            scheduledAt: format(event.start, "yyyy-MM-dd'T'HH:mm:ss"),
+            habitId: meta.habitId,
+            scheduledAt: format(start, "yyyy-MM-dd'T'HH:mm:ss"),
           },
         },
         optimisticResponse: {
           myCompleteHabit: {
             __typename: 'HabitCompletion',
-            id: `${event.id}-optimistic`,
+            id: `${arg.event.id}-optimistic`,
             completedAt: now,
           },
         },
-      }).catch(() => {});
-    } else if (isTodo) {
-      const todoId = event.id.replace(/^scheduled-todo-/, '');
+      }).catch(console.error);
+    } else if (isTodo && meta.itemId) {
+      const todoId = meta.itemId;
       completeTodo({
         variables: { id: todoId },
         optimisticResponse: {
           myCompleteTodo: { __typename: 'Todo', id: todoId, completedAt: now },
         },
-      }).catch(() => {});
+      }).catch(console.error);
     }
   }
 
   return (
     <div
-      className="flex h-full items-center justify-between gap-1 overflow-hidden px-0.5"
+      className="flex h-full w-full items-center justify-between gap-1 overflow-hidden px-0.5"
       style={{ opacity: completing ? 0.5 : 1, transition: 'opacity 150ms' }}
     >
-      <span className="truncate text-xs leading-tight">{event.title}</span>
-      {(isHabit || isTodo) && (
+      <span
+        className="truncate text-xs leading-tight"
+        style={{
+          textDecoration: meta.isCompleted ? 'line-through' : 'none',
+          fontStyle: meta.isCompleted ? 'italic' : 'normal',
+          fontWeight: meta.isCompleted ? 400 : 600,
+        }}
+      >
+        {arg.event.title}
+      </span>
+      {canComplete && (
         <button
           type="button"
           disabled={completing}
-          className="flex-shrink-0 rounded p-0.5 opacity-80 hover:opacity-100 hover:bg-black/20 disabled:cursor-not-allowed"
+          className="flex-shrink-0 rounded p-0.5 opacity-80 hover:bg-black/20 hover:opacity-100 disabled:cursor-not-allowed"
           title={isHabit ? 'Mark habit complete' : 'Mark todo complete'}
           onClick={handleClick}
         >
@@ -285,9 +280,22 @@ function CalendarEventComponent({ event }: { event: CalendarEvent }) {
   );
 }
 
+function renderEventContent(arg: EventDisplayInfo) {
+  const meta = arg.event.extendedProps as EventMeta;
+  // Background time-block shading uses FullCalendar's default (empty) rendering.
+  if (meta.isBackground) return undefined;
+  return <TaskEventContent arg={arg} />;
+}
+
 // ─── Component ───────────────────────────────────────────────────────────────
 
 type CalendarViewMode = 'day' | 'week' | 'month';
+
+const FC_VIEW: Record<CalendarViewMode, string> = {
+  day: 'timeGridDay',
+  week: 'timeGridWeek',
+  month: 'dayGridMonth',
+};
 
 type CalendarViewProps = {
   timeBlocks: Array<TimeBlock_CalendarViewFragment>;
@@ -302,28 +310,34 @@ export function CalendarView({
   date,
   view,
 }: CalendarViewProps) {
+  const calendarRef = useRef<CalendarRef>(null);
+  const [selected, setSelected] = useState<EventMeta | null>(null);
   const toast = useToast();
-
+  // A drop is applied to the calendar before the server confirms it, so a
+  // rejection snaps the event back with no other sign it failed.
   const [pinTodo] = useMutation(PIN_TODO, {
     update: (cache) => invalidate(cache, ...DERIVED),
-    // A refused drag snaps the event back to where it started, which on its own
-    // is indistinguishable from the drop not registering.
-    onError: (err) => toast(err.message || 'Could not move this todo'),
+    onError: (err) => toast(err.message || 'Could not move this item'),
   });
 
-  const backgroundEvents = useMemo<CalendarEvent[]>(() => {
-    const now = new Date();
+  const fcView = FC_VIEW[view];
+
+  // The parent owns date/view via the URL; drive FullCalendar imperatively.
+  useEffect(() => {
+    const api = calendarRef.current?.getApi();
+    if (!api) return;
+    if (api.view.type !== fcView) api.changeView(fcView, date);
+    else api.gotoDate(date);
+  }, [fcView, date]);
+
+  const backgroundEvents = useMemo<EventInput[]>(() => {
     // Skip background time-block shading in month view — too noisy on a grid
     if (view === 'month') return [];
-    return timeBlocks.flatMap((block) =>
-      expandTimeBlock(block, date).map((event) => ({
-        ...event,
-        isPast: event.end < now,
-      })),
-    );
+    const now = new Date();
+    return timeBlocks.flatMap((block) => expandTimeBlock(block, date, now));
   }, [timeBlocks, date, view]);
 
-  const scheduledEvents = useMemo<CalendarEvent[]>(() => {
+  const scheduledEvents = useMemo<EventInput[]>(() => {
     const now = new Date();
     return schedule
       .filter((item) => {
@@ -333,20 +347,49 @@ export function CalendarView({
         return new Date(item.scheduledEnd) > now;
       })
       .map((item) => {
+        const color = item.activityType?.color ?? FALLBACK_COLOR;
+        const start = new Date(item.scheduledStart as string);
+        const end = new Date(item.scheduledEnd as string);
+        const isPast = end < now;
         const kindPrefix = item.kind === 'todo' ? '✓ ' : '↻ ';
+        const meta: EventMeta = {
+          isTask: true,
+          isBackground: false,
+          isCompleted: false,
+          kind: item.kind,
+          itemId: item.id,
+          detailTitle: item.title,
+          isOverdue: item.isOverdue,
+          priority: item.priority,
+          estimatedLength: item.estimatedLength,
+          startISO: item.scheduledStart as string,
+          endISO: item.scheduledEnd as string,
+          ...(item.activityType
+            ? {
+                activityName: item.activityType.name,
+                activityColor: item.activityType.color,
+              }
+            : {}),
+          // Habit instance ids look like "<habitId>-<n>"; strip the suffix.
+          ...(item.kind === 'habit'
+            ? { habitId: item.id.replace(/-\d+$/, '') }
+            : {}),
+        };
         return {
           id: `scheduled-${item.kind}-${item.id}`,
           title: `${kindPrefix}${item.title}`,
-          kind: item.kind,
-          start: new Date(item.scheduledStart as string),
-          end: new Date(item.scheduledEnd as string),
-          color: item.activityType?.color ?? '#64748b',
-          isTask: true,
-        };
+          start,
+          end,
+          color: isPast ? desaturateColor(color) : color,
+          contrastColor: isPast ? '#d1d5db' : '#ffffff',
+          // Only todos can be dragged to reschedule.
+          startEditable: item.kind === 'todo',
+          extendedProps: meta,
+        } satisfies EventInput;
       });
   }, [schedule]);
 
-  const completedEvents = useMemo<CalendarEvent[]>(() => {
+  const completedEvents = useMemo<EventInput[]>(() => {
     return schedule
       .filter(
         (item) =>
@@ -356,72 +399,194 @@ export function CalendarView({
           item.scheduledEnd,
       )
       .map((item) => {
+        const color = item.activityType?.color ?? FALLBACK_COLOR;
         const start = new Date(item.completedAt as string);
         const scheduledStart = new Date(item.scheduledStart as string);
         const scheduledEnd = new Date(item.scheduledEnd as string);
         const durationMs = scheduledEnd.getTime() - scheduledStart.getTime();
+        const meta: EventMeta = {
+          isTask: true,
+          isBackground: false,
+          isCompleted: true,
+          kind: 'todo',
+          itemId: item.id,
+          detailTitle: item.title,
+          isOverdue: false,
+          priority: item.priority,
+          estimatedLength: item.estimatedLength,
+          startISO: item.scheduledStart as string,
+          endISO: item.scheduledEnd as string,
+          completedAtISO: item.completedAt as string,
+          ...(item.activityType
+            ? {
+                activityName: item.activityType.name,
+                activityColor: item.activityType.color,
+              }
+            : {}),
+        };
         return {
           id: `completed-todo-${item.id}`,
           title: `✓ ${item.title}`,
-          kind: 'todo',
           start,
           end: new Date(start.getTime() + durationMs),
-          color: item.activityType?.color ?? '#64748b',
-          isTask: true,
-          isPast: true,
-          isCompleted: true,
-        };
+          color: desaturateColor(color),
+          contrastColor: '#d1d5db',
+          startEditable: false,
+          extendedProps: meta,
+        } satisfies EventInput;
       });
   }, [schedule]);
 
-  function onEventDrop({
-    event,
-    start,
-  }: { event: CalendarEvent; start: Date | string }) {
-    if (!event.isTask || event.kind !== 'todo') return;
-    // event.id format: "scheduled-todo-{id}"
-    const match = event.id.match(/^scheduled-todo-(.+)$/);
-    if (!match) return;
-    const todoId = match[1] ?? '';
-    const newStart = start instanceof Date ? start : new Date(start);
+  const events = useMemo<EventInput[]>(
+    () => [...backgroundEvents, ...scheduledEvents, ...completedEvents],
+    [backgroundEvents, scheduledEvents, completedEvents],
+  );
+
+  function onEventDrop(info: EventDropInfo) {
+    const meta = info.event.extendedProps as EventMeta;
+    if (meta.kind !== 'todo' || meta.isCompleted || !meta.itemId) {
+      info.revert();
+      return;
+    }
+    const newStart = info.event.start;
+    if (!newStart) {
+      info.revert();
+      return;
+    }
     // Send naive local datetime (no Z) so the server stores local time, not UTC
     pinTodo({
       variables: {
         input: {
-          id: todoId,
+          id: meta.itemId,
           scheduledAt: format(newStart, "yyyy-MM-dd'T'HH:mm:ss"),
           manuallyScheduled: true,
         },
       },
-    }).catch(() => {});
+    }).catch((err) => {
+      console.error(err);
+      info.revert();
+    });
   }
 
+  function onEventClick(info: EventClickInfo) {
+    const meta = info.event.extendedProps as EventMeta;
+    if (meta.isBackground) return;
+    // Let the inline complete button handle its own clicks.
+    const target = info.jsEvent.target as HTMLElement | null;
+    if (target?.closest('button')) return;
+    info.jsEvent.preventDefault();
+    setSelected(meta);
+  }
+
+  const detailRange = selected
+    ? formatDetailRange(selected.startISO, selected.endISO)
+    : null;
+
   return (
-    <div className="rbc-calendar-wrapper h-full" style={{ minHeight: '400px' }}>
-      <DnDCalendar
-        localizer={localizer}
-        date={date}
-        view={view}
-        onNavigate={() => {}}
-        onView={() => {}}
-        toolbar={false}
-        events={[...scheduledEvents, ...completedEvents]}
-        backgroundEvents={backgroundEvents}
-        defaultView="week"
-        views={['day', 'week', 'month']}
-        step={30}
-        timeslots={2}
-        eventPropGetter={eventStyleGetter as never}
-        components={{ event: CalendarEventComponent as never }}
-        style={{ height: '100%' }}
-        formats={{
-          timeGutterFormat: (date: Date) => format(date, 'h a'),
-          eventTimeRangeFormat: ({ start, end }: { start: Date; end: Date }) =>
-            `${format(start, 'h:mm')}–${format(end, 'h:mm a')}`,
+    <div className="fc-calendar-wrapper h-full" style={{ minHeight: '400px' }}>
+      <FullCalendar
+        ref={calendarRef}
+        plugins={[
+          classicTheme,
+          dayGridPlugin,
+          timeGridPlugin,
+          interactionPlugin,
+        ]}
+        initialView={fcView}
+        initialDate={date}
+        headerToolbar={false}
+        firstDay={1}
+        height="100%"
+        expandRows={true}
+        nowIndicator={true}
+        allDaySlot={false}
+        slotDuration="00:30:00"
+        scrollTime="07:00:00"
+        editable={true}
+        eventDurationEditable={false}
+        events={events}
+        eventContent={renderEventContent}
+        eventDrop={onEventDrop}
+        eventClick={onEventClick}
+        eventTimeFormat={{
+          hour: 'numeric',
+          minute: '2-digit',
+          meridiem: 'short',
         }}
-        onEventDrop={onEventDrop}
-        resizable={false}
+        slotHeaderFormat={{ hour: 'numeric', meridiem: 'short' }}
       />
+
+      <Dialog
+        open={selected !== null}
+        onOpenChange={(open) => {
+          if (!open) setSelected(null);
+        }}
+      >
+        <DialogContent className="max-w-sm">
+          {selected && (
+            <>
+              <DialogHeader>
+                <DialogTitle className="flex items-center gap-2 pr-6">
+                  {selected.activityColor && (
+                    <ColorDot color={selected.activityColor} />
+                  )}
+                  <span>{selected.detailTitle}</span>
+                </DialogTitle>
+                <DialogDescription className="capitalize">
+                  {selected.kind}
+                  {selected.isCompleted
+                    ? ' · completed'
+                    : selected.isOverdue
+                      ? ' · overdue'
+                      : ' · scheduled'}
+                </DialogDescription>
+              </DialogHeader>
+              <dl className="grid grid-cols-[5rem_1fr] gap-x-3 gap-y-2 text-sm">
+                {detailRange && (
+                  <>
+                    <dt className="text-muted-foreground">When</dt>
+                    <dd>{detailRange}</dd>
+                  </>
+                )}
+                {selected.activityName && (
+                  <>
+                    <dt className="text-muted-foreground">Activity</dt>
+                    <dd className="flex items-center gap-1.5">
+                      {selected.activityColor && (
+                        <ColorDot color={selected.activityColor} size="sm" />
+                      )}
+                      {selected.activityName}
+                    </dd>
+                  </>
+                )}
+                {typeof selected.estimatedLength === 'number' && (
+                  <>
+                    <dt className="text-muted-foreground">Length</dt>
+                    <dd>{selected.estimatedLength} min</dd>
+                  </>
+                )}
+                {typeof selected.priority === 'number' && (
+                  <>
+                    <dt className="text-muted-foreground">Priority</dt>
+                    <dd>{priorityLabel(selected.priority)}</dd>
+                  </>
+                )}
+                {selected.completedAtISO && (
+                  <>
+                    <dt className="text-muted-foreground">Completed</dt>
+                    <dd>
+                      {format(
+                        parseISO(selected.completedAtISO),
+                        'EEE, MMM d, h:mm a',
+                      )}
+                    </dd>
+                  </>
+                )}
+              </dl>
+            </>
+          )}
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -58,141 +58,26 @@
   }
 }
 
-/* ─── react-big-calendar theme overrides ─────────────────────────────────── */
-.rbc-calendar-wrapper {
+/* ─── FullCalendar (classic theme) overrides ─────────────────────────────────
+   The theme's palette defines its --fc-classic-* variables at :root. We redefine
+   them on the calendar wrapper so every descendant inherits our design tokens
+   instead — which flip automatically with the app's `.dark` class. (v7 uses
+   hashed class names and has no plain `.fc` element to target directly.) */
+.fc-calendar-wrapper {
+  --fc-classic-background: hsl(var(--background));
+  --fc-classic-foreground: hsl(var(--foreground));
+  --fc-classic-muted-foreground: hsl(var(--muted-foreground));
+  --fc-classic-faint-foreground: hsl(var(--muted-foreground));
+  --fc-classic-faint: hsl(var(--muted));
+  --fc-classic-muted: hsl(var(--muted));
+  --fc-classic-strong: hsl(var(--muted));
+  --fc-classic-border: hsl(var(--border));
+  --fc-classic-strong-border: hsl(var(--border));
+  --fc-classic-primary: hsl(var(--primary));
+  --fc-classic-primary-foreground: hsl(var(--primary-foreground));
+  --fc-classic-highlight: hsl(var(--accent));
+  --fc-classic-today: hsl(var(--accent));
+  --fc-classic-now: hsl(var(--destructive));
+  --fc-classic-ring-color: hsl(var(--ring));
   font-family: inherit;
-}
-
-.rbc-calendar {
-  background: hsl(var(--background));
-  color: hsl(var(--foreground));
-  border-radius: var(--radius);
-}
-
-.rbc-header {
-  background: hsl(var(--card));
-  color: hsl(var(--card-foreground));
-  border-color: hsl(var(--border));
-  padding: 0.5rem 0.25rem;
-  font-weight: 600;
-  font-size: 0.875rem;
-}
-
-.rbc-time-view,
-.rbc-month-view {
-  border-color: hsl(var(--border));
-  border-radius: var(--radius);
-  overflow: hidden;
-}
-
-.rbc-time-content {
-  border-color: hsl(var(--border));
-}
-
-.rbc-time-slot {
-  border-color: hsl(var(--border));
-}
-
-.rbc-timeslot-group {
-  border-color: hsl(var(--border));
-  min-height: 40px;
-}
-
-.rbc-time-gutter .rbc-timeslot-group {
-  background: hsl(var(--card));
-}
-
-.rbc-time-gutter .rbc-time-slot {
-  color: hsl(var(--muted-foreground));
-  font-size: 0.75rem;
-  font-weight: 500;
-  padding-right: 0.5rem;
-  text-align: right;
-}
-
-.rbc-day-bg {
-  background: hsl(var(--background));
-}
-
-.rbc-day-bg + .rbc-day-bg {
-  border-color: hsl(var(--border));
-}
-
-.rbc-today {
-  background: hsl(var(--accent)) !important;
-}
-
-.rbc-off-range-bg {
-  background: hsl(var(--muted));
-}
-
-.rbc-toolbar {
-  margin-bottom: 1rem;
-  gap: 0.5rem;
-  flex-wrap: wrap;
-}
-
-.rbc-toolbar button {
-  background: hsl(var(--background));
-  color: hsl(var(--foreground));
-  border: 1px solid hsl(var(--border));
-  border-radius: calc(var(--radius) - 2px);
-  padding: 0.375rem 0.75rem;
-  font-size: 0.875rem;
-  font-weight: 500;
-  cursor: pointer;
-  transition: background 150ms, color 150ms;
-}
-
-.rbc-toolbar button:hover {
-  background: hsl(var(--muted));
-}
-
-.rbc-toolbar button.rbc-active {
-  background: hsl(var(--primary));
-  color: hsl(var(--primary-foreground));
-  border-color: hsl(var(--primary));
-}
-
-.rbc-toolbar button.rbc-active:hover {
-  background: hsl(var(--primary));
-  opacity: 0.9;
-}
-
-.rbc-toolbar-label {
-  font-size: 1.125rem;
-  font-weight: 700;
-  color: hsl(var(--foreground));
-}
-
-.rbc-event {
-  border-radius: 4px !important;
-  font-size: 0.8rem !important;
-  font-weight: 500;
-  padding: 2px 6px;
-}
-
-.rbc-event:focus {
-  outline: 2px solid hsl(var(--ring));
-  outline-offset: 2px;
-}
-
-.rbc-current-time-indicator {
-  background: hsl(var(--destructive));
-  height: 2px;
-}
-
-.rbc-label {
-  color: hsl(var(--muted-foreground));
-  font-size: 0.75rem;
-}
-
-.rbc-allday-cell {
-  background: hsl(var(--card));
-  border-color: hsl(var(--border));
-}
-
-.rbc-show-more {
-  color: hsl(var(--primary));
-  font-size: 0.75rem;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,8 @@
       "dependencies": {
         "@apollo/client": "^4.1.9",
         "@expo/metro-runtime": "~57.0.3",
+        "@fullcalendar/core": "^7.0.1",
+        "@fullcalendar/react": "^7.0.1",
         "@radix-ui/react-dialog": "^1.1.4",
         "@radix-ui/react-dropdown-menu": "^2.1.4",
         "@radix-ui/react-label": "^2.1.1",
@@ -63,7 +65,6 @@
         "lucide-react-native": "^1.34.0",
         "nativewind": "^4.2.3",
         "react": "19.2.3",
-        "react-big-calendar": "^1.19.4",
         "react-day-picker": "^10.0.0",
         "react-dom": "19.2.3",
         "react-native": "0.86.0",
@@ -76,11 +77,11 @@
         "react-native-worklets": "0.10.0",
         "tailwind-merge": "^2.5.5",
         "tailwindcss-animate": "^1.0.7",
+        "temporal-polyfill": "^1.0.1",
         "zod": "^3.25.76"
       },
       "devDependencies": {
         "@types/react": "^19.2.0",
-        "@types/react-big-calendar": "^1.16.3",
         "@types/react-dom": "^19.2.0",
         "autoprefixer": "^10.4.20",
         "babel-plugin-module-resolver": "^5.0.3",
@@ -2886,6 +2887,40 @@
       "version": "0.2.11",
       "license": "MIT"
     },
+    "node_modules/@full-ui/headless-calendar": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@full-ui/headless-calendar/-/headless-calendar-7.0.1.tgz",
+      "integrity": "sha512-ridxaPRKiSzfeXkk8kta1wC9asYqPWXf4q0KbUW5hRvWQ1rkxeUbhBarcMEOFC7FvJHczPSAm0JzSrXv/ykuKw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "temporal-polyfill": "^1.0.1"
+      }
+    },
+    "node_modules/@fullcalendar/core": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/core/-/core-7.0.1.tgz",
+      "integrity": "sha512-SRJT4lSRZZGVCz6ss48pFCNiIS7iutpQVID73GFQufH94MTYs+akCW9aKCjMwsnEWad5UV7Mcm4xndFQ4dDi0g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@full-ui/headless-calendar": "7.0.1",
+        "temporal-polyfill": "^1.0.1"
+      }
+    },
+    "node_modules/@fullcalendar/react": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/react/-/react-7.0.1.tgz",
+      "integrity": "sha512-R+/YnZVr82eJy3qeA94Kj1xjNta3MU+xkHAKuqTVCriNxUusjaLIskh7bcRt7TJHsoT3OmdSCBgw5fjXjIC9vQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@full-ui/headless-calendar": "7.0.1",
+        "@fullcalendar/core": "7.0.1"
+      },
+      "peerDependencies": {
+        "react": "^17 || ^18 || ^19",
+        "react-dom": "^17 || ^18 || ^19",
+        "temporal-polyfill": "^1.0.1"
+      }
+    },
     "node_modules/@gql.tada/internal": {
       "version": "1.0.9",
       "dev": true,
@@ -4250,14 +4285,6 @@
         "url": "https://github.com/sponsors/Boshen"
       }
     },
-    "node_modules/@popperjs/core": {
-      "version": "2.11.8",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/popperjs"
-      }
-    },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
       "license": "BSD-3-Clause"
@@ -5415,16 +5442,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@restart/hooks": {
-      "version": "0.4.16",
-      "license": "MIT",
-      "dependencies": {
-        "dequal": "^2.0.3"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0"
-      }
-    },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0.tgz",
@@ -5877,11 +5894,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/date-arithmetic": {
-      "version": "4.1.4",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "dev": true,
@@ -5952,11 +5964,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/prop-types": {
-      "version": "15.7.15",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/qs": {
       "version": "6.15.0",
       "dev": true,
@@ -5969,19 +5976,10 @@
     },
     "node_modules/@types/react": {
       "version": "19.2.14",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
-      }
-    },
-    "node_modules/@types/react-big-calendar": {
-      "version": "1.16.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/date-arithmetic": "*",
-        "@types/prop-types": "*",
-        "@types/react": "*"
       }
     },
     "node_modules/@types/react-dom": {
@@ -6008,10 +6006,6 @@
         "@types/http-errors": "*",
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/warning": {
-      "version": "3.0.4",
-      "license": "MIT"
     },
     "node_modules/@types/ws": {
       "version": "8.18.1",
@@ -7719,6 +7713,7 @@
     },
     "node_modules/csstype": {
       "version": "3.2.3",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/data-uri-to-buffer": {
@@ -7731,10 +7726,6 @@
     },
     "node_modules/dataloader": {
       "version": "2.2.3",
-      "license": "MIT"
-    },
-    "node_modules/date-arithmetic": {
-      "version": "4.1.0",
       "license": "MIT"
     },
     "node_modules/date-fns": {
@@ -7751,10 +7742,6 @@
       "peerDependencies": {
         "date-fns": "^3.0.0 || ^4.0.0"
       }
-    },
-    "node_modules/dayjs": {
-      "version": "1.11.20",
-      "license": "MIT"
     },
     "node_modules/debounce": {
       "version": "3.0.0",
@@ -7901,14 +7888,6 @@
       "resolved": "https://registry.npmjs.org/dnssd-advertise/-/dnssd-advertise-1.1.6.tgz",
       "integrity": "sha512-Ndrrf6BMPalkQPd/zubL+4YghH2J9NspapQ09uDXwYbvOPkP0oaqf5CkcwJ0b50kS2O3ul6yVu+jz+RY62Cejg==",
       "license": "MIT"
-    },
-    "node_modules/dom-helpers": {
-      "version": "5.2.1",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.8.7",
-        "csstype": "^3.0.2"
-      }
     },
     "node_modules/dom-serializer": {
       "version": "2.0.0",
@@ -9771,9 +9750,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/globalize": {
-      "version": "0.1.1"
-    },
     "node_modules/globby": {
       "version": "11.1.0",
       "dev": true,
@@ -10922,14 +10898,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/lodash": {
-      "version": "4.17.23",
-      "license": "MIT"
-    },
-    "node_modules/lodash-es": {
-      "version": "4.18.1",
-      "license": "MIT"
-    },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -11129,13 +11097,6 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-native": "*",
         "react-native-svg": "^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0"
-      }
-    },
-    "node_modules/luxon": {
-      "version": "3.7.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/magic-string": {
@@ -11735,23 +11696,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/moment": {
-      "version": "2.30.1",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/moment-timezone": {
-      "version": "0.5.48",
-      "license": "MIT",
-      "dependencies": {
-        "moment": "^2.29.4"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/ms": {
@@ -12679,15 +12623,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/prop-types": {
-      "version": "15.8.1",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.4.0",
-        "object-assign": "^4.1.1",
-        "react-is": "^16.13.1"
-      }
-    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "license": "MIT",
@@ -12782,39 +12717,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/react-big-calendar": {
-      "version": "1.19.4",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.20.7",
-        "clsx": "^1.2.1",
-        "date-arithmetic": "^4.1.0",
-        "dayjs": "^1.11.7",
-        "dom-helpers": "^5.2.1",
-        "globalize": "^0.1.1",
-        "invariant": "^2.2.4",
-        "lodash": "^4.17.21",
-        "lodash-es": "^4.17.21",
-        "luxon": "^3.2.1",
-        "memoize-one": "^6.0.0",
-        "moment": "^2.29.4",
-        "moment-timezone": "^0.5.40",
-        "prop-types": "^15.8.1",
-        "react-overlays": "^5.2.1",
-        "uncontrollable": "^7.2.1"
-      },
-      "peerDependencies": {
-        "react": "^16.14.0 || ^17 || ^18 || ^19",
-        "react-dom": "^16.14.0 || ^17 || ^18 || ^19"
-      }
-    },
-    "node_modules/react-big-calendar/node_modules/clsx": {
-      "version": "1.2.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/react-day-picker": {
       "version": "10.0.0",
       "license": "MIT",
@@ -12885,14 +12787,6 @@
       "peerDependencies": {
         "react": ">=17.0.0"
       }
-    },
-    "node_modules/react-is": {
-      "version": "16.13.1",
-      "license": "MIT"
-    },
-    "node_modules/react-lifecycles-compat": {
-      "version": "3.0.4",
-      "license": "MIT"
     },
     "node_modules/react-native": {
       "version": "0.86.0",
@@ -13472,24 +13366,6 @@
         "utf-8-validate": {
           "optional": true
         }
-      }
-    },
-    "node_modules/react-overlays": {
-      "version": "5.2.1",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.8",
-        "@popperjs/core": "^2.11.6",
-        "@restart/hooks": "^0.4.7",
-        "@types/warning": "^3.0.0",
-        "dom-helpers": "^5.2.0",
-        "prop-types": "^15.7.2",
-        "uncontrollable": "^7.2.1",
-        "warning": "^4.0.3"
-      },
-      "peerDependencies": {
-        "react": ">=16.3.0",
-        "react-dom": ">=16.3.0"
       }
     },
     "node_modules/react-refresh": {
@@ -14440,6 +14316,28 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/temporal-polyfill": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/temporal-polyfill/-/temporal-polyfill-1.0.1.tgz",
+      "integrity": "sha512-N2SoI9olnW7BUsU8RosDphZQl9s+WJ8O7PoJMFCr/e5/1rFkVI4GNOWaSeySG+UoP04foPYsnLWbJmbXOiShZg==",
+      "license": "MIT",
+      "dependencies": {
+        "temporal-spec": "1.0.0",
+        "temporal-utils": "1.0.1"
+      }
+    },
+    "node_modules/temporal-spec": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/temporal-spec/-/temporal-spec-1.0.0.tgz",
+      "integrity": "sha512-00Ahj1e1ifaERTMOIIGpOCdOo9IEk2m6GGSMedsn9a2SIsGLdOTbmME1Htv6IM82b6VHrzSUTIVc7YHy6hdhFQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/temporal-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/temporal-utils/-/temporal-utils-1.0.1.tgz",
+      "integrity": "sha512-HAixuesxFQIUaQk3ptX2jhfO/FsOkgVkDDMawvp6n/fkB1q6BKfs3lURw9I+pK/2e2e/q/vrLrxmeqauBoyGMQ==",
+      "license": "MIT"
+    },
     "node_modules/terminal-link": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-2.1.1.tgz",
@@ -14740,19 +14638,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/uncontrollable": {
-      "version": "7.2.1",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.6.3",
-        "@types/react": ">=16.9.11",
-        "invariant": "^2.2.4",
-        "react-lifecycles-compat": "^3.0.4"
-      },
-      "peerDependencies": {
-        "react": ">=15.0.0"
       }
     },
     "node_modules/undici-types": {
@@ -15145,13 +15030,6 @@
     "node_modules/warn-once": {
       "version": "0.1.1",
       "license": "MIT"
-    },
-    "node_modules/warning": {
-      "version": "4.0.3",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.0.0"
-      }
     },
     "node_modules/wcwidth": {
       "version": "1.0.1",


### PR DESCRIPTION
## Summary
Replaces **react-big-calendar** with **FullCalendar v7** on the web `CalendarView`, and adds two UX improvements plus a theming fix.

- **Calendar swap** — day/week/month views (`timeGridDay`/`timeGridWeek`/`dayGridMonth`), time-block background shading, todo/habit scheduled + completed events, drag-to-reschedule (todos only), and inline complete buttons all carried over. The parent still owns date/view via the URL; the calendar is driven imperatively through the ref API (`headerToolbar={false}`, since `WeekNavigator` handles navigation).
- **Title-only events** — events show just the title (with the existing `✓`/`↻` kind prefix); the leading time range is gone.
- **Click-to-open detail dialog** — clicking a task event opens a popup with activity (color + name), when, estimated length, priority, completion time, and status. Backed by adding `priority`/`estimatedLength` to the `ScheduledItem_CalendarView` fragment (already fetched by `MySchedule`).
- **Dark-mode theming** — the calendar now follows the site theme and matches the app palette in both modes. The classic theme's `--fc-classic-*` variables are remapped onto the app design tokens on the wrapper element, so they inherit into the calendar and flip with the app's `.dark` class. (v7 uses hashed class names — the earlier `.fc` selector matched nothing, so the calendar had been stuck on the theme's light defaults.)

Removes `react-big-calendar` + its types; adds `@fullcalendar/react`, `@fullcalendar/core`, and `temporal-polyfill`.

## Verification
- `npm run typecheck` ✅ · `npm run lint` ✅ · `npm test` ✅ (290/290)
- `npm run build:client` ✅ — v7's `exports`-map subpath plugins and theme CSS bundle cleanly under Expo/Metro
- GraphQL data path (`myTimeBlocks` + `mySchedule`) confirmed end-to-end against the local DB

⚠️ Not visually verified in a browser (browser automation was declined during the session) — recommend a quick manual look at the Calendar page in both light and dark before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)