### PR TITLE
fix(db): export a real DB type instead of any

### DIFF
--- a/.agents/db-patterns.md
+++ b/.agents/db-patterns.md
@@ -81,6 +81,20 @@ await migrate(db, { migrationsFolder });
 That is the only remaining use of PGLite in the repo; it is a devDependency of
 `server`, so a production install never pulls it in.
 
+**`DB` is the driver-agnostic type, not `typeof db`.** The runtime instance is a
+`PostgresJsDatabase`, but every shared signature (`Context['db']`,
+`runSchedulerWriteback`, `createLoaders`, …) is written against the exported
+alias:
+
+```typescript
+export type DB = PgAsyncDatabase<PgQueryResultHKT, typeof relations>;
+```
+
+postgres.js and PGLite produce the same database class parameterised by
+different query-result HKTs, so widening to the base is what lets the tests hand
+their PGLite instance to server code with no cast anywhere. Narrowing this to
+`typeof db` puts an `as unknown as` at every test call site; do not.
+
 **`drizzle-orm` and `drizzle-kit` are pinned to an exact version**, not a range.
 Their prerelease tags carry a commit hash (`1.0.0-rc.5-ab785fc`), and semver
 compares a non-numeric identifier as *greater* than a numeric one — so

--- a/codegen.server.ts
+++ b/codegen.server.ts
@@ -25,6 +25,7 @@ const config: CodegenConfig = {
           ApiKey: '@auto-cal/db#ApiKey as ApiKeyRow',
           Habit: '@auto-cal/db#Habit as HabitRow',
           HabitCompletion: '@auto-cal/db#HabitCompletion as HabitCompletionRow',
+          ManualEvent: '@auto-cal/db#ManualEvent as ManualEventRow',
           Project: '@auto-cal/db#Project as ProjectRow',
           ProjectNote: '@auto-cal/db#ProjectNote as ProjectNoteRow',
           TimeBlock: '@auto-cal/db#TimeBlock as TimeBlockRow',

--- a/db/src/index.ts
+++ b/db/src/index.ts
@@ -1,5 +1,6 @@
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import type { PgAsyncDatabase, PgQueryResultHKT } from 'drizzle-orm/pg-core';
 import { drizzle } from 'drizzle-orm/postgres-js';
 import { migrate } from 'drizzle-orm/postgres-js/migrator';
 import postgres from 'postgres';
@@ -28,18 +29,22 @@ const migrationsFolder = path.resolve(__dirname, '../drizzle');
 console.log('[auto-cal] DB backend: Postgres (via DATABASE_URL)');
 
 const client = postgres(databaseUrl);
-// The exported type stays wide. Narrowing it to PostgresJsDatabase surfaces 24
-// pre-existing type errors — 9 in src/ resolvers, the rest in tests that hand a
-// PGLite instance to a `DB`-typed function — so it is tightened separately in
-// cubicecho/auto-cal#66.
-//
-// biome-ignore lint/suspicious/noExplicitAny: see the note above
-const db: any = drizzle({ client, relations });
+const db = drizzle({ client, relations });
 
 await migrate(db, { migrationsFolder });
 
 export { db };
-export type DB = typeof db;
+
+/**
+ * The database type shared code is written against.
+ *
+ * Deliberately the driver-agnostic base rather than `typeof db`: the server
+ * always runs on postgres.js, but `server/test/**` passes in-memory PGLite
+ * instances to the same functions, and the two drivers differ only in their
+ * query-result HKT. Widening here is what lets a resolver keep its types
+ * without the tests casting at every call site.
+ */
+export type DB = PgAsyncDatabase<PgQueryResultHKT, typeof relations>;
 
 export { schema };
 export * from './schema.ts';

--- a/db/src/models/api_keys.ts
+++ b/db/src/models/api_keys.ts
@@ -10,7 +10,7 @@ export const apiKeys = pgTable('api_keys', {
   name: text('name').notNull(),
   keyHash: text('key_hash').notNull().unique(),
   keyPrefix: text('key_prefix').notNull(),
-  scopes: text('scopes').array().notNull().$type<ApiKeyScope[]>(),
+  scopes: text('scopes').$type<ApiKeyScope>().array().notNull(),
   lastUsedAt: timestamp('last_used_at'),
   expiresAt: timestamp('expires_at'),
   revokedAt: timestamp('revoked_at'),

--- a/server/src/schema/resolvers/load.ts
+++ b/server/src/schema/resolvers/load.ts
@@ -1,6 +1,7 @@
 import type {
   ActivityType,
   ApiKey,
+  DB,
   Habit,
   ManualEvent,
   Project,
@@ -45,15 +46,38 @@ const ENTITY_LABEL: Record<keyof OwnedRow, string> = {
 };
 
 /**
+ * Per-table `findFirst` by id.
+ *
+ * Spelled out rather than indexed generically (`db.query[table].findFirst(...)`)
+ * because indexing with a type parameter collapses the nine query builders into
+ * a union, and the argument then has to satisfy the *intersection* of nine
+ * different relation configs — which nothing does. Each entry below is a
+ * concrete call that type-checks on its own, so `loadOwned` needs no cast.
+ */
+const FIND_BY_ID: {
+  [K in keyof OwnedRow]: (
+    db: DB,
+    id: string,
+  ) => Promise<OwnedRow[K] | undefined>;
+} = {
+  activityTypes: (db, id) =>
+    db.query.activityTypes.findFirst({ where: { id } }),
+  apiKeys: (db, id) => db.query.apiKeys.findFirst({ where: { id } }),
+  habits: (db, id) => db.query.habits.findFirst({ where: { id } }),
+  manualEvents: (db, id) => db.query.manualEvents.findFirst({ where: { id } }),
+  projectNotes: (db, id) => db.query.projectNotes.findFirst({ where: { id } }),
+  projects: (db, id) => db.query.projects.findFirst({ where: { id } }),
+  timeBlocks: (db, id) => db.query.timeBlocks.findFirst({ where: { id } }),
+  todoLists: (db, id) => db.query.todoLists.findFirst({ where: { id } }),
+  todos: (db, id) => db.query.todos.findFirst({ where: { id } }),
+};
+
+/**
  * Load a row by id and assert the caller owns it, in the guard order CLAUDE.md
  * documents: existence (NOT_FOUND), then ownership (FORBIDDEN).
  *
  * This is the `findFirst` + {@link requireOwner} pair that every mutation
- * touching an existing row opens with. Collapsing it is worth more than the
- * line count: `context.db` is typed `any` (it is a dual-backend instance, see
- * `db/src/index.ts`), so the inline form infers the row as `any` and silently
- * gives up type-checking on everything read from it afterwards. Going through
- * here pins the row to its Drizzle type.
+ * touching an existing row opens with.
  *
  * Takes `userId` rather than re-deriving it from the context because callers
  * have already called `requireUser` — they need the id for the write itself.
@@ -64,8 +88,6 @@ export async function loadOwned<K extends keyof OwnedRow>(
   id: string,
   userId: string,
 ): Promise<OwnedRow[K]> {
-  const row = (await context.db.query[table].findFirst({ where: { id } })) as
-    | OwnedRow[K]
-    | undefined;
+  const row = await FIND_BY_ID[table](context.db, id);
   return requireOwner(row, ENTITY_LABEL[table], id, userId);
 }

--- a/server/test/ical-route.test.ts
+++ b/server/test/ical-route.test.ts
@@ -152,7 +152,7 @@ describe('icalHandler', () => {
 
     it('returns 403 when the API key lacks read scope', async () => {
       vi.mocked(db.query.apiKeys.findFirst).mockResolvedValue(
-        makeApiKey({ scopes: ['write'] as unknown as ('read' | 'write')[][] }),
+        makeApiKey({ scopes: ['write'] }),
       );
       const res = makeRes();
       await icalHandler(makeReq({ secret: VALID_API_KEY }), res);

--- a/server/test/test-mocks.ts
+++ b/server/test/test-mocks.ts
@@ -119,8 +119,7 @@ export function makeApiKey(overrides: Partial<ApiKey> = {}): ApiKey {
     name: 'Test key',
     keyHash: 'fakehash',
     keyPrefix: 'dGVzdGt',
-    // drizzle infers .array().$type<T[]> as T[][] at the type level
-    scopes: ['read'] as unknown as ('read' | 'write')[][],
+    scopes: ['read'],
     ...overrides,
   };
 }


### PR DESCRIPTION
Closes #66.

`db/src/index.ts` exported `const db: any` behind a `biome-ignore`, which meant every `context.db` read in the server was unchecked. Removing it surfaced 24 type errors — all of them real.

## What changed

- **`DB` is now a driver-agnostic alias**: `PgAsyncDatabase<PgQueryResultHKT, typeof relations>`. postgres.js and PGLite build the same database class parameterised by different query-result HKTs, so widening to the base is what lets `server/test/**` pass its in-memory PGLite into server code — with no `as unknown as` at any call site, per the issue's acceptance criteria.
- **Real bug fixed**: `api_keys.scopes` was `text('scopes').array().notNull().$type<ApiKeyScope[]>()`, which infers `ApiKeyScope[][]`. Corrected to `.$type<ApiKeyScope>().array().notNull()`. `drizzle-kit generate` reports "No schema changes" — TS-only. Two test mocks carried casts working around the bad inference; both are gone.
- **`ManualEvent` was missing from the codegen `mappers`** in `codegen.server.ts`, so `myCreateManualEvent`/`myUpdateManualEvent` were checked against the fully-resolved GraphQL type (which now carries `cursor`) instead of the Drizzle row.
- **`loadOwned` no longer indexes `db.query[table]` generically.** Indexing with a type parameter collapses the nine query builders into a union, so the argument has to satisfy the *intersection* of nine relation configs. Replaced with a per-table finder map — each entry is a concrete call that type-checks on its own, and the result cast is gone.
- Documented the `DB` alias and why it must not be narrowed to `typeof db` in `.agents/db-patterns.md`.

## Verification

- `npm run typecheck` — clean across all workspaces (was 24 errors)
- `npm test` — 384 passed / 26 files
- `npm run lint` — clean