### PR TITLE
chore(server): migrate Express 4 to 5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -517,19 +517,6 @@
         "graphql": "*"
       }
     },
-    "node_modules/@as-integrations/express4": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@as-integrations/express4/-/express4-1.1.2.tgz",
-      "integrity": "sha512-PGeMcwoOKdYnZ4LtsmM7aLNoel3tbK8wKnfyahdRau1qb7wLbuaXB35zg3w34Ov4bm3WJtO3yzd8Bw5jVE+aIQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
-      },
-      "peerDependencies": {
-        "@apollo/server": "^4.0.0 || ^5.0.0",
-        "express": "^4.0.0"
-      }
-    },
     "node_modules/@asamuzakjp/css-color": {
       "version": "5.1.11",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
@@ -8078,12 +8065,6 @@
         "dequal": "^2.0.3"
       }
     },
-    "node_modules/array-flatten": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
-      "license": "MIT"
-    },
     "node_modules/array-timsort": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/array-timsort/-/array-timsort-1.0.3.tgz",
@@ -9296,18 +9277,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/content-disposition": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
-      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "5.2.1"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/content-type": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
@@ -9331,12 +9300,6 @@
       "engines": {
         "node": ">= 0.6"
       }
-    },
-    "node_modules/cookie-signature": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
-      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
-      "license": "MIT"
     },
     "node_modules/core-js-compat": {
       "version": "3.50.0",
@@ -11487,174 +11450,6 @@
       "integrity": "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==",
       "license": "Apache-2.0"
     },
-    "node_modules/express": {
-      "version": "4.22.2",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
-      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
-      "license": "MIT",
-      "dependencies": {
-        "accepts": "~1.3.8",
-        "array-flatten": "1.1.1",
-        "body-parser": "~1.20.5",
-        "content-disposition": "~0.5.4",
-        "content-type": "~1.0.4",
-        "cookie": "~0.7.1",
-        "cookie-signature": "~1.0.6",
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "encodeurl": "~2.0.0",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
-        "finalhandler": "~1.3.1",
-        "fresh": "~0.5.2",
-        "http-errors": "~2.0.0",
-        "merge-descriptors": "1.0.3",
-        "methods": "~1.1.2",
-        "on-finished": "~2.4.1",
-        "parseurl": "~1.3.3",
-        "path-to-regexp": "~0.1.12",
-        "proxy-addr": "~2.0.7",
-        "qs": "~6.15.1",
-        "range-parser": "~1.2.1",
-        "safe-buffer": "5.2.1",
-        "send": "~0.19.0",
-        "serve-static": "~1.16.2",
-        "setprototypeof": "1.2.0",
-        "statuses": "~2.0.1",
-        "type-is": "~1.6.18",
-        "utils-merge": "1.0.1",
-        "vary": "~1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.10.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/express/node_modules/body-parser": {
-      "version": "1.20.6",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.6.tgz",
-      "integrity": "sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==",
-      "license": "MIT",
-      "dependencies": {
-        "bytes": "~3.1.2",
-        "content-type": "~1.0.5",
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "destroy": "~1.2.0",
-        "http-errors": "~2.0.1",
-        "iconv-lite": "~0.4.24",
-        "on-finished": "~2.4.1",
-        "qs": "~6.15.1",
-        "raw-body": "~2.5.3",
-        "type-is": "~1.6.18",
-        "unpipe": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8",
-        "npm": "1.2.8000 || >= 1.4.16"
-      }
-    },
-    "node_modules/express/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/express/node_modules/finalhandler": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
-      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "2.6.9",
-        "encodeurl": "~2.0.0",
-        "escape-html": "~1.0.3",
-        "on-finished": "~2.4.1",
-        "parseurl": "~1.3.3",
-        "statuses": "~2.0.2",
-        "unpipe": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/express/node_modules/iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/express/node_modules/media-typer": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/express/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "license": "MIT"
-    },
-    "node_modules/express/node_modules/qs": {
-      "version": "6.15.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "es-define-property": "^1.0.1",
-        "side-channel": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/express/node_modules/raw-body": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
-      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
-      "license": "MIT",
-      "dependencies": {
-        "bytes": "~3.1.2",
-        "http-errors": "~2.0.1",
-        "iconv-lite": "~0.4.24",
-        "unpipe": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/express/node_modules/type-is": {
-      "version": "1.6.18",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
-      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
-      "license": "MIT",
-      "dependencies": {
-        "media-typer": "0.3.0",
-        "mime-types": "~2.1.24"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -12810,6 +12605,12 @@
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
     },
     "node_modules/is-relative": {
@@ -14049,15 +13850,6 @@
       "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
       "license": "MIT"
     },
-    "node_modules/merge-descriptors": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
-      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/merge-options": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
@@ -14101,15 +13893,6 @@
         "@types/node": {
           "optional": true
         }
-      }
-    },
-    "node_modules/methods": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/metro": {
@@ -14972,6 +14755,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
     "node_modules/onetime": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
@@ -15410,12 +15202,6 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
-    },
-    "node_modules/path-to-regexp": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
-      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
-      "license": "MIT"
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -16952,6 +16738,32 @@
         "@rolldown/binding-openharmony-arm64": "1.2.6",
         "@rolldown/binding-win32-arm64-msvc": "1.2.6",
         "@rolldown/binding-win32-x64-msvc": "1.2.6"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/router/node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/run-parallel": {
@@ -18866,6 +18678,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
     "node_modules/ws": {
       "version": "8.21.3",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
@@ -19046,7 +18864,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@apollo/server": "^5.5.1",
-        "@as-integrations/express4": "^1.1.2",
+        "@as-integrations/express5": "^1.1.2",
         "@auto-cal/db": "*",
         "@graphql-tools/utils": "^12.0.0",
         "@vantreeseba/drizzle-graphql": "^9.0.0",
@@ -19055,7 +18873,7 @@
         "date-fns": "^4.1.0",
         "date-fns-tz": "^3.2.0",
         "drizzle-orm": "1.0.0-rc.5-ab785fc",
-        "express": "^4.21.2",
+        "express": "^5.2.1",
         "graphql": "^16.9.0",
         "graphql-parse-resolve-info": "^4.13.0",
         "graphql-scalars": "^2.0.0",
@@ -19078,6 +18896,19 @@
         "@types/ws": "^8.18.1"
       }
     },
+    "server/node_modules/@as-integrations/express5": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@as-integrations/express5/-/express5-1.1.2.tgz",
+      "integrity": "sha512-BxfwtcWNf2CELDkuPQxi5Zl3WqY/dQVJYafeCBOGoFQjv5M0fjhxmAFZ9vKx/5YKKNeok4UY6PkFbHzmQrdxIA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@apollo/server": "^4.0.0 || ^5.0.0",
+        "express": "^5.0.0"
+      }
+    },
     "server/node_modules/@graphql-tools/utils": {
       "version": "12.0.0",
       "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-12.0.0.tgz",
@@ -19094,6 +18925,166 @@
       },
       "peerDependencies": {
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "server/node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "server/node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "server/node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "server/node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "server/node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "server/node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "server/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "server/node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "server/node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     }
   }

--- a/server/package.json
+++ b/server/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@apollo/server": "^5.5.1",
-    "@as-integrations/express4": "^1.1.2",
+    "@as-integrations/express5": "^1.1.2",
     "@auto-cal/db": "*",
     "@graphql-tools/utils": "^12.0.0",
     "@vantreeseba/drizzle-graphql": "^9.0.0",
@@ -18,7 +18,7 @@
     "date-fns": "^4.1.0",
     "date-fns-tz": "^3.2.0",
     "drizzle-orm": "1.0.0-rc.5-ab785fc",
-    "express": "^4.21.2",
+    "express": "^5.2.1",
     "graphql": "^16.9.0",
     "graphql-parse-resolve-info": "^4.13.0",
     "graphql-scalars": "^2.0.0",

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -5,7 +5,7 @@ import { fileURLToPath } from 'node:url';
 import { ApolloServer } from '@apollo/server';
 import { unwrapResolverError } from '@apollo/server/errors';
 import { ApolloServerPluginDrainHttpServer } from '@apollo/server/plugin/drainHttpServer';
-import { expressMiddleware } from '@as-integrations/express4';
+import { expressMiddleware } from '@as-integrations/express5';
 import { db } from '@auto-cal/db';
 import { apiKeys } from '@auto-cal/db/schema';
 import cors from 'cors';
@@ -23,6 +23,7 @@ import { icalHandler } from './ical-route.ts';
 import { authLog, log, logLevelName, wsLog } from './logger.ts';
 import { schema } from './schema/index.ts';
 import { startNotificationTick } from './services/notifications.ts';
+import { SPA_FALLBACK_ROUTE, spaFallback } from './spa-fallback.ts';
 
 // Read version from server/package.json (../ from src/). Works under
 // `node src/index.ts` in Docker where npm_package_version is unset.
@@ -266,9 +267,7 @@ app.use(
 app.get('/ical', icalHandler);
 
 if (clientDistExists) {
-  app.get('*', (_req, res) => {
-    res.sendFile(path.join(clientDist, 'index.html'));
-  });
+  app.get(SPA_FALLBACK_ROUTE, spaFallback(clientDist));
 }
 
 const PORT = Number(process.env.PORT ?? 3001);

--- a/server/src/spa-fallback.ts
+++ b/server/src/spa-fallback.ts
@@ -1,0 +1,30 @@
+import path from 'node:path';
+import type { Request, RequestHandler, Response } from 'express';
+
+/**
+ * Path pattern for the single-page-app fallback.
+ *
+ * Express 5 routes through path-to-regexp v8, where a wildcard has to be a
+ * *named* parameter. The Express 4 form, a bare `*`, is not merely different —
+ * it throws `Missing parameter name at index 1` when the route is registered,
+ * so that half of the upgrade fails the boot rather than the deep links.
+ *
+ * `{*splat}` is the optional form and matches `/` as well as any deeper path.
+ * `/*splat` — one-or-more segments — would also work here, because
+ * `express.static` answers `/` with `index.html` before the fallback is
+ * reached, but only for as long as that stays true. The optional form does not
+ * depend on it.
+ *
+ * Exported (with {@link spaFallback}) because `index.ts` starts a server at
+ * import time and so cannot be imported by a test. See
+ * `server/test/spa-fallback.test.ts`.
+ */
+export const SPA_FALLBACK_ROUTE = '/{*splat}';
+
+/** Serves the built `index.html` for any path the static handler did not claim. */
+export function spaFallback(clientDist: string): RequestHandler {
+  const indexHtml = path.join(clientDist, 'index.html');
+  return (_req: Request, res: Response) => {
+    res.sendFile(indexHtml);
+  };
+}

--- a/server/test/spa-fallback.test.ts
+++ b/server/test/spa-fallback.test.ts
@@ -1,0 +1,91 @@
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import type { Server } from 'node:http';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import express from 'express';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { SPA_FALLBACK_ROUTE, spaFallback } from '../src/spa-fallback.ts';
+
+// `index.ts` starts a server at import time, so the route it registers cannot be
+// exercised from a test directly — hence spa-fallback.ts. What is worth pinning
+// is the path pattern: Express 5 dropped the bare `*` wildcard, and a fallback
+// that matches too little breaks every deep link while leaving `/graphql`,
+// `/ical` and the static assets working, so nothing else would fail.
+//
+// The app is assembled here in the same order as index.ts — static, then the
+// real routes, then the catch-all — because the ordering is half of what is
+// being asserted.
+
+const INDEX_HTML = '<!DOCTYPE html><html><body>app shell</body></html>';
+const ASSET_JS = 'console.log("asset")';
+
+let server: Server;
+let origin: string;
+
+beforeAll(async () => {
+  const dist = mkdtempSync(path.join(tmpdir(), 'auto-cal-dist-'));
+  writeFileSync(path.join(dist, 'index.html'), INDEX_HTML);
+  writeFileSync(path.join(dist, 'asset.js'), ASSET_JS);
+
+  // The same order as index.ts: static first, then the catch-all.
+  const app = express();
+  app.use(express.static(dist));
+  app.get('/ical', (_req, res) => {
+    res.send('CALENDAR');
+  });
+  app.get(SPA_FALLBACK_ROUTE, spaFallback(dist));
+
+  server = await new Promise<Server>((resolve) => {
+    const s = app.listen(0, '127.0.0.1', () => resolve(s));
+  });
+  const address = server.address();
+  if (typeof address === 'string' || address === null) {
+    throw new Error('expected a TCP address');
+  }
+  origin = `http://127.0.0.1:${address.port}`;
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});
+
+describe('SPA fallback route', () => {
+  // Answered by express.static rather than the fallback, which is exactly why
+  // the fallback uses the optional `{*splat}` and not `/*splat`: the behaviour
+  // holds either way today, and only one of them keeps holding if static stops
+  // serving an index.
+  it('serves the app shell at the site root', async () => {
+    const response = await fetch(`${origin}/`);
+    expect(response.status).toBe(200);
+    expect(await response.text()).toContain('app shell');
+  });
+
+  it.each([
+    ['/todos', 'a one-segment route'],
+    ['/projects/abc-123', 'a two-segment route'],
+    ['/a/b/c/d/e', 'an arbitrarily deep route'],
+  ])('serves the app shell at %s (%s)', async (route) => {
+    const response = await fetch(`${origin}${route}`);
+    expect(response.status).toBe(200);
+    expect(await response.text()).toContain('app shell');
+  });
+
+  it('does not shadow a real static asset', async () => {
+    const response = await fetch(`${origin}/asset.js`);
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe(ASSET_JS);
+  });
+
+  it('does not shadow a route registered before it', async () => {
+    const response = await fetch(`${origin}/ical`);
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe('CALENDAR');
+  });
+
+  it('leaves non-GET methods alone', async () => {
+    const response = await fetch(`${origin}/todos`, { method: 'POST' });
+    expect(response.status).toBe(404);
+  });
+});


### PR DESCRIPTION
Part of #68 — the dependency-refresh issue. Express only; the rest of that issue is tracked below.

## What changed

- `express` `^4.21.2` → `^5.2.1`, and `@as-integrations/express4` → `@as-integrations/express5`. The Apollo integration is a straight swap.
- The SPA catch-all had to change. Express 5 routes through path-to-regexp v8, where a wildcard must be a *named* parameter — `app.get('*', ...)` doesn't just behave differently, it throws `Missing parameter name at index 1` when the route is registered. The upgrade fails the boot rather than silently 404ing every deep link.
- The replacement is `/{*splat}` — the optional form, so it matches `/` as well as any deeper path. `/*splat` (one-or-more segments) also works today only because `express.static` answers `/` with `index.html` before the fallback is reached; the optional form doesn't depend on that.
- The pattern and its handler moved to `server/src/spa-fallback.ts`, because `index.ts` starts a listener at import time and can't be imported by a test.

## Test

`server/test/spa-fallback.test.ts` (7 tests) assembles a real express app over a temp dist directory in the same order `index.ts` uses — static, then `/ical`, then the catch-all — listens on port 0 and fetches. It covers the root, `/todos`, `/projects/abc-123`, a 5-deep path, a real asset not being shadowed, `/ical` not being shadowed, and `POST /todos` still 404ing. No new dependency (the repo has no supertest).

Negative-tested: swapping in the Express 4 `'*'` fails the whole file with the path-to-regexp `TypeError`.

## Runtime verification

Against a live server on a real Postgres container:

| Check | Result |
|---|---|
| `/`, `/todos`, `/projects/abc-123` | 200, app shell |
| `/favicon.ico` | 200 `image/vnd.microsoft.icon` |
| `/ical?secret=nope` | 400 |
| `/ical?secret=<valid>` | 200 `text/calendar`, real VEVENTs |
| GraphQL smoke (profile, mutations, `mySchedule`, persisted `scheduledAt`, `myCreateApiKey`) | pass |
| `myTodosUpdated` WS subscription | delivered `type: "created"` |

`npm run lint`, `npm run typecheck`, `npm test` (34 files / 496 tests) all green.

## Still open on #68

- **zod 3 → 4** — next PR. Touches every validator plus ~10 client forms, and Zod 4 replaces `.format()`/`.flatten()` with `z.treeifyError`, so anything surfacing a validation message needs re-checking against `error-codes.test.ts`.
- **graphql 17** — blocked upstream: `graphql-parse-resolve-info` is a peer of `@vantreeseba/drizzle-graphql` and pins 16.
- **`@react-native-async-storage/async-storage` 3** — pinned by Expo SDK 57.
- **tailwind 4 / tailwind-merge 3** — coupled to NativeWind's tailwind 4 support.

Based on `feat/eas-android` (#78).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014L39MkrRhYGcnDjRZMHtjH