### PR TITLE
chore: align every Node version on 24

### DIFF
--- a/.agents/deployment.md
+++ b/.agents/deployment.md
@@ -18,6 +18,18 @@ might not have.
 `>=24` rather than an exact pin because local development runs ahead (26 at time
 of writing) and nothing about that has caused trouble; the floor is what matters.
 
+The workflow *actions* are on Node 24 too — `actions/checkout@v7`,
+`actions/setup-node@v7`, `actions/upload-pages-artifact@v5`,
+`actions/deploy-pages@v5`. The v4 line ran on Node 20, which the runner now
+force-runs on 24 and warns about on every job.
+
+One of those bumps needed a flag. `upload-pages-artifact` stopped including
+dotfiles by default in v4, and `site/eleventy.config.js` copies `src/nojekyll`
+to `_site/.nojekyll` deliberately — without that file GitHub Pages runs the
+build output through Jekyll, which ignores every path beginning with an
+underscore. `include-hidden-files: true` keeps it. Nothing would have failed
+loudly; the site would just have started 404ing assets.
+
 The one exception is `client/eas.json`, which pins `node: "22.20.0"` for the EAS
 builders. That machine only bundles JavaScript — it never runs the server — and
 the version has to be one EAS actually provides, so it is pinned on its own

--- a/.agents/deployment.md
+++ b/.agents/deployment.md
@@ -1,5 +1,28 @@
 # Deployment
 
+## Node Version
+
+**Node 24 everywhere.** `engines.node` in the root `package.json` is `>=24`,
+`@types/node` is `^24` in `db` and `server`, all three GitHub workflows pin
+`node-version: '24'`, and both Dockerfile stages are `node:24-alpine`.
+
+That alignment is the point, not the number. The server has no build step — it
+runs TypeScript directly under `--experimental-strip-types` — so the Node that
+runs in production is the only thing standing between the source and the
+process, and CI is the only place that gets to find out first. Before this the
+three workflows disagreed with each other (22, 22, 24) and `@types/node` was a
+major ahead of all of them: `release.yml` built the release artifact on 22 for
+an image that ran it on 24, and `tsc` type-checked against APIs the runtime
+might not have.
+
+`>=24` rather than an exact pin because local development runs ahead (26 at time
+of writing) and nothing about that has caused trouble; the floor is what matters.
+
+The one exception is `client/eas.json`, which pins `node: "22.20.0"` for the EAS
+builders. That machine only bundles JavaScript — it never runs the server — and
+the version has to be one EAS actually provides, so it is pinned on its own
+schedule rather than following this one.
+
 ## Docker
 
 Single-stage image — build must run **outside** Docker before `docker build`:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: '24'
           cache: 'npm'

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -26,15 +26,20 @@ jobs:
       run:
         working-directory: site
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: '24'
       - run: npm install
       - run: npm run build
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: site/_site
+          # v4 stopped including dotfiles by default. eleventy.config.js copies
+          # src/nojekyll to _site/.nojekyll on purpose — without it Pages runs
+          # the output through Jekyll, which ignores every path starting with
+          # an underscore.
+          include-hidden-files: true
 
   deploy:
     needs: build
@@ -44,4 +49,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24'
       - run: npm install
       - run: npm run build
       - uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'npm'
 
       - run: npm ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,12 +21,12 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: '24'
           cache: 'npm'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,7 @@ Drizzle ORM schema over postgres.js. Exports a single `db` instance built from `
 PGLite survives only as a *test* fixture: `server/test/**` constructs its own in-memory instances (`new PGlite('memory://')`) and never imports this module. It is a devDependency of `server`, not a dependency of `db`, so a production install cannot pull it in. It was dropped as a runtime backend because its WASM event loop busy-waits (see [`deployment.md`](.agents/deployment.md)), which made a deploy that lost its `DATABASE_URL` degrade silently instead of failing.
 
 ### `server`
-Express + Apollo Server, running TypeScript directly via `--experimental-strip-types` (Node 22). **All imports must include `.ts` extension.** No build step.
+Express + Apollo Server, running TypeScript directly via `--experimental-strip-types` (Node 24). **All imports must include `.ts` extension.** No build step.
 
 **Schema pipeline** (three layers):
 1. `buildSchema(db, buildSchemaConfig)` — `@vantreeseba/drizzle-graphql` (v9) auto-generates the full SDL from Drizzle tables. The config carries the tenant `scope`, the per-table `defaults` (ordering), the `exclude`d columns, and the disabled features

--- a/db/package.json
+++ b/db/package.json
@@ -20,7 +20,7 @@
     "drizzle-orm": "1.0.0-rc.5-ab785fc"
   },
   "devDependencies": {
-    "@types/node": "^25.6.0",
+    "@types/node": "^24.13.3",
     "drizzle-kit": "1.0.0-rc.5-ab785fc",
     "env-cmd": "^11.0.0"
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -180,13 +180,30 @@
         "postgres": "^3.4.9"
       },
       "devDependencies": {
-        "@types/node": "^25.6.0",
+        "@types/node": "^24.13.3",
         "drizzle-kit": "1.0.0-rc.5-ab785fc",
         "env-cmd": "^11.0.0"
       },
       "peerDependencies": {
         "drizzle-orm": "1.0.0-rc.5-ab785fc"
       }
+    },
+    "db/node_modules/@types/node": {
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "db/node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@0no-co/graphql.web": {
       "version": "1.3.4",
@@ -18899,7 +18916,7 @@
         "@electric-sql/pglite": "^0.5.8",
         "@types/cors": "^2.8.17",
         "@types/express": "^5.0.0",
-        "@types/node": "^25.6.0",
+        "@types/node": "^24.13.3",
         "@types/pluralize": "^0.0.33",
         "@types/web-push": "^3.6.4",
         "@types/ws": "^8.18.1"
@@ -18934,6 +18951,16 @@
       },
       "peerDependencies": {
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "server/node_modules/@types/node": {
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
       }
     },
     "server/node_modules/accepts": {
@@ -19095,6 +19122,13 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "server/node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
     },
     "server/node_modules/zod": {
       "version": "4.5.4",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "type": "module",
   "description": "Auto Cal - Todo and habit scheduling application",
   "private": true,
+  "engines": {
+    "node": ">=24"
+  },
   "workspaces": ["client", "db", "server"],
   "scripts": {
     "dev": "npm run codegen && concurrently \"npm:dev:server\" \"npm:dev:client\"",

--- a/server/package.json
+++ b/server/package.json
@@ -35,7 +35,7 @@
     "@electric-sql/pglite": "^0.5.8",
     "@types/cors": "^2.8.17",
     "@types/express": "^5.0.0",
-    "@types/node": "^25.6.0",
+    "@types/node": "^24.13.3",
     "@types/pluralize": "^0.0.33",
     "@types/web-push": "^3.6.4",
     "@types/ws": "^8.18.1"


### PR DESCRIPTION
Closes #68 (the last actionable item — see the deferred list at the bottom).

## The problem

The repo gave four different answers to "what Node does this run on":

| Where | Was | Now |
|---|---|---|
| `.github/workflows/ci.yml` | 24 | 24 |
| `.github/workflows/release.yml` | **22** | 24 |
| `.github/workflows/pages.yml` | **22** | 24 |
| `Dockerfile` (both stages) | 24 | 24 |
| `@types/node` (`db`, `server`) | **^25** | ^24 |
| `engines.node` | *(absent)* | `>=24` |

Two consequences that were live, not theoretical: `release.yml` built the release artifact on Node 22 for an image that runs it on Node 24, and `tsc` type-checked the server against a `@types/node` major the runtime doesn't have.

That gap matters more here than in most repos because **the server has no build step** — it runs TypeScript directly under `--experimental-strip-types`. The Node in the image is the only thing standing between the source and the process, and CI is the only place that gets to find out first.

`>=24` is a floor rather than an exact pin because local development runs ahead (26 currently) and nothing about that has caused trouble.

## The one exception

`client/eas.json` keeps `node: "22.20.0"`. That builder only bundles JavaScript — it never runs the server — and the version string has to be one EAS actually provides, so it's pinned on its own schedule rather than following this one. `.agents/deployment.md` gets a new **Node Version** section saying all of the above, including why.

Also corrected: `CLAUDE.md` said "(Node 22)" next to `--experimental-strip-types`.

## Gates

`npm run lint`, `npm run typecheck` (clean under `@types/node` 24), `npm test` — 34 files / 498 tests, all green.

## Deferred from #68, with reasons

These three are blocked rather than skipped, and should stay on the issue or move to a new one when it closes:

- **graphql 17** — `graphql-parse-resolve-info` is a peer dependency of `@vantreeseba/drizzle-graphql` and pins graphql 16. Needs the upstream bump first.
- **`@react-native-async-storage/async-storage` 3** — pinned by Expo SDK 57's dependency set; moves when the SDK does.
- **tailwind 4 / tailwind-merge 3** — coupled to NativeWind's tailwind 4 support, which the client's styling goes through.

Based on `chore/zod-4` (#80), which is based on `chore/express-5` (#79).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014L39MkrRhYGcnDjRZMHtjH