### PR TITLE
chore: migrate zod 3 to 4

### DIFF
--- a/.agents/server-patterns.md
+++ b/.agents/server-patterns.md
@@ -338,11 +338,25 @@ All validators live in `server/src/schema/validators.ts`, with coverage in `serv
 | `daysOfWeek` | array of 0–6, min 1, max 7, unique |
 | `startTime` / `endTime` | `HH:mm` format; end must be after start |
 | `scheduledAt` | local datetime string (no `Z`) |
+| any `*Id` | RFC 9562 UUID — see below |
 
 ```typescript
 // In resolver:
 const input = CreateTodoInput.parse(args.input);
 ```
+
+Formats use Zod 4's top-level constructors — `z.uuid()`, `z.email()`,
+`z.url()`, `z.iso.datetime({ local: true })` — not the `z.string().uuid()`
+method chain, which is deprecated in 4.
+
+`z.uuid()` is stricter than the Zod 3 method it replaces: the 8-4-4-4-12 hex
+shape is no longer enough, the version nibble must be 1-8 and the variant
+nibble 8/9/a/b (the nil and max UUIDs are carved out). Nothing real is caught
+by that — every id the API sees is a `gen_random_uuid()` or a
+`crypto.randomUUID()` — but a hand-written fixture like
+`00000000-0000-0000-0000-000000000001` is rejected where it used to pass. Use
+`z.guid()` if a genuinely loose check is ever needed; two tests in
+`validators.test.ts` pin the boundary.
 
 **Every** validator belongs in `validators.ts` — never declare one next to the
 resolver that uses it. `UpdateHabitInput` and `UpdateTimeBlockInput` were both

--- a/client/package.json
+++ b/client/package.json
@@ -56,7 +56,7 @@
     "tailwind-merge": "^2.5.5",
     "tailwindcss-animate": "^1.0.7",
     "temporal-polyfill": "^1.0.1",
-    "zod": "^3.25.76"
+    "zod": "^4.5.4"
   },
   "devDependencies": {
     "@types/react": "^19.2.0",

--- a/client/src/components/domain/habit/HabitForm.tsx
+++ b/client/src/components/domain/habit/HabitForm.tsx
@@ -106,7 +106,7 @@ const habitSchema = z
       .min(1, 'Title is required')
       .max(200, 'Max 200 characters'),
     description: z.string().max(2000, 'Max 2000 characters'),
-    activityTypeId: z.string().uuid('Activity type is required'),
+    activityTypeId: z.uuid('Activity type is required'),
     priority: z.string().min(1, 'Priority is required'),
     estimatedLength: z.string().min(1, 'Duration is required'),
     frequencyCount: z

--- a/client/src/components/domain/onboarding/StepHabits.tsx
+++ b/client/src/components/domain/onboarding/StepHabits.tsx
@@ -40,7 +40,7 @@ const CREATE_HABIT = graphql(`
 
 const schema = z.object({
   title: z.string().min(1, 'Title is required').max(200),
-  activityTypeId: z.string().uuid('Activity type is required'),
+  activityTypeId: z.uuid('Activity type is required'),
   frequencyCount: z.number().int().min(1).max(30),
   frequencyUnit: z.enum(['week', 'month']),
 });

--- a/client/src/components/domain/onboarding/StepTimeBlocks.tsx
+++ b/client/src/components/domain/onboarding/StepTimeBlocks.tsx
@@ -46,7 +46,7 @@ const CREATE_TIME_BLOCK = graphql(`
 
 const schema = z
   .object({
-    activityTypeId: z.string().uuid('Activity type is required'),
+    activityTypeId: z.uuid('Activity type is required'),
     daysOfWeek: z
       .array(z.number().int().min(0).max(6))
       .min(1, 'Select at least one day'),

--- a/client/src/components/domain/onboarding/StepTodos.tsx
+++ b/client/src/components/domain/onboarding/StepTodos.tsx
@@ -47,7 +47,7 @@ const CREATE_TODO = graphql(`
 
 const schema = z.object({
   title: z.string().min(1, 'Title is required').max(200),
-  listId: z.string().uuid('List is required'),
+  listId: z.uuid('List is required'),
   priority: z.number().int().min(0).max(100),
 });
 

--- a/client/src/components/domain/project/ProjectForm.tsx
+++ b/client/src/components/domain/project/ProjectForm.tsx
@@ -48,7 +48,7 @@ const STATUS_OPTIONS = [
 // child type is auto-created server-side); editing exposes name + status only.
 const createSchema = z.object({
   name: z.string().min(1, 'Name is required').max(100),
-  parentActivityTypeId: z.string().uuid('Pick a parent activity type'),
+  parentActivityTypeId: z.uuid('Pick a parent activity type'),
 });
 
 const editSchema = z.object({

--- a/client/src/components/domain/time-block/TimeBlockForm.tsx
+++ b/client/src/components/domain/time-block/TimeBlockForm.tsx
@@ -56,7 +56,7 @@ const UPDATE_TIME_BLOCK = graphql(`
 
 const timeBlockSchema = z
   .object({
-    activityTypeId: z.string().uuid('Activity type is required'),
+    activityTypeId: z.uuid('Activity type is required'),
     daysOfWeek: z
       .array(z.number().int().min(0).max(6))
       .min(1, 'Select at least one day')

--- a/client/src/components/domain/todo-list/TodoListForm.tsx
+++ b/client/src/components/domain/todo-list/TodoListForm.tsx
@@ -57,7 +57,7 @@ const DELETE_TODO_LIST = graphql(`
 const schema = z.object({
   name: z.string().min(1, 'Name is required').max(100),
   description: z.string().max(2000),
-  activityTypeId: z.string().uuid('Activity type is required'),
+  activityTypeId: z.uuid('Activity type is required'),
   defaultPriority: z.string().min(1),
   defaultEstimatedLength: z.string().min(1),
 });

--- a/client/src/components/domain/todo/TodoForm.tsx
+++ b/client/src/components/domain/todo/TodoForm.tsx
@@ -80,7 +80,7 @@ const COMPLETE_TODO = graphql(`
 const todoSchema = z.object({
   title: z.string().min(1, 'Title is required').max(200, 'Max 200 characters'),
   description: z.string().max(2000, 'Max 2000 characters'),
-  listId: z.string().uuid('List is required'),
+  listId: z.uuid('List is required'),
   priority: z.string().min(1, 'Priority is required'),
   estimatedLength: z.string().min(1, 'Duration is required'),
   // Local datetime string (YYYY-MM-DDTHH:mm) from <input type="datetime-local">

--- a/package-lock.json
+++ b/package-lock.json
@@ -84,7 +84,7 @@
         "tailwind-merge": "^2.5.5",
         "tailwindcss-animate": "^1.0.7",
         "temporal-polyfill": "^1.0.1",
-        "zod": "^3.25.76"
+        "zod": "^4.5.4"
       },
       "devDependencies": {
         "@types/react": "^19.2.0",
@@ -162,6 +162,15 @@
         "expo-widgets": {
           "optional": true
         }
+      }
+    },
+    "client/node_modules/zod": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.5.4.tgz",
+      "integrity": "sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "db": {
@@ -18884,7 +18893,7 @@
         "js-logger": "^1.6.1",
         "web-push": "^3.6.7",
         "ws": "^8.20.1",
-        "zod": "^3.24.1"
+        "zod": "^4.5.4"
       },
       "devDependencies": {
         "@electric-sql/pglite": "^0.5.8",
@@ -19085,6 +19094,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "server/node_modules/zod": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.5.4.tgz",
+      "integrity": "sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/server/package.json
+++ b/server/package.json
@@ -29,7 +29,7 @@
     "js-logger": "^1.6.1",
     "web-push": "^3.6.7",
     "ws": "^8.20.1",
-    "zod": "^3.24.1"
+    "zod": "^4.5.4"
   },
   "devDependencies": {
     "@electric-sql/pglite": "^0.5.8",

--- a/server/src/schema/resolvers/auth.ts
+++ b/server/src/schema/resolvers/auth.ts
@@ -9,7 +9,7 @@ export const authMutations: MutationMap<
   'requestMagicLink' | 'verifyMagicLink'
 > = {
   requestMagicLink: async (_parent, args, context) => {
-    const email = z.string().email().parse(args.email).toLowerCase();
+    const email = z.email().parse(args.email).toLowerCase();
     const token = await signMagicToken(email);
     const magicLink = `${context.appBaseUrl}/auth/verify?token=${token}`;
 

--- a/server/src/schema/validators.ts
+++ b/server/src/schema/validators.ts
@@ -5,7 +5,7 @@ export const CreateProjectInput = z.object({
   name: z.string().min(1).max(100),
   // Parent activity type the project's dedicated type nests under. Omit for a
   // top-level project type.
-  parentActivityTypeId: z.string().uuid().nullable().optional(),
+  parentActivityTypeId: z.uuid().nullable().optional(),
   color: z
     .string()
     .regex(/^#[0-9a-fA-F]{6}$/, 'Must be a valid hex color')
@@ -15,26 +15,26 @@ export const CreateProjectInput = z.object({
 });
 
 export const UpdateProjectInput = z.object({
-  id: z.string().uuid(),
+  id: z.uuid(),
   name: z.string().min(1).max(100).optional(),
   status: z.enum(PROJECT_STATUSES).optional(),
 });
 
 export const CreateProjectNoteInput = z.object({
-  projectId: z.string().uuid(),
+  projectId: z.uuid(),
   title: z.string().min(1).max(200),
   content: z.string().max(50000).default(''),
 });
 
 export const UpdateProjectNoteInput = z.object({
-  id: z.string().uuid(),
+  id: z.uuid(),
   title: z.string().min(1).max(200).optional(),
   content: z.string().max(50000).optional(),
 });
 
 export const ReorderProjectNotesInput = z.object({
-  projectId: z.string().uuid(),
-  noteIds: z.array(z.string().uuid()).min(1).max(500),
+  projectId: z.uuid(),
+  noteIds: z.array(z.uuid()).min(1).max(500),
 });
 
 export const CreateActivityTypeInput = z.object({
@@ -46,7 +46,7 @@ export const CreateActivityTypeInput = z.object({
 });
 
 export const UpdateActivityTypeInput = z.object({
-  id: z.string().uuid(),
+  id: z.uuid(),
   name: z.string().min(1).max(100).optional(),
   color: z
     .string()
@@ -57,33 +57,33 @@ export const UpdateActivityTypeInput = z.object({
 export const CreateTodoListInput = z.object({
   name: z.string().min(1).max(100),
   description: z.string().max(2000).optional(),
-  activityTypeId: z.string().uuid(),
+  activityTypeId: z.uuid(),
   defaultPriority: z.number().int().min(0).max(100).default(0),
   defaultEstimatedLength: z.number().int().min(0).max(1440).default(0),
 });
 
 export const UpdateTodoListInput = z.object({
-  id: z.string().uuid(),
+  id: z.uuid(),
   name: z.string().min(1).max(100).optional(),
   description: z.string().max(2000).nullable().optional(),
-  activityTypeId: z.string().uuid().optional(),
+  activityTypeId: z.uuid().optional(),
   defaultPriority: z.number().int().min(0).max(100).optional(),
   defaultEstimatedLength: z.number().int().min(0).max(1440).optional(),
 });
 
 export const CreateTodoInput = z.object({
-  listId: z.string().uuid(),
+  listId: z.uuid(),
   title: z.string().min(1).max(200),
   description: z.string().max(2000).optional(),
   priority: z.number().int().min(0).max(100).default(0),
   estimatedLength: z.number().int().min(1).max(1440).optional(),
-  dueAt: z.string().datetime({ local: true }).nullable().optional(),
-  scheduledAt: z.string().datetime({ local: true }).optional(),
+  dueAt: z.iso.datetime({ local: true }).nullable().optional(),
+  scheduledAt: z.iso.datetime({ local: true }).optional(),
 });
 
 export const UpdateTodoInput = z.object({
-  id: z.string().uuid(),
-  listId: z.string().uuid().optional(),
+  id: z.uuid(),
+  listId: z.uuid().optional(),
   title: z.string().min(1).max(200).optional(),
   description: z.string().max(2000).optional(),
   priority: z.number().int().min(0).max(100).optional(),
@@ -98,14 +98,14 @@ export const UpdateTodoInput = z.object({
  * Ids for a bulk complete/delete. Capped so one request cannot ask for an
  * unbounded `IN (…)`; 200 is well past what a multi-select produces.
  */
-export const TodoIdsInput = z.array(z.string().uuid()).min(1).max(200);
+export const TodoIdsInput = z.array(z.uuid()).min(1).max(200);
 
 export const CreateHabitInput = z.object({
   title: z.string().min(1).max(200),
   description: z.string().max(2000).optional(),
   priority: z.number().int().min(0).max(100).default(0),
   estimatedLength: z.number().int().min(1).max(1440).optional(),
-  activityTypeId: z.string().uuid(),
+  activityTypeId: z.uuid(),
   frequencyCount: z.number().int().positive().min(1).max(30),
   frequencyUnit: z.enum(['week', 'month'] as const),
   minTimeBetweenInstances: z.number().int().min(0).nullable().optional(),
@@ -136,12 +136,12 @@ export const CreateHabitInput = z.object({
 });
 
 export const UpdateHabitInput = z.object({
-  id: z.string().uuid(),
+  id: z.uuid(),
   title: z.string().min(1).max(200).optional(),
   description: z.string().max(2000).optional(),
   priority: z.number().int().min(0).max(100).optional(),
   estimatedLength: z.number().int().min(1).max(1440).optional(),
-  activityTypeId: z.string().uuid().optional(),
+  activityTypeId: z.uuid().optional(),
   frequencyCount: z.number().int().positive().min(1).max(30).optional(),
   frequencyUnit: z.enum(['week', 'month'] as const).optional(),
   minTimeBetweenInstances: z.number().int().min(0).nullable().optional(),
@@ -173,7 +173,7 @@ export const UpdateHabitInput = z.object({
 
 export const CreateTimeBlockInput = z
   .object({
-    activityTypeId: z.string().uuid(),
+    activityTypeId: z.uuid(),
     daysOfWeek: z
       .array(z.number().int().min(0).max(6))
       .min(1)
@@ -192,8 +192,8 @@ export const CreateTimeBlockInput = z
 
 export const UpdateTimeBlockInput = z
   .object({
-    id: z.string().uuid(),
-    activityTypeId: z.string().uuid().optional(),
+    id: z.uuid(),
+    activityTypeId: z.uuid().optional(),
     daysOfWeek: z
       .array(z.number().int().min(0).max(6))
       .min(1)
@@ -242,7 +242,7 @@ export const CreateManualEventInput = z
 
 export const UpdateManualEventInput = z
   .object({
-    id: z.string().uuid(),
+    id: z.uuid(),
     title: z.string().min(1).max(200).optional(),
     description: z.string().max(2000).nullable().optional(),
     color: hexColor.nullable().optional(),
@@ -256,21 +256,21 @@ export const UpdateManualEventInput = z
   );
 
 export const CompleteHabitInput = z.object({
-  habitId: z.string().uuid(),
-  scheduledAt: z.string().datetime({ local: true }).optional(),
-  completedAt: z.string().datetime({ local: true }).optional(),
+  habitId: z.uuid(),
+  scheduledAt: z.iso.datetime({ local: true }).optional(),
+  completedAt: z.iso.datetime({ local: true }).optional(),
 });
 
 export const SkipHabitInput = z.object({
-  habitId: z.string().uuid(),
+  habitId: z.uuid(),
   /** The instance slot being declined. Defaults to now. */
-  scheduledAt: z.string().datetime({ local: true }).optional(),
+  scheduledAt: z.iso.datetime({ local: true }).optional(),
 });
 
 export const MyCreateApiKeyInput = z.object({
   name: z.string().min(1).max(60),
   scopes: z.array(z.enum(API_KEY_SCOPES)).min(1),
-  expiresAt: z.string().datetime({ local: true }).optional(),
+  expiresAt: z.iso.datetime({ local: true }).optional(),
 });
 
 // Bulk import (e.g. Google Tasks). Dates arrive as arbitrary ISO strings from
@@ -286,7 +286,7 @@ export const ImportTodoInput = z.object({
 export const ImportTodoListInput = z.object({
   name: z.string().min(1).max(100),
   description: z.string().max(2000).nullish(),
-  activityTypeId: z.string().uuid(),
+  activityTypeId: z.uuid(),
   defaultPriority: z.number().int().min(0).max(100).default(0),
   defaultEstimatedLength: z.number().int().min(0).max(1440).default(0),
   todos: z.array(ImportTodoInput).max(2000),
@@ -311,7 +311,7 @@ export const UpdateNotificationPreferencesInput = z.object({
   leadTimeMinutes: z.number().int().min(1).max(120).optional(),
   quietHoursStart: TimeOfDay.nullable().optional(),
   quietHoursEnd: TimeOfDay.nullable().optional(),
-  activityTypeIds: z.array(z.string().uuid()).max(100).optional(),
+  activityTypeIds: z.array(z.uuid()).max(100).optional(),
   habitDigest: z.boolean().optional(),
 });
 
@@ -320,7 +320,7 @@ export const RegisterPushSubscriptionInput = z.object({
    * The push service URL the browser handed us. Capped because it is stored
    * verbatim and comes straight from the client.
    */
-  endpoint: z.string().url().max(2048),
+  endpoint: z.url().max(2048),
   p256dh: z.string().min(1).max(512),
   auth: z.string().min(1).max(512),
   userAgent: z.string().max(512).optional(),

--- a/server/test/schema/validator-drift.test.ts
+++ b/server/test/schema/validator-drift.test.ts
@@ -56,7 +56,7 @@ import {
  * suffixes `Args`, the validators suffix `Input`), so the pairing has to be
  * written out; the tests below then prove it is complete in both directions.
  */
-const VALIDATORS: Record<string, z.ZodTypeAny> = {
+const VALIDATORS: Record<string, z.ZodType> = {
   CompleteHabitArgs: CompleteHabitInput,
   CreateActivityTypeArgs: CreateActivityTypeInput,
   CreateHabitArgs: CreateHabitInput,
@@ -124,13 +124,21 @@ function unwrap(type: unknown): unknown {
 }
 
 /**
- * `.refine()` wraps the object in a `ZodEffects`, which has no `.shape` —
- * `CreateTimeBlockInput` is one, and reading its keys means unwrapping first.
+ * Reads the field names off a validator.
+ *
+ * Under Zod 3 this needed the unwrap loop below: `.refine()` returned a
+ * `ZodEffects` wrapping the object, and a wrapper has no `.shape`, so
+ * `CreateTimeBlockInput` — which is refined — would have thrown. Zod 4 keeps
+ * refinements on the schema itself, so `.shape` is there directly and the loop
+ * no longer fires. It stays because it costs nothing and the wrapper types are
+ * still reachable through `.optional()` and friends, and because a validator
+ * that stops being a plain object should fail loudly rather than silently
+ * report no fields.
  */
-function keysOf(validator: z.ZodTypeAny): string[] {
-  let v = validator;
+function keysOf(validator: z.ZodType): string[] {
+  let v: z.ZodType = validator;
   while ('innerType' in v && typeof v.innerType === 'function') {
-    v = (v as unknown as { innerType(): z.ZodTypeAny }).innerType();
+    v = (v as unknown as { innerType(): z.ZodType }).innerType();
   }
   const shape = (v as unknown as { shape?: Record<string, unknown> }).shape;
   if (!shape) throw new Error('not a ZodObject');

--- a/server/test/schema/validators.test.ts
+++ b/server/test/schema/validators.test.ts
@@ -54,7 +54,7 @@ describe('CreateActivityTypeInput', () => {
 });
 
 describe('UpdateActivityTypeInput', () => {
-  const validId = '00000000-0000-0000-0000-000000000001';
+  const validId = '11111111-1111-4111-8111-111111111111';
 
   it('accepts valid update with only id', () => {
     expect(() => UpdateActivityTypeInput.parse({ id: validId })).not.toThrow();
@@ -70,6 +70,28 @@ describe('UpdateActivityTypeInput', () => {
     expect(() => UpdateActivityTypeInput.parse({ id: 'not-a-uuid' })).toThrow();
   });
 
+  // Zod 4's `z.uuid()` is RFC 9562, not just the 8-4-4-4-12 hex shape that
+  // Zod 3's `z.string().uuid()` accepted: the version nibble must be 1-8 and
+  // the variant nibble 8/9/a/b. Every id the API ever sees is a Postgres
+  // `gen_random_uuid()` or a `crypto.randomUUID()`, so nothing real is caught
+  // by the tightening — but the two ids below are the shape an ad-hoc client
+  // or a hand-written fixture reaches for, and they are rejected now.
+  it('rejects a shape-valid id with no UUID version', () => {
+    expect(() =>
+      UpdateActivityTypeInput.parse({
+        id: '00000000-0000-0000-0000-000000000001',
+      }),
+    ).toThrow();
+  });
+
+  it('accepts the nil UUID, which RFC 9562 carves out', () => {
+    expect(() =>
+      UpdateActivityTypeInput.parse({
+        id: '00000000-0000-0000-0000-000000000000',
+      }),
+    ).not.toThrow();
+  });
+
   it('rejects invalid color in update', () => {
     expect(() =>
       UpdateActivityTypeInput.parse({ id: validId, color: 'red' }),
@@ -78,7 +100,7 @@ describe('UpdateActivityTypeInput', () => {
 });
 
 describe('CreateTodoInput', () => {
-  const validListId = '00000000-0000-0000-0000-000000000001';
+  const validListId = '11111111-1111-4111-8111-111111111111';
 
   it('accepts valid minimal input', () => {
     const result = CreateTodoInput.parse({
@@ -171,7 +193,7 @@ describe('CreateTodoInput', () => {
 });
 
 describe('UpdateTodoInput', () => {
-  const validId = '00000000-0000-0000-0000-000000000001';
+  const validId = '11111111-1111-4111-8111-111111111111';
 
   it('accepts update with only id', () => {
     expect(() => UpdateTodoInput.parse({ id: validId })).not.toThrow();
@@ -201,7 +223,7 @@ describe('UpdateTodoInput', () => {
 });
 
 describe('CreateHabitInput', () => {
-  const validActivityTypeId = '00000000-0000-0000-0000-000000000001';
+  const validActivityTypeId = '11111111-1111-4111-8111-111111111111';
 
   it('accepts valid input', () => {
     const result = CreateHabitInput.parse({
@@ -281,7 +303,7 @@ describe('CreateHabitInput', () => {
 });
 
 describe('UpdateHabitInput', () => {
-  const validId = '00000000-0000-0000-0000-000000000001';
+  const validId = '11111111-1111-4111-8111-111111111111';
 
   it('accepts partial update', () => {
     expect(() =>
@@ -295,7 +317,7 @@ describe('UpdateHabitInput', () => {
 });
 
 describe('CreateTimeBlockInput', () => {
-  const validActivityTypeId = '00000000-0000-0000-0000-000000000001';
+  const validActivityTypeId = '11111111-1111-4111-8111-111111111111';
 
   it('accepts valid time block', () => {
     expect(() =>
@@ -386,7 +408,7 @@ describe('CreateTimeBlockInput', () => {
 });
 
 describe('UpdateTimeBlockInput', () => {
-  const validId = '00000000-0000-0000-0000-000000000001';
+  const validId = '11111111-1111-4111-8111-111111111111';
 
   it('accepts partial update with only id', () => {
     expect(() => UpdateTimeBlockInput.parse({ id: validId })).not.toThrow();
@@ -400,7 +422,7 @@ describe('UpdateTimeBlockInput', () => {
 });
 
 describe('CompleteHabitInput', () => {
-  const validHabitId = '00000000-0000-0000-0000-000000000001';
+  const validHabitId = '11111111-1111-4111-8111-111111111111';
 
   it('accepts valid habitId', () => {
     expect(() =>


### PR DESCRIPTION
Part of #68. Follows the Express 5 PR (#79).

`zod` `^3.24.1` (server) / `^3.25.76` (client) → `^4.5.4` in both. `drizzle-orm` and the Expo CLI keep their own zod 3 underneath; nothing shares a zod instance across that line.

## What the issue expected, and what was actually there

The issue flagged the error-formatting change — `.format()` / `.flatten()` replaced by `z.treeifyError` — as the risk. Nothing in the repo used either. `formatError` in `server/src/index.ts` reads `error.issues` directly, which is unchanged, so the BAD_USER_INPUT path is untouched and `error-codes.test.ts` needed no edits. The client never parses by hand either: TanStack Form consumes the schemas as Standard Schema, which zod 4 implements natively.

## What did change

**The string-format API.** `z.string().uuid()` and friends are deprecated in favour of top-level constructors, so validators now read `z.uuid()`, `z.email()`, `z.url()`, `z.iso.datetime({ local: true })`.

**`z.uuid()` is a stricter check than the method it replaces.** Zod 3 accepted the 8-4-4-4-12 hex shape; zod 4 enforces RFC 9562 — version nibble 1-8, variant nibble 8/9/a/b, with the nil and max UUIDs carved out.

This is the only behaviour change in the PR, and it's the right direction: every id the API ever sees is a Postgres `gen_random_uuid()` or a `crypto.randomUUID()`, all conforming, so no real request is affected. What it does catch is exactly the kind of id a hand-written fixture reaches for — and that's how it surfaced. All 16 initial test failures traced to one constant, `'00000000-0000-0000-0000-000000000001'` (version nibble 0), in `validators.test.ts`. It's now a real v4 UUID, and two new tests pin the boundary in both directions: the versionless id rejected, the nil UUID still accepted. `z.guid()` is the loose check if one is ever wanted; noted in `.agents/server-patterns.md` alongside a new `*Id` row in the constraint table.

**`validator-drift.test.ts`** keeps its `innerType()` unwrap loop, but it no longer fires — zod 4 keeps `.refine()` on the schema rather than wrapping it in a `ZodEffects`, so a refined object like `CreateTimeBlockInput` exposes `.shape` directly. The loop stays as a guard (wrapper types are still reachable via `.optional()`, and a validator that stops being an object should fail loudly rather than report zero fields); the comment now says so. `z.ZodTypeAny` → `z.ZodType` throughout.

## Gates

`npm run lint`, `npm run typecheck`, `npm test` — 34 files / 498 tests, all green.

## Still open on #68 after this

- **graphql 17** — blocked upstream: `graphql-parse-resolve-info` is a peer of `@vantreeseba/drizzle-graphql` and pins 16.
- **`@react-native-async-storage/async-storage` 3** — pinned by Expo SDK 57.
- **tailwind 4 / tailwind-merge 3** — coupled to NativeWind's tailwind 4 support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014L39MkrRhYGcnDjRZMHtjH