### PR TITLE
test(client): pin the useConfirm contract

### DIFF
--- a/.agents/client-patterns.md
+++ b/.agents/client-patterns.md
@@ -830,6 +830,14 @@ which supplies the `MockedProvider` plus the Toast, Confirm and Tooltip
 providers `app/(app)/_layout.tsx` supplies. A component that reaches for a
 missing provider throws rather than degrading — `useConfirm` is the usual one.
 
+The exception is a test *of* a provider. `client/test/components/confirm.test.tsx`
+mounts `ConfirmProvider` itself, because the contract worth pinning is invisible
+from a screen test: a screen only ever takes the happy path, while the ways
+`useConfirm()` can break are all silent — a promise nothing settles leaves the
+caller's `await` hanging forever, and a dismissal that resolved `true` deletes
+the row the user just declined to delete. One case there deliberately renders
+with no provider at all.
+
 **Mocks must reference the same DocumentNode the component uses.** Either
 export the operation from the module under test (`export const MY_TODAY = …`)
 or import the generated one (`GetTodoListsPageDocument` from

--- a/client/test/components/confirm.test.tsx
+++ b/client/test/components/confirm.test.tsx
@@ -1,0 +1,129 @@
+// @vitest-environment jsdom
+/**
+ * The `useConfirm()` contract.
+ *
+ * Every destructive action in the app is gated on the promise this hook hands
+ * back, and the failure modes are all silent ones: a promise nothing settles
+ * leaves the caller's `await` hanging forever, and a dismissal that resolved
+ * `true` would delete a row the user just declined to delete. Neither shows up
+ * in a screen test, which only ever takes the happy path.
+ *
+ * Rendered without `renderWithProviders` on purpose — the provider under test
+ * is the thing being mounted, and one case needs it deliberately absent.
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+import { useState } from 'react';
+import { describe, expect, it } from 'vitest';
+
+import {
+  type ConfirmOptions,
+  ConfirmProvider,
+  useConfirm,
+} from '@/components/ui/confirm';
+
+/** Records what the promise settled to, so a test can read it off the DOM. */
+function Harness({ prompts }: { prompts: ConfirmOptions[] }) {
+  const confirm = useConfirm();
+  const [answers, setAnswers] = useState<string[]>([]);
+
+  return (
+    <>
+      {prompts.map((options, i) => (
+        <button
+          key={options.title}
+          type="button"
+          onClick={async () => {
+            const ok = await confirm(options);
+            setAnswers((prev) => [...prev, `${i}:${ok}`]);
+          }}
+        >
+          ask {i}
+        </button>
+      ))}
+      <div data-testid="answers">{answers.join(',')}</div>
+    </>
+  );
+}
+
+const DELETE_LIST: ConfirmOptions = {
+  title: 'Delete list?',
+  description: 'This removes every todo on it.',
+};
+
+function mount(prompts: ConfirmOptions[] = [DELETE_LIST]) {
+  return render(
+    <ConfirmProvider>
+      <Harness prompts={prompts} />
+    </ConfirmProvider>,
+  );
+}
+
+const answers = () => screen.getByTestId('answers').textContent;
+
+describe('useConfirm', () => {
+  it('shows nothing until a caller asks', () => {
+    mount();
+    expect(screen.queryByText('Delete list?')).toBeNull();
+  });
+
+  it('renders the title and description it was given', async () => {
+    mount();
+    fireEvent.click(screen.getByText('ask 0'));
+    expect(await screen.findByText('Delete list?')).toBeTruthy();
+    expect(screen.getByText('This removes every todo on it.')).toBeTruthy();
+  });
+
+  it('resolves true and closes when the destructive button is pressed', async () => {
+    mount();
+    fireEvent.click(screen.getByText('ask 0'));
+    fireEvent.click(await screen.findByText('Delete'));
+
+    await screen.findByText('0:true');
+    expect(answers()).toBe('0:true');
+    expect(screen.queryByText('Delete list?')).toBeNull();
+  });
+
+  it('resolves false when cancelled — a dismissal is not a confirmation', async () => {
+    mount();
+    fireEvent.click(screen.getByText('ask 0'));
+    fireEvent.click(await screen.findByText('Cancel'));
+
+    await screen.findByText('0:false');
+    expect(answers()).toBe('0:false');
+    expect(screen.queryByText('Delete list?')).toBeNull();
+  });
+
+  it('uses the caller-supplied labels over the defaults', async () => {
+    mount([
+      { ...DELETE_LIST, confirmLabel: 'Archive it', cancelLabel: 'Keep it' },
+    ]);
+    fireEvent.click(screen.getByText('ask 0'));
+
+    expect(await screen.findByText('Archive it')).toBeTruthy();
+    expect(screen.getByText('Keep it')).toBeTruthy();
+    expect(screen.queryByText('Delete')).toBeNull();
+  });
+
+  it('settles the older caller when a second prompt supersedes it', async () => {
+    mount([DELETE_LIST, { title: 'Delete todo?', description: 'Gone.' }]);
+    fireEvent.click(screen.getByText('ask 0'));
+    await screen.findByText('Delete list?');
+
+    // The first caller must not be left awaiting a promise nothing will
+    // settle. It is told no; the second prompt is the one on screen.
+    fireEvent.click(screen.getByText('ask 1'));
+    await screen.findByText('0:false');
+    expect(await screen.findByText('Delete todo?')).toBeTruthy();
+
+    fireEvent.click(screen.getByText('Delete'));
+    await screen.findByText('0:false,1:true');
+  });
+
+  it('throws without a provider rather than silently answering no', () => {
+    // A delete that never happens and never says why is worse than a crash in
+    // development, so the hook does not fall back to a default `false`.
+    expect(() => render(<Harness prompts={[DELETE_LIST]} />)).toThrow(
+      /useConfirm must be used inside <ConfirmProvider>/,
+    );
+  });
+});


### PR DESCRIPTION
Closes #61.

## The implementation was already there

#61 asked for a `useConfirm()` provider replacing the split web/native confirms. That landed with the native component fold (#73): `components/native/confirm.ts` is deleted, `ConfirmProvider` is mounted once in `app/_layout.tsx`, `ConfirmDialog` is now just its presentational half, and all four call sites (`ProjectDetail`, `ProjectNotesEditor`, `TodoListCard`, `TodoItem`) `await confirm({...})`. Every acceptance box on the issue is ticked.

What was missing is any test of it, so this PR adds one and closes the issue on evidence rather than assertion.

## Why it's worth a test

Every destructive action in the app is gated on the promise this hook hands back, and its failure modes are all silent ones:

- A promise nothing settles leaves the caller's `await` hanging forever — no error, no dialog, nothing in the console.
- A dismissal that resolved `true` deletes the row the user just declined to delete.

Neither shows up in a screen test, which only ever takes the happy path.

## The seven cases

| Case | What it protects |
|---|---|
| Nothing rendered until a caller asks | The dialog isn't mounted-open |
| Title and description shown | Options reach the dialog |
| Confirm resolves `true` and closes | Happy path |
| Cancel resolves `false` and closes | A dismissal is not a confirmation |
| Caller labels override the defaults | `confirmLabel` / `cancelLabel` wiring |
| A second prompt supersedes the first, settling the older caller `false` | The abandoned-promise case the `resolveRef` exists for |
| No provider throws | The hook doesn't fall back to a silent `false` |

Mounted without `renderWithProviders` on purpose — the provider is the thing under test, and the last case needs it deliberately absent. `.agents/client-patterns.md` notes that exception next to the rule it breaks.

## Negative-tested

Both non-obvious cases were confirmed to fail when the behaviour is removed, and confirmed that nothing else in the suite catches them:

- Dropping `resolveRef.current?.(false)` from `confirm()` → only the supersede case fails.
- Changing the dismiss handler to `settle(true)` → only the cancel case fails.

## Gates

`npm run lint`, `npm run typecheck`, `npm test` — 35 files / 505 tests, all green.

Based on `chore/node-24-alignment` (#81).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014L39MkrRhYGcnDjRZMHtjH